### PR TITLE
管理者ダッシュボードに検索UIとそのロジックを実装

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -16,28 +16,45 @@ class AdminController extends Controller
      */
     public function dashboard(Request $request)
     {
-        // 初期表示では検索語なし・対象は既定3つ
+        // 検索対象フィールドのホワイトリスト
+        $allowedFields = ['employee_code', 'name', 'phone_number'];
+
+        // 入力取得
         $word   = trim((string) $request->query('search_word', ''));
-        $fields = collect((array) $request->query('fields', ['employee_code', 'name', 'phone_number']))
-            ->intersect(['employee_code', 'name', 'phone_number'])
+        $fields = collect((array) $request->query('fields', $allowedFields))
+            ->intersect($allowedFields)
             ->take(3);
 
-        // 検索語が空なら全件、入っていれば対象フィールドで部分一致
+        // 万が一 0 件になったら全項目にフォールバック（?fields[]= などの変形入力対策）
+        if ($fields->isEmpty()) {
+            $fields = collect($allowedFields);
+        }
+
+        // 検索クエリ
         $query = User::query()
             ->when(filled($word), function ($q) use ($word, $fields) {
                 $q->where(function ($w) use ($word, $fields) {
                     $fields->values()->each(function ($field, $i) use ($w, $word) {
-                        // 先頭だけ where、それ以降は orWhere
                         $method = $i === 0 ? 'where' : 'orWhere';
                         $w->{$method}($field, 'like', "%{$word}%");
                     });
                 });
             });
 
-        $users = $query
-            ->orderByDesc('updated_at')
-            ->paginate(10)
-            ->withQueryString();
+        // 並び替え（既定: updated_at desc）
+        $sort = $request->query('sort', 'updated_at');
+        $dir  = strtolower($request->query('dir', 'desc'));
+
+        $allowedSorts = ['updated_at', 'employee_code', 'name'];
+        $allowedDirs  = ['asc', 'desc'];
+
+        if (!in_array($sort, $allowedSorts, true)) $sort = 'updated_at';
+        if (!in_array($dir,  $allowedDirs,  true)) $dir  = 'desc';
+
+        // employee_code が 5桁固定ならそのままでOK。可変長なら数値順にキャストも可（下のコメント参照）
+        $query->orderBy($sort, $dir);
+
+        $users = $query->paginate(10)->withQueryString();
 
         return view('admin.dashboard', compact('users', 'word', 'fields'));
     }
@@ -94,15 +111,20 @@ class AdminController extends Controller
 
     /**
      * 検索（GET /admin/search）
-     * 実質は dashboard と同じロジック。分けたいという要望に合わせてルートだけ分離。
+     * 実質は dashboard と100％同じロジック。URL表示を分けるため、ルートだけ分離。
      */
     public function search(Request $request)
     {
-        // dashboard() をそのまま再利用でもOK。ここではコピペで明示。
+        $allowedFields = ['employee_code', 'name', 'phone_number'];
+
         $word   = trim((string) $request->query('search_word', ''));
-        $fields = collect((array) $request->query('fields', ['employee_code','name','phone_number']))
-            ->intersect(['employee_code','name','phone_number'])
+        $fields = collect((array) $request->query('fields', $allowedFields))
+            ->intersect($allowedFields)
             ->take(3);
+
+        if ($fields->isEmpty()) {
+            $fields = collect($allowedFields);
+        }
 
         $query = User::query()
             ->when(filled($word), function ($q) use ($word, $fields) {
@@ -114,11 +136,19 @@ class AdminController extends Controller
                 });
             });
 
-        $users = $query
-            ->orderByDesc('updated_at')
-            ->paginate(10)
-            ->withQueryString();
+        $sort = $request->query('sort', 'updated_at');
+        $dir  = strtolower($request->query('dir', 'desc'));
 
-        return view('admin.dashboard', compact('users','word','fields'));
+        $allowedSorts = ['updated_at', 'employee_code', 'name'];
+        $allowedDirs  = ['asc', 'desc'];
+
+        if (!in_array($sort, $allowedSorts, true)) $sort = 'updated_at';
+        if (!in_array($dir,  $allowedDirs,  true)) $dir  = 'desc';
+
+        $query->orderBy($sort, $dir);
+
+        $users = $query->paginate(10)->withQueryString();
+
+        return view('admin.dashboard', compact('users', 'word', 'fields'));
     }
 }

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\UserRequest;
 use App\Http\Requests\AdminUpdateUserFieldRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\Request;
 use App\Models\User;
 
 class AdminController extends Controller
@@ -63,5 +64,23 @@ class AdminController extends Controller
         $targetUser->save();
 
         return response()->json(['message' => '更新完了']);
+    }
+
+    public function search(Request $request)
+    {
+        $word = trim((string) $request->query('search_word', ''));
+
+        $mq = User::query()
+            ->when(filled($word), fn ($q)=>
+                $q->where(fn($w) =>
+                    $w->where('employee_code', 'like', "%{$word}%")
+                    ->orWhere('name', 'like', "%{$word}%")
+                    ->orWhere('phone_number', 'like', "%{$word}%")
+                ) 
+            );
+
+        $user = $mq->orderByDesc('id')->paginate(20)->withQueryString();
+
+        return view('admin.dashboard', compact('user', 'word'));
     }
 }

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -11,9 +11,35 @@ use App\Models\User;
 
 class AdminController extends Controller
 {
-    public function dashboard()
+    /**
+     * ダッシュボード（初期表示：全件→検索UIも表示）
+     */
+    public function dashboard(Request $request)
     {
-        return view('admin.dashboard');
+        // 初期表示では検索語なし・対象は既定3つ
+        $word   = trim((string) $request->query('search_word', ''));
+        $fields = collect((array) $request->query('fields', ['employee_code', 'name', 'phone_number']))
+            ->intersect(['employee_code', 'name', 'phone_number'])
+            ->take(3);
+
+        // 検索語が空なら全件、入っていれば対象フィールドで部分一致
+        $query = User::query()
+            ->when(filled($word), function ($q) use ($word, $fields) {
+                $q->where(function ($w) use ($word, $fields) {
+                    $fields->values()->each(function ($field, $i) use ($w, $word) {
+                        // 先頭だけ where、それ以降は orWhere
+                        $method = $i === 0 ? 'where' : 'orWhere';
+                        $w->{$method}($field, 'like', "%{$word}%");
+                    });
+                });
+            });
+
+        $users = $query
+            ->orderByDesc('updated_at')
+            ->paginate(10)
+            ->withQueryString();
+
+        return view('admin.dashboard', compact('users', 'word', 'fields'));
     }
 
     public function showForm()
@@ -66,21 +92,33 @@ class AdminController extends Controller
         return response()->json(['message' => '更新完了']);
     }
 
+    /**
+     * 検索（GET /admin/search）
+     * 実質は dashboard と同じロジック。分けたいという要望に合わせてルートだけ分離。
+     */
     public function search(Request $request)
     {
-        $word = trim((string) $request->query('search_word', ''));
+        // dashboard() をそのまま再利用でもOK。ここではコピペで明示。
+        $word   = trim((string) $request->query('search_word', ''));
+        $fields = collect((array) $request->query('fields', ['employee_code','name','phone_number']))
+            ->intersect(['employee_code','name','phone_number'])
+            ->take(3);
 
-        $mq = User::query()
-            ->when(filled($word), fn ($q)=>
-                $q->where(fn($w) =>
-                    $w->where('employee_code', 'like', "%{$word}%")
-                    ->orWhere('name', 'like', "%{$word}%")
-                    ->orWhere('phone_number', 'like', "%{$word}%")
-                ) 
-            );
+        $query = User::query()
+            ->when(filled($word), function ($q) use ($word, $fields) {
+                $q->where(function ($w) use ($word, $fields) {
+                    $fields->values()->each(function ($field, $i) use ($w, $word) {
+                        $method = $i === 0 ? 'where' : 'orWhere';
+                        $w->{$method}($field, 'like', "%{$word}%");
+                    });
+                });
+            });
 
-        $user = $mq->orderByDesc('id')->paginate(20)->withQueryString();
+        $users = $query
+            ->orderByDesc('updated_at')
+            ->paginate(10)
+            ->withQueryString();
 
-        return view('admin.dashboard', compact('user', 'word'));
+        return view('admin.dashboard', compact('users','word','fields'));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,4 +55,12 @@ class User extends Authenticatable
     {
         return 'employee_code';
     }
+
+    // app/Models/User.php
+    public function getProfileImageUrlAttribute(): string
+    {
+        $defaults = config('user.default_profile_pictures');
+        $file = $this->profile_picture ?: ($defaults[$this->gender] ?? ($defaults['other'] ?? 'default_other.png'));
+        return asset('image/' . ltrim($file, '/'));
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -56,11 +56,10 @@ class User extends Authenticatable
         return 'employee_code';
     }
 
-    // app/Models/User.php
     public function getProfileImageUrlAttribute(): string
     {
         $defaults = config('user.default_profile_pictures');
-        $file = $this->profile_picture ?: ($defaults[$this->gender] ?? ($defaults['other'] ?? 'default_other.png'));
+        $file = $this->profile_picture ?: $defaults[$this->gender];
         return asset('image/' . ltrim($file, '/'));
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Paginator::useBootstrapFive(); //user.userListのpagination用に
     }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -46,9 +46,38 @@
                 <small class="text-muted">何も選択しない場合は3項目すべてを検索対象にします。</small>
             </div>
 
-            <div class="col-12 d-flex gap-2">
+            <div class="col-md-6 ustify-content-end mb-3 gap-2">
                 <button type="submit" class="btn btn-primary">検索</button>
                 <a href="{{ route('admin.dashboard') }}" class="btn btn-outline-secondary">条件をクリア</a>
+            </div>
+
+            {{-- 並び替え --}}
+            <div class="col-md-6 justify-content-end mb-3 gap-2">
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
+                        並び替え
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                        <li>
+                            <a class="dropdown-item"
+                                href="{{ request()->fullUrlWithQuery(['sort'=>'updated_at','dir'=>'desc','page'=>1]) }}">
+                                更新日（新→旧）
+                            </a>
+                        </li>
+                        <li>
+                            <a class="dropdown-item"
+                                href="{{ request()->fullUrlWithQuery(['sort'=>'employee_code','dir'=>'asc','page'=>1]) }}">
+                                社員コード（昇順）
+                            </a>
+                        </li>
+                        <li>
+                            <a class="dropdown-item"
+                                href="{{ request()->fullUrlWithQuery(['sort'=>'employee_code','dir'=>'desc','page'=>1]) }}">
+                                社員コード（降順）
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </div>
     </form>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,8 +1,79 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container text-center">
-    <h1>管理者ダッシュボード</h1>
-    <p>ここでは管理者向けの情報を表示します。</p>
+<div class="container">
+    <h1 class="mb-3 text-center">管理者ダッシュボード</h1>
+    <p class="text-center text-muted mb-4">ここでは管理者向けの情報を表示します。</p>
+
+    {{-- 検索フォーム --}}
+    <form method="GET" action="{{ route('admin.search') }}" class="mb-4">
+        <div class="row g-3 align-items-end">
+            <div class="col-md-6">
+                <label for="search_word" class="form-label">検索ワード</label>
+                <input type="text"
+                    id="search_word"
+                    name="search_word"
+                    value="{{ $word ?? '' }}"
+                    class="form-control"
+                    placeholder="社員コード／氏名／電話番号の一部で検索">
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label d-block">検索対象（1〜3件）</label>
+                @php
+                $selected = collect($fields ?? []);
+                @endphp
+                <div class="d-flex flex-wrap gap-3">
+                    <div class="form-check">
+                        <input class="form-check-input field-check" type="checkbox" id="f-emp"
+                            name="fields[]" value="employee_code"
+                            {{ $selected->contains('employee_code') ? 'checked' : '' }}>
+                        <label class="form-check-label" for="f-emp">employee_code</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input field-check" type="checkbox" id="f-name"
+                            name="fields[]" value="name"
+                            {{ $selected->contains('name') ? 'checked' : '' }}>
+                        <label class="form-check-label" for="f-name">name</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input field-check" type="checkbox" id="f-phone"
+                            name="fields[]" value="phone_number"
+                            {{ $selected->contains('phone_number') ? 'checked' : '' }}>
+                        <label class="form-check-label" for="f-phone">phone_number</label>
+                    </div>
+                </div>
+                <small class="text-muted">何も選択しない場合は3項目すべてを検索対象にします。</small>
+            </div>
+
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-primary">検索</button>
+                <a href="{{ route('admin.dashboard') }}" class="btn btn-outline-secondary">条件をクリア</a>
+            </div>
+        </div>
+    </form>
+
+    {{-- ユーザー一覧 --}}
+    @include('user.userList', ['users' => $users])
 </div>
+
+{{-- 最大3つまでチェックできるようにする（将来項目が増えても安全） --}}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const max = 3;
+        const boxes = document.querySelectorAll('.field-check');
+        boxes.forEach(box => {
+            box.addEventListener('change', () => {
+                const checked = Array.from(boxes).filter(b => b.checked);
+                if (checked.length === 0) {
+                    // 最低1件は維持（UX保護）。外したら直ちに戻す
+                    box.checked = true;
+                } else if (checked.length > max) {
+                    alert('検索対象は最大3件までです。');
+                    box.checked = false;
+                }
+            });
+        });
+    });
+</script>
 @endsection

--- a/resources/views/user/userList.blade.php
+++ b/resources/views/user/userList.blade.php
@@ -1,0 +1,66 @@
+@if($users->count())
+<div class="d-flex justify-content-between align-items-center mb-2">
+    <h5 class="mb-0">ユーザー一覧</h5>
+    <small class="text-muted">{{ $users->total() }} 件</small>
+</div>
+
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+    @foreach($users as $user)
+
+    {{-- 1行1～4件：col-12 col-sm-6 col-md-4 col-lg-3で自動調整 --}}
+    <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+        <div class="card h-100 shadow-sm">
+            {{-- 丸い小さめアバター --}}
+            <div class="pt-3 text-center">
+                <img
+                    src="{{ $user->profile_image_url }}"
+                    alt="profile picture of {{ $user->name }}"
+                    class="rounded-circle img-thumbnail"
+                    style="width: 128px; height: 128px; object-fit: cover;">
+            </div>
+
+            <div class="card-body">
+                <h6 class="card-title mb-1 text-center">
+                    <a href="{{ route('user.profile', $user) }}">
+                    {{ $user->name }}
+                    </a>
+                </h6>
+                <p class="text-center mb-2">
+                    <span class="badge bg-secondary">{{ ucfirst($user->gender) }}</span>
+                </p>
+
+                <ul class="list-group list-group-flush small">
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Code</span>
+                        <span class="fw-semibold">{{ $user->employee_code }}</span>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Email</span>
+                        <a class="text-decoration-none" href="mailto:{{ $user->email }}">{{ $user->email }}</a>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Phone</span>
+                        <span>{{ $user->phone_number ?? '—' }}</span>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="card-footer bg-white">
+                <small class="text-muted">
+                    Updated: {{ $user->updated_at?->format('Y-m-d H:i') }}
+                </small>
+            </div>
+        </div>
+    </div>
+    @endforeach
+</div>
+
+<div class="mt-3">
+    {{-- ページング（検索条件を維持） --}}
+    {{ $users->withQueryString()->links() }}
+</div>
+@else
+<div class="alert alert-light border">
+    データがありません。
+</div>
+@endif

--- a/resources/views/user/userList.blade.php
+++ b/resources/views/user/userList.blade.php
@@ -21,7 +21,7 @@
 
             <div class="card-body">
                 <h6 class="card-title mb-1 text-center">
-                    <a href="{{ route('user.profile', $user) }}">
+                    <a href="{{ route('admin.user.profile', $user) }}">
                     {{ $user->name }}
                     </a>
                 </h6>

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,5 +52,6 @@ Route::prefix('profile')->group(function () {
     Route::middleware(['auth', 'role:admin'])->group(function () {
         Route::get('{user}', [UsersController::class, 'showProfile'])->name('admin.user.profile');
         Route::patch('/update-field/{user}', [AdminController::class, 'updateField'])->name('admin.user.updateField');
+        Route::get('/admin/search', [AdminController::class, 'search'])->name('admin.search');
     });
 });


### PR DESCRIPTION

## [簡単なクエリーベースの作成]  (https://github.com/Jin6hara/LaravelSprout/pull/13/commits/640c50e3bed14adc52835821188483b9ed88a968)

- 学習目的の為。


## [管理者ダッシュボードに検索UIとそのロジックを実装] 概要(https://github.com/Jin6hara/LaravelSprout/pull/13/commits/f4a4d60116ce3261e28a3ffc106d6c3089be2850)

1. URL表示を変えるためルート（admin.dashboard、admin.search）は二つに分けた。
2. 検索はname、employee_code、phone_numberに対して可能。
3. 上記項目のチェックボックスあり、いらない項目のチェックを外すとフィルターをかけることができる。
4. 下記により、Blade側では`@php`で変数を定義することなく、`<img src="{{ $user->profile_image_url }}" alt...` での呼び出しが可能に。
```
app/Models/User.php

    public function getProfileImageUrlAttribute(): string
    {
        $defaults = config('user.default_profile_pictures');
        $file = $this->profile_picture ?: ($defaults[$this->gender] ?? ($defaults['other'] ?? 'default_other.png'));
        return asset('image/' . ltrim($file, '/'));
    }
```
5．user.userListのpagenatorのTailwindがうまく動作しなかったため、
[app/Providers/AppServiceProvider.php](https://github.com/Jin6hara/LaravelSprout/pull/13/commits/f4a4d60116ce3261e28a3ffc106d6c3089be2850#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48e)
の`boot()`に`Paginator::useBootstrapFive();`を追加。

## [並び替え選択を追加] (https://github.com/Jin6hara/LaravelSprout/pull/13/commits/e8cd4785f6016c3c4c969ff9984347176884f613)

- ユーザーの表示結果はupdated_atがdeefaultだったが、employ_code（昇順・降順）でもできるようにした。
- URLが`/dashboard...`になっていれば`dashboard()`、`/search...`になっていれば`search()`を使う。
