### PR TITLE
ユーザープロフィール一般情報の編集

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Models\User;
+use Illuminate\Validation\ValidationException;
 
 
 class UsersController extends Controller
@@ -43,7 +44,6 @@ class UsersController extends Controller
         $this->authorize('view', $targetUser);
 
         $field = $request->input('field');
-        $value = $request->input('value');
 
         $allowedFields = ['email', 'phone_number', 'address', 'self_introduction'];
 
@@ -51,7 +51,26 @@ class UsersController extends Controller
             return response()->json(['error' => '更新できません'], 400);
         }
 
-        $targetUser->$field = $value;
+        $rules = match ($field) {
+            'email' => ['value' => "required|email|max:255|unique:users,email,{$targetUser->id}"],
+            'phone_number' => ['value' => 'nullable|numeric|digits_between:10,11'],
+            'address' => ['value' => 'nullable|string|max:255'],
+            'self_introduction' => ['value' => 'nullable|string|max:1000'],
+        };
+
+        // 以前はバリデーションせずに直接取得していた：$value = $request->input('value');
+        // → バリデーションエラーをJSON形式で返すよう、try-catch + validate() に変更
+        try {
+            $validated = $request->validate($rules);
+        } catch (ValidationException $e) {
+            return response()->json([
+                'error' => $e->errors()['value'][0] ?? '不正な値です'
+            ], 422);
+        }
+
+        // 以前は $targetUser->$field = $value; のように使っていたが、
+        // validate() で取得した値を使用するため $validated['value'] に変更
+        $targetUser->$field = $validated['value']; // ※ $validated は ['value' => 入力値] の形
         $targetUser->save();
 
         return response()->json(['message' => '更新完了']);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Http\Request;
 use App\Models\User;
-use Illuminate\Validation\ValidationException;
+//use Illuminate\Validation\ValidationException;(try catch 用)
+use App\Http\Requests\UpdateUserFieldRequest;
 
 
 class UsersController extends Controller
@@ -33,7 +33,7 @@ class UsersController extends Controller
      * @property string $name
      * @method bool save()
      */
-    public function updateField(Request $request, ?User $user = null)
+    public function updateField(UpdateUserFieldRequest $request, ?User $user = null)
     {
         $currentUser = Auth::user();
 
@@ -44,6 +44,7 @@ class UsersController extends Controller
         $this->authorize('view', $targetUser);
 
         $field = $request->input('field');
+        $validated = $request->validated(); // バリデーション通過後のデータ
 
         $allowedFields = ['email', 'phone_number', 'address', 'self_introduction'];
 
@@ -51,25 +52,6 @@ class UsersController extends Controller
             return response()->json(['error' => '更新できません'], 400);
         }
 
-        $rules = match ($field) {
-            'email' => ['value' => "required|email|max:255|unique:users,email,{$targetUser->id}"],
-            'phone_number' => ['value' => 'nullable|numeric|digits_between:10,11'],
-            'address' => ['value' => 'nullable|string|max:255'],
-            'self_introduction' => ['value' => 'nullable|string|max:1000'],
-        };
-
-        // 以前はバリデーションせずに直接取得していた：$value = $request->input('value');
-        // → バリデーションエラーをJSON形式で返すよう、try-catch + validate() に変更
-        try {
-            $validated = $request->validate($rules);
-        } catch (ValidationException $e) {
-            return response()->json([
-                'error' => $e->errors()['value'][0] ?? '不正な値です'
-            ], 422);
-        }
-
-        // 以前は $targetUser->$field = $value; のように使っていたが、
-        // validate() で取得した値を使用するため $validated['value'] に変更
         $targetUser->$field = $validated['value']; // ※ $validated は ['value' => 入力値] の形
         $targetUser->save();
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -26,4 +26,28 @@ class UsersController extends Controller
 
         return view('user.profile', ['user' => $targetUser]);
     }
+
+    /**
+     * @property int $id
+     * @property string $name
+     * @method bool save()
+     */
+    public function updateField(Request $request)
+    {
+        $user = auth()->user();
+
+        $field = $request->input('field');
+        $value = $request->input('value');
+
+        $allowedFields = ['email', 'phone_number', 'address', 'self_introduction'];
+
+        if (!in_array($field, $allowedFields)) {
+            return response()->json(['error' => '更新できません'], 400);
+        }
+
+        $user->$field = $value;
+        $user->save();
+
+        return response()->json(['message' => '更新完了']);
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -32,9 +32,15 @@ class UsersController extends Controller
      * @property string $name
      * @method bool save()
      */
-    public function updateField(Request $request)
+    public function updateField(Request $request, ?User $user = null)
     {
-        $user = auth()->user();
+        $currentUser = Auth::user();
+
+        // userがnull → 自分のプロフィール（一般ユーザー）
+        $targetUser = $user ?? $currentUser;
+
+        // 権限チェック
+        $this->authorize('view', $targetUser);
 
         $field = $request->input('field');
         $value = $request->input('value');
@@ -45,8 +51,8 @@ class UsersController extends Controller
             return response()->json(['error' => '更新できません'], 400);
         }
 
-        $user->$field = $value;
-        $user->save();
+        $targetUser->$field = $value;
+        $targetUser->save();
 
         return response()->json(['message' => '更新完了']);
     }

--- a/app/Http/Requests/UpdateUserFieldRequest.php
+++ b/app/Http/Requests/UpdateUserFieldRequest.php
@@ -37,7 +37,7 @@ class UpdateUserFieldRequest extends FormRequest
         };
     }
 
-    //コントローラーのtry catchをここに移した結果
+    ///コントローラーでの try-catch バリデーション処理を、FormRequest 側に移動したもの
     public function failedValidation(Validator $validator)
     {
         throw new HttpResponseException(response()->json([

--- a/app/Http/Requests/UpdateUserFieldRequest.php
+++ b/app/Http/Requests/UpdateUserFieldRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+//use Illuminate\Validation\ValidationException;(備え付き。ここではtry catch 用ではない。)
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class UpdateUserFieldRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $field = $this->input('field');
+        $targetUser = $this->route('user') ?? Auth::user(); // ルートモデル or 自分
+
+        return match ($field) {
+            'email' => ['value' => "required|email|max:255|ascii|unique:users,email,{$targetUser->id}"],
+            'phone_number' => ['value' => 'nullable|numeric|digits_between:10,11'],
+            'address' => ['value' => 'nullable|string|max:255'],
+            'self_introduction' => ['value' => 'nullable|string|max:1000'],
+            default => ['value' => 'nullable|string'],
+        };
+    }
+
+    //コントローラーのtry catchをここに移した結果
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json([
+            'error' => $validator->errors()->first('value') ?? '不正な値です',
+        ], 422));
+    }
+}

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -113,6 +113,17 @@
     </div>
 </div>
 
+@php
+    $updateFieldUrl = (Auth::user()->role === 'admin' && isset($user))
+        ? route('admin.user.updateField', ['user' => $user])
+        : route('user.updateField');
+@endphp
+
+<script>
+    const updateFieldUrl = @json($updateFieldUrl);
+</script>
+
+
 <script>
 function editField(field) {
     document.getElementById(`${field}_display`).classList.add('d-none');
@@ -129,7 +140,7 @@ function editField(field) {
 function saveField(field) {
     const value = document.getElementById(`${field}_input`).value;
 
-    fetch("{{ route('user.updateField') }}", {
+    fetch(updateFieldUrl, {
         method: 'PATCH',
         headers: {
             'Content-Type': 'application/json',

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -46,31 +46,63 @@
                 <table class="table table-bordered">
                     <tr>
                         <th>社員コード</th>
-                        <td>{{ $user->employee_code }}</td>
+                        <td>{{ $user->employee_code }}</td><td></td>
                     </tr>
                     <tr>
                         <th>名前</th>
-                        <td>{{ $user->name }}</td>
+                        <td>{{ $user->name }}</td><td></td>
                     </tr>
                     <tr>
                         <th>性別</th>
-                        <td>{{ ucfirst($user->gender) }}</td>
+                        <td>{{ ucfirst($user->gender) }}</td><td></td>
                     </tr>
                     <tr>
                         <th>Email</th>
-                        <td>{{ $user->email }}</td>
+                        <td>
+                            <span id="email_display">{{ $user->email }}</span>
+                            <input type="text" id="email_input" class="form-control d-none" value="{{ $user->email }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="email_edit" onclick="editField('email')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="email_save" onclick="saveField('email')">✅</button>  
+                            <button class="btn btn-sm btn-danger d-none" id="email_cancel" onclick="cancelField('email')">❌</button>                         
+                        </td>
                     </tr>
                     <tr>
                         <th>電話番号</th>
-                        <td>{{ $user->phone_number }}</td>
+                        <td>
+                            <span id="phone_number_display">{{ $user->phone_number }}</span>
+                            <input type="text" id="phone_number_input" class="form-control d-none" value="{{ $user->phone_number }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="phone_number_edit" onclick="editField('phone_number')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="phone_number_save" onclick="saveField('phone_number')">✅</button>
+                            <button class="btn btn-sm btn-danger d-none" id="phone_number_cancel" onclick="cancelField('phone_number')">❌</button>
+                        </td>
                     </tr>
                     <tr>
                         <th>住所</th>
-                        <td>{{ $user->address }}</td>
+                            <td>
+                            <span id="address_display">{{ $user->address }}</span>
+                            <input type="text" id="address_input" class="form-control d-none" value="{{ $user->address }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="address_edit" onclick="editField('address')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="address_save" onclick="saveField('address')">✅</button>
+                            <button class="btn btn-sm btn-danger d-none" id="address_cancel" onclick="cancelField('address')">❌</button>
+                        </td>
                     </tr>
                     <tr>
                         <th>自己紹介</th>
-                        <td>{{ $user->self_introduction }}</td>
+                            <td>
+                            <span id="self_introduction_display">{{ $user->self_introduction }}</span>
+                            <input type="text" id="self_introduction_input" class="form-control d-none" value="{{ $user->self_introduction }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="self_introduction_edit" onclick="editField('self_introduction')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="self_introduction_save" onclick="saveField('self_introduction')">✅</button>
+                            <button class="btn btn-sm btn-danger d-none" id="self_introduction_cancel" onclick="cancelField('self_introduction')">❌</button>
+                        </td>
                     </tr>
                 </table>
                 <div class="mt-3">
@@ -80,4 +112,64 @@
         </div>
     </div>
 </div>
+
+<script>
+function editField(field) {
+    document.getElementById(`${field}_display`).classList.add('d-none');
+    document.getElementById(`${field}_input`).classList.remove('d-none');
+    document.getElementById(`${field}_edit`).classList.add('d-none');
+    document.getElementById(`${field}_save`).classList.remove('d-none');
+    document.getElementById(`${field}_cancel`).classList.remove('d-none');
+
+    // 編集前の値を保持（キャンセル時に使う）
+    const input = document.getElementById(`${field}_input`);
+    input.setAttribute('data-original', input.value);
+}
+
+function saveField(field) {
+    const value = document.getElementById(`${field}_input`).value;
+
+    fetch("{{ route('user.updateField') }}", {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        },
+        body: JSON.stringify({ field, value })
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.message) {
+            document.getElementById(`${field}_display`).textContent = value;
+            document.getElementById(`${field}_display`).classList.remove('d-none');
+            document.getElementById(`${field}_input`).classList.add('d-none');
+            document.getElementById(`${field}_edit`).classList.remove('d-none');
+            document.getElementById(`${field}_save`).classList.add('d-none');
+            document.getElementById(`${field}_cancel`).classList.add('d-none');
+        } else {
+            alert(data.error || '更新に失敗しました');
+        }
+    });
+}
+
+function cancelField(field) {
+    const display = document.getElementById(`${field}_display`);
+    const input = document.getElementById(`${field}_input`);
+    const editBtn = document.getElementById(`${field}_edit`);
+    const saveBtn = document.getElementById(`${field}_save`);
+    const cancelBtn = document.getElementById(`${field}_cancel`);
+
+    // 入力値を元に戻す
+    const originalValue = input.getAttribute('data-original');
+    input.value = originalValue;
+
+    // 表示切り替え
+    display.classList.remove('d-none');
+    input.classList.add('d-none');
+    saveBtn.classList.add('d-none');
+    cancelBtn.classList.add('d-none');
+    editBtn.classList.remove('d-none');
+}
+</script>
+
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,7 @@ Route::prefix('profile')->group(function () {
     // admin: 他人のプロフィール
     Route::middleware(['auth', 'role:admin'])->group(function () {
         Route::get('{user}', [UsersController::class, 'showProfile'])->name('admin.user.profile');
-        
+        Route::patch('/update-field/{user}', [UsersController::class, 'updateField'])->name('admin.user.updateField');
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,11 +43,14 @@ Route::prefix('profile')->group(function () {
     // general: 自分のプロフィール
     Route::middleware(['auth'])->group(function () {
         Route::get('/', [UsersController::class, 'showProfile'])->name('user.profile');
+        Route::patch('/update-field', [UsersController::class, 'updateField'])->name('user.updateField');
+
     });
 
     // admin: 他人のプロフィール
     Route::middleware(['auth', 'role:admin'])->group(function () {
         Route::get('{user}', [UsersController::class, 'showProfile'])->name('admin.user.profile');
+        
     });
 });
 


### PR DESCRIPTION
## 概要
[自分のプロフィールの編集は成功。管理人の他人のプロフィールの編集も成功。](https://github.com/Jin6hara/LaravelSprout/commit/2a24571a636f9983e25566670117a08f7226835b)
- 権限の実装はユーザー情報の表示と同じ方法を使用（同じPolicy、変数名、引数名）。
- Routeも同じく**role認証無**と**admin**に分けている。`admin`は`{user}`が必要。
- JSを使用（今のFocusではないが）。

## 注意
- Routeで`general`はURLに`{user}`がないため、コントローラ側引数の順番に注意。`public function updateField(?User $user = null, Request $request) `にしてしまうと、Laravelは $`request` を` $user `に渡してしまい、` $request` は` null `に → **500エラー**

**「null OKの引数は後ろに置く。複数でもOKだが、バインディングされる可能性があるものは全部後ろに揃える」**
1. フレームワークが注入するもの	`Request $request`, `Response $res`	最初に置くべき
2. ルートで定義されたモデル	`User $user`, `Post $post`	後ろに置くべき
3. null許容のモデル	`?User $user = null`	後ろに置けばOK（1つ以上でも可）
4. 自分で処理する引数	`$id`, `$slug`, `$field`	最初に置くべき（Laravelは勝手に当ててこないから）

- `->name('')`の相違に気づいていない。
- `getRouteKeyName()`を使用しているため、blade側では、`admin`に渡す値に注意。`['user' => $user->id]`ではなく、`['user' => $user->employee_code]`、もしくは`['user' => $user]`でok。
- JSは後日確認（Viewに集中していないため）。
