### PR TITLE
在籍状態分別の為、在籍期間と休職期間のテーブルとシーダー作成

### DIFF
--- a/app/Models/EmploymentTerm.php
+++ b/app/Models/EmploymentTerm.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+
+class EmploymentTerm extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'start_date', 'end_date', 'note'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+    public function leavePeriods()
+    {
+        return $this->hasMany(LeavePeriod::class);
+    }
+
+    public function scopeCurrentAt($q, ?string $date = null)
+    {
+        $d = ($date ?? today()->toDateString());
+        return $q->whereDate('start_date', '<=', $d)
+            ->where(function ($qq) use ($d) {
+                $qq->whereNull('end_date')->orWhereDate('end_date', '>=', $d);
+            });
+    }
+}

--- a/app/Models/LeavePeriod.php
+++ b/app/Models/LeavePeriod.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LeavePeriod extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['employment_term_id', 'start_date', 'end_date', 'reason'];
+
+    public function employmentTerm()
+    {
+        return $this->belongsTo(EmploymentTerm::class);
+    }
+
+    public function scopeCoversDate($q, ?string $date = null)
+    {
+        $d = ($date ?? today()->toDateString());
+        return $q->whereDate('start_date', '<=', $d)
+            ->whereDate('end_date', '>=', $d);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Carbon\Carbon;
 
 class User extends Authenticatable
 {
@@ -61,5 +62,100 @@ class User extends Authenticatable
         $defaults = config('user.default_profile_pictures');
         $file = $this->profile_picture ?: $defaults[$this->gender];
         return asset('image/' . ltrim($file, '/'));
+    }
+
+    public function employmentTerms()
+    {
+        return $this->hasMany(EmploymentTerm::class);
+    }
+
+    public function currentEmploymentTerm(?Carbon $date = null)
+    {
+        $d = ($date ?? now())->toDateString();
+        return $this->employmentTerms()
+            ->whereDate('start_date', '<=', $d)
+            ->where(function ($q) use ($d) {
+                $q->whereNull('end_date')->orWhereDate('end_date', '>=', $d);
+            });
+    }
+
+    /**
+     * 今日“在籍として扱う”ユーザー
+     * 在籍期間には含まれるが、休職には該当しない
+     */
+    public function scopeActiveAt($q, ?Carbon $date = null)
+    {
+        $d = ($date ?? today())->toDateString();
+
+        return $q->whereHas('employmentTerms', function ($term) use ($d) {
+            $term->currentAt($d)
+                ->whereDoesntHave('leavePeriods', fn($leave) => $leave->coversDate($d));
+        });
+    }
+
+    /** 今日 休職中（在籍だが就業停止） */
+    public function scopeOnLeaveAt($q, ?Carbon $date = null)
+    {
+        $d = ($date ?? today())->toDateString();
+
+        return $q->whereHas('employmentTerms', function ($term) use ($d) {
+            $term->currentAt($d)
+                ->whereHas('leavePeriods', fn($leave) => $leave->coversDate($d));
+        });
+    }
+
+    /** 入社待ち（未来開始の雇用期間がある） */
+    public function scopePrehire($q, ?Carbon $date = null)
+    {
+        $d = ($date ?? today())->toDateString();
+        return $q->whereHas('employmentTerms', fn($t) => $t->whereDate('start_date', '>', $d));
+    }
+
+    /** 退職済（今日有効な雇用期間なし＆将来の開始もなし） */
+    public function scopeTerminated($q, ?Carbon $date = null)
+    {
+        $d = ($date ?? today())->toDateString();
+        return $q->whereDoesntHave(
+            'employmentTerms',
+            fn($t) =>
+            $t->whereDate('start_date', '>', $d)
+                ->orWhere(function ($tt) use ($d) {
+                    $tt->whereDate('start_date', '<=', $d)
+                        ->where(function ($qq) use ($d) {
+                            $qq->whereNull('end_date')->orWhereDate('end_date', '>=', $d);
+                        });
+                })
+        );
+    }
+
+    /** 派生プロパティ：現在の状態（active/on_leave/prehire/terminated） */
+    public function getEmploymentStateAttribute(): string
+    {
+        $d = today()->toDateString();
+
+        // 入社待ち（未来開始が1つでもあれば prehire 扱い）
+        if ($this->employmentTerms()->whereDate('start_date', '>', $d)->exists()) {
+            return 'prehire';
+        }
+
+        // 現在有効な雇用期間
+        $term = $this->currentEmploymentTerm(today())->first();
+        if (!$term) {
+            return 'terminated';
+        }
+
+        // 有効期間中に休職が重なっていれば on_leave
+        if ($term->leavePeriods()->coversDate($d)->exists()) {
+            return 'on_leave';
+        }
+
+        return 'active';
+    }
+
+    /** 通知や自動メールの基本判定 */
+    public function shouldReceiveOperationalEmails(?Carbon $date = null): bool
+    {
+        $state = $this->employment_state; // 上のアクセサで取得
+        return $state === 'active';
     }
 }

--- a/database/migrations/2025_08_14_214605_create_employment_terms_table.php
+++ b/database/migrations/2025_08_14_214605_create_employment_terms_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employment_terms', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->date('start_date');            // 入社日 or 再入社日（将来日なら入社待ち）
+            $table->date('end_date')->nullable();  // 退職日（未定ならNULL = 無期限）
+            $table->string('note')->nullable();    // 備考（契約種別などもここでOK）
+            $table->timestamps();
+
+            // よく使う検索用のインデックス
+            $table->index(['user_id', 'start_date']);
+            $table->index(['user_id', 'end_date']);
+            $table->index(['start_date', 'end_date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employment_terms');
+    }
+};

--- a/database/migrations/2025_08_14_214857_create_leave_periods_table.php
+++ b/database/migrations/2025_08_14_214857_create_leave_periods_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('leave_periods', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employment_term_id')->constrained()->cascadeOnDelete();//termsではなくterm。model名が単数の為。
+            $table->date('start_date');           // 休職開始（当日を含む）
+            $table->date('end_date');             // 休職終了（当日を含む）
+            $table->string('reason')->nullable(); // 育休, 傷病など自由記述
+            $table->timestamps();
+
+            $table->index(['employment_term_id', 'start_date']);
+            $table->index(['employment_term_id', 'end_date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('leave_periods');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,8 +13,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(UsersSeeder::class);
-        
+        $this->call([
+            UsersSeeder::class,
+            EmploymentTermsSeeder::class,
+            LeavePeriodsSeeder::class,
+        ]);
+
         // \App\Models\User::factory(10)->create();
 
         // \App\Models\User::factory()->create([

--- a/database/seeders/EmploymentTermsSeeder.php
+++ b/database/seeders/EmploymentTermsSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class EmploymentTermsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 19; $i++) {
+            $user = User::where('employee_code', str_pad($i, 5, '0', STR_PAD_LEFT))->first();
+            if (!$user) continue;
+
+            if ($i >= 1 && $i <= 13) {
+                // 在籍：2020/01/01〜（無期限）
+                $start = '2020-01-01';
+                $end   = null;
+            } elseif ($i >= 14 && $i <= 16) {
+                // 退職：2020/01/01〜2024/12/31
+                $start = '2020-01-01';
+                $end   = '2024-12-31';
+            } else { // 17〜19
+                // 入社待ち：2026/01/01〜
+                $start = '2026-01-01';
+                $end   = null;
+            }
+
+            $user->employmentTerms()->create([
+                'start_date' => $start,
+                'end_date'   => $end,
+                'note'       => null,
+            ]);
+        }
+    }
+}

--- a/database/seeders/LeavePeriodsSeeder.php
+++ b/database/seeders/LeavePeriodsSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class LeavePeriodsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // 11〜13 を 2025/01/01〜2025/12/31 で休職
+        for ($i = 11; $i <= 13; $i++) {
+            $user = User::where('employee_code', str_pad($i, 5, '0', STR_PAD_LEFT))->first();
+            if (!$user) continue;
+
+            $term = $user->employmentTerms()->orderBy('start_date', 'desc')->first();
+            if (!$term) continue;
+
+            $term->leavePeriods()->create([
+                'start_date' => '2025-01-01',
+                'end_date'   => '2025-12-31',
+                'reason'     => '休職（テストデータ）',
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## [在籍状態分別の為、在籍期間と休職期間のテーブルとシーダー作成] (https://github.com/Jin6hara/LaravelSprout/commit/b72178a41b0cacbe202880ce9d7127affa9db0b1) 概要
- 在籍履歴を `employment_terms`テーブル、休職を `leave_periods`テーブルに分離。
- 「今日その人をどう扱うか」を日付から計算（保存しない）。
- 将来の書類自動作成／メール配信判定の一貫性を担保。
## 雇用状態の判定
- `prehire`：今日より後に開始する雇用期間が1件以上。
- `active`：`start_date <= today` かつ (`end_date is null` or `end_date >= today`) の雇用期間があり、かつその期間に休職が重なっていない。
- `on_leave`：上記「現在有効な雇用期間」に休職が重なっている。
- `terminated`：上記いずれにも該当せず、将来開始予定もない。
- パフォーマンス：期間の基本インデックスを付与`（employment_terms(start_date,end_date)`, `leave_periods(employment_term_id,start_date,end_date)`

## その他
- モデル名（単数）がデフォルト外部キーの基準

**hasMany / hasOne：親モデル名のスネークケース + _id**
`EmploymentTerm` → `employment_term_id`
`EmploymentTerms` → `employment_terms_id`

**belongsTo：リレーション関数名のスネークケース + _id**
関数が `employmentTerm()` なら → `employment_term_id`
関数が` employmentTerms()` なら → `employment_terms_id`

- 複数に（カスタマイズ）したい場合

// 親（EmploymentTerms）
```
public function leavePeriods() {
    return $this->hasMany(LeavePeriod::class, 'employment_terms_id', 'id');
}
```
// 子（LeavePeriod）
```
public function employmentTerm() {
    return $this->belongsTo(EmploymentTerms::class, 'employment_terms_id', 'id');
}
```
`, 'employment_terms_id', 'id'`**を明記。**

## Eloquent 関数の役割まとめ（何をしているか）

- **User モデル**

`employmentTerms()`
hasMany。ユーザーに紐づく全ての雇用期間を取得するための基本リレーション。
例：$user->employmentTerms()->create([...])

`currentEmploymentTerm($date = null)`
helper（クエリビルダ）。start_date <= $date かつ end_date is null or end_date >= $date を満たす雇用期間に限定。
例：$user->currentEmploymentTerm(today())->first()

`scopeActiveAt($q, $date = null)`
スコープ。指定日で「在籍扱い」のユーザーだけに絞る。
内部では employmentTerms()->currentAt($date) が存在し、かつその term に leavePeriods()->coversDate($date) が無いことをチェック。
例：User::activeAt()->get()

`scopeOnLeaveAt($q, $date = null)`
スコープ。指定日に「休職中（在籍＋休職該当）」のユーザー。
例：User::onLeaveAt('2025-04-01')->paginate()

`scopePrehire($q, $date = null)`
スコープ。未来日に開始する雇用期間があるユーザー。
例：User::prehire()->count()

`scopeTerminated($q, $date = null)`
スコープ。指定日に有効な雇用期間がなく、かつ将来の開始予定も無いユーザー。
例：User::terminated()->get()

`getEmploymentStateAttribute()`
アクセサ。$user->employment_state で prehire / on_leave / active / terminated のいずれかを計算して返す。
画面ラベル・配信可否の基準に利用。

`shouldReceiveOperationalEmails($date = null): bool`
業務通知可否の基本判定（例では active のみ true）。用途別に分けて増やす方針が安全。

- **EmploymentTerm モデル**

`leavePeriods()`
hasMany。この雇用期間に紐づく休職の穴を取得。

`scopeCurrentAt($q, $date = null)`
スコープ。指定日に有効な雇用期間だけに限定。
例：EmploymentTerm::currentAt('2025-01-10')->get()

- **LeavePeriod モデル**

`employmentTerm()`
belongsTo。どの雇用期間の休職かを辿る。

`scopeCoversDate($q, $date = null)`
スコープ。指定日が start_date <= date <= end_date に含まれる休職に限定。
例：$term->leavePeriods()->coversDate(today())->exists()