### PR TITLE
新規登録機能の変更、フォームタイプの明記

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -2,12 +2,38 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\UserRequest;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
 
 class AdminController extends Controller
 {
     public function dashboard()
     {
         return view('admin.dashboard');
+    }
+
+        public function showForm()
+    {
+        return view('auth.register');
+    }
+
+    public function register(UserRequest $request)
+    {
+
+        $defaultPictures = config('user.default_profile_pictures');
+
+        User::create([
+            'name'              => $request->name,
+            'email'             => $request->email,
+            'employee_code'     => $request->employee_code,
+            'password'          => Hash::make($request->password),
+            'gender'            => $request->gender,
+            'role'              => 'general',//登録時の誤設定を防ぐ目的で、権限は後から変更できる仕様とする。
+            'profile_picture'   => $defaultPictures[$request->gender],
+            'self_introduction' => 'こんにちは、' . $request->name . 'です。',
+        ]);
+
+        return redirect()->route('admin.dashboard')->with("status", "登録成功");
     }
 }

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -22,18 +22,17 @@ class RegisterController extends Controller
 
         $defaultPictures = config('user.default_profile_pictures');
 
-        $user = User::create([
+        User::create([
             'name'              => $request->name,
             'email'             => $request->email,
+            'employee_code'     => $request->employee_code,
             'password'          => Hash::make($request->password),
             'gender'            => $request->gender,
-            'role'              => 'general',
+            'role'              => 'general',//登録時の誤設定を防ぐ目的で、権限は後から変更できる仕様としています。
             'profile_picture'   => $defaultPictures[$request->gender],
             'self_introduction' => 'こんにちは、' . $request->name . 'です。',
         ]);
 
-        Auth::login($user);
-
-        return redirect()->route('welcome');
+        return redirect()->route('admin.dashboard')->with("status", "登録成功");
     }
 }

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
@@ -12,27 +11,5 @@ use App\Models\User;
 
 class RegisterController extends Controller
 {
-    public function showForm()
-    {
-        return view('auth.register');
-    }
-
-    public function register(UserRequest $request)
-    {
-
-        $defaultPictures = config('user.default_profile_pictures');
-
-        User::create([
-            'name'              => $request->name,
-            'email'             => $request->email,
-            'employee_code'     => $request->employee_code,
-            'password'          => Hash::make($request->password),
-            'gender'            => $request->gender,
-            'role'              => 'general',//登録時の誤設定を防ぐ目的で、権限は後から変更できる仕様としています。
-            'profile_picture'   => $defaultPictures[$request->gender],
-            'self_introduction' => 'こんにちは、' . $request->name . 'です。',
-        ]);
-
-        return redirect()->route('admin.dashboard')->with("status", "登録成功");
-    }
+    //もう必要ないかな？とりあえず置いておく。
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -26,6 +26,17 @@ class UserRequest extends FormRequest
             'email'    => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8|confirmed',
             'gender'   => 'required|in:male,female,other,unknown',
+            'employee_code' => 'required|digits:5|unique:users',
+        ];
+    }
+
+    //これは追加のカスタマイズメッセージ
+    public function messages()
+    {
+        return [
+        'employee_code.required' => 'Employee code is required.',
+        'employee_code.digits'   => 'Employee code must be exactly 5 digits.',
+        'employee_code.unique'   => 'This employee code is already in use.',
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
+        'employee_code', 
         'password',
         'email_verified_at',
         'gender',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,35 +11,43 @@
             <div class="mb-3">
                 <label class="form-label">名前</label>
                 <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
-                       value="{{ old('name') }}">
+                    value="{{ old('name') }}">
                 @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
 
             <div class="mb-3">
                 <label class="form-label">メールアドレス</label>
                 <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                       value="{{ old('email') }}">
+                    value="{{ old('email') }}">
                 @error('email') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
 
             <div class="mb-3">
+                <label class="form-label">社員番号</label>
+                <input type="text" name="employee_code" class="form-control @error('employee_code') is-invalid @enderror"
+                    value="{{ old('employee_code') }}">
+                @error('employee_code') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+
+            <div class="mb-3">
                 <label class="form-label">パスワード</label>
-                <input type="password" name="password" class="form-control @error('password') is-invalid @enderror">
+                <input type="password" name="password" autocomplete="new-password" class="form-control @error('password') is-invalid @enderror">
                 @error('password') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
 
             <div class="mb-3">
                 <label class="form-label">パスワード（確認）</label>
-                <input type="password" name="password_confirmation" class="form-control">
+                <input type="password" name="password_confirmation" autocomplete="new-password" class="form-control">
             </div>
 
             <div class="mb-4">
                 <label class="form-label">性別</label>
                 <select name="gender" class="form-select @error('gender') is-invalid @enderror">
+                    <option value="unknown" {{ old('gender') == 'unknown' ? 'selected' : '' }}>未選択</option>
                     <option value="male" {{ old('gender') == 'male' ? 'selected' : '' }}>男性</option>
                     <option value="female" {{ old('gender') == 'female' ? 'selected' : '' }}>女性</option>
                     <option value="other" {{ old('gender') == 'other' ? 'selected' : '' }}>その他</option>
-                    <option value="unknown" {{ old('gender') == 'unknown' ? 'selected' : '' }}>不明</option>
                 </select>
                 @error('gender') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="utf-8">
-    <title>ミチログ</title>
+    <title>ルートハブ</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Bootstrap 5 CDN -->

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <!-- サイトの代表的なシンボル -->
 <div class="text-center my-5">
-    <img src="{{ asset('image/RouteHub1.png') }}" alt="ミチログ" class="img-fluid img-thumbnail" style="max-width: auto; height: auto;">
+    <img src="{{ asset('image/RouteHub1.png') }}" alt="ルートハブ" class="img-fluid img-thumbnail" style="max-width: auto; height: auto;">
     <h2 class="mt-3">ようこそルートハブへ</h2>
     <p class="text-muted">講師と本部をつなぐ、交通費と社内連携のポータルです。</p>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\RegisterController;
+
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\UsersController;
@@ -21,8 +21,8 @@ Route::get('/login', [LoginController::class, 'showForm'])->name('login');
 Route::post('/login', [LoginController::class, 'login'])->name('login.submit');
 
 Route::middleware(['auth', 'role:admin'])->group(function () {
-    Route::get('/register', [RegisterController::class, 'showForm'])->name('register.showForm');
-    Route::post('/register', [RegisterController::class, 'register'])->name('register.submit');
+    Route::get('/admin/register', [AdminController::class, 'showForm'])->name('register.showForm');
+    Route::post('/admin/register', [AdminController::class, 'register'])->name('register.submit');
     Route::get('/admin/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
 });
 


### PR DESCRIPTION
## 新規登録
- Controller, View, Model, Requestの変更
- Requestはとりあえずカスタムメッセージを使用。`'employee_code.unique'   => 'This employee code is already in use.',`の`'employee_code.unique'`は覚えておくべき。
- 特にModelにあるfillableの変更は忘れやすいと感じた。
↓
`User::create([...])` は` fillable`（または `guarded`）で指定された属性だけを保存する。
```
User::create([
    'name' => 'Jin',
    'email' => 'jin@example.com',
    'password' => Hash::make('password'),
]);
```
は
```
    protected $fillable = [
        'name',
        'email',
        'password',
    ];
```
と一緒に変更が必要。

下記は違うやり方。
```
$user = new User([
    'name' => 'Jin',
    'email' => 'jin@example.com',
    'password' => Hash::make('password'),
]);
$user->save();
```

## フォームタイプ
- `<input type="password" name="password" autocomplete="new-password" class="form-control @error('password') is-invalid @enderror">`の`autocomplete="new-password"`により、Googleブラウザーは”これが”ログインではなく、新規登録だと認識
