### PR TITLE
ユーザー情報のカテゴリ整理と表示

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -14,10 +14,8 @@ class UsersController extends Controller
 {
     public function showProfile(?User $user = null): View
     {
-        $currentUser = Auth::user();
-
         // userがnull → 自分のプロフィール（一般ユーザー）
-        $targetUser = $user ?? $currentUser;
+        $targetUser = $user ?? Auth::user();;
 
         // 権限チェック
         $this->authorize('view', $targetUser);
@@ -30,11 +28,13 @@ class UsersController extends Controller
             },
         ]);
 
-        // 最新の雇用情報 1 件（なければ null）
-        $employment = $targetUser->employmentTerms->first();
+        // 最新の雇用期間を取得（今日の日付でフィルタ）
+        // $employment = $targetUser->employmentTerms()->currentAt()->latest('start_date')->first(); // クエリで条件＆並び
+        $employment = $targetUser->employmentTerms->first(); // コレクションから最初
 
-        // 「現在休職中」の期間だけ抽出（start_date <= today <= end_date or end_date is null）
-        $activeLeaves = $employment?->activeLeavePeriods() ?? collect();
+        // 休職期間の取得（今日の日付でフィルタ）
+        // $activeLeaves = $employment?->activeLeavePeriods() ?? collect();
+        $activeLeaves = $employment?->leavePeriods()->coversDate()->get() ?? collect(); //性能的に有利
 
         return view('user.profile', [
             'user'         => $targetUser,

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -22,12 +22,34 @@ class UsersController extends Controller
         // 権限チェック
         $this->authorize('view', $targetUser);
 
-        // プロフィール画像取得ロジック
-        $defaultPictures = config('user.default_profile_pictures');
-        $gender = $targetUser->gender;
-        $targetUser->profile_picture = $targetUser->profile_picture ?? $defaultPictures[$gender];
+        // 雇用情報と休職期間をまとめてロード（最新開始日が先頭に来るように）
+        $targetUser->load([
+            'employmentTerms' => function ($q) {
+                $q->with('leavePeriods')
+                  ->orderByDesc('start_date');
+            },
+        ]);
 
-        return view('user.profile', ['user' => $targetUser]);
+        // 最新の雇用情報 1 件（なければ null）
+        $employment = $targetUser->employmentTerms->first();
+
+        // 「現在休職中」の期間だけ抽出（start_date <= today <= end_date or end_date is null）
+        $activeLeaves = collect();
+        if ($employment) {
+            $today = now()->startOfDay();
+            $activeLeaves = $employment->leavePeriods->filter(function ($lp) use ($today) {
+                // start_date / end_date は casts で date(Carbon) にしておく
+                $started = $lp->start_date ? $lp->start_date->startOfDay()->lte($today) : false;
+                $notEnded = is_null($lp->end_date) ? true : $lp->end_date->endOfDay()->gte($today);
+                return $started && $notEnded;
+            })->values();
+        }
+
+        return view('user.profile', [
+            'user'         => $targetUser,
+            'employment'   => $employment,
+            'activeLeaves' => $activeLeaves,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -26,7 +26,7 @@ class UsersController extends Controller
         $targetUser->load([
             'employmentTerms' => function ($q) {
                 $q->with('leavePeriods')
-                  ->orderByDesc('start_date');
+                    ->orderByDesc('start_date');
             },
         ]);
 
@@ -34,16 +34,7 @@ class UsersController extends Controller
         $employment = $targetUser->employmentTerms->first();
 
         // 「現在休職中」の期間だけ抽出（start_date <= today <= end_date or end_date is null）
-        $activeLeaves = collect();
-        if ($employment) {
-            $today = now()->startOfDay();
-            $activeLeaves = $employment->leavePeriods->filter(function ($lp) use ($today) {
-                // start_date / end_date は casts で date(Carbon) にしておく
-                $started = $lp->start_date ? $lp->start_date->startOfDay()->lte($today) : false;
-                $notEnded = is_null($lp->end_date) ? true : $lp->end_date->endOfDay()->gte($today);
-                return $started && $notEnded;
-            })->values();
-        }
+        $activeLeaves = $employment?->activeLeavePeriods() ?? collect();
 
         return view('user.profile', [
             'user'         => $targetUser,

--- a/app/Models/EmploymentTerm.php
+++ b/app/Models/EmploymentTerm.php
@@ -22,6 +22,7 @@ class EmploymentTerm extends Model
     {
         return $this->belongsTo(User::class);
     }
+    
     public function leavePeriods()
     {
         return $this->hasMany(LeavePeriod::class);
@@ -34,5 +35,10 @@ class EmploymentTerm extends Model
             ->where(function ($qq) use ($d) {
                 $qq->whereNull('end_date')->orWhereDate('end_date', '>=', $d);
             });
+    }
+
+    public function activeLeavePeriods()
+    {
+        return $this->leavePeriods->filter->isActive()->values();
     }
 }

--- a/app/Models/EmploymentTerm.php
+++ b/app/Models/EmploymentTerm.php
@@ -12,6 +12,12 @@ class EmploymentTerm extends Model
 
     protected $fillable = ['user_id', 'start_date', 'end_date', 'note'];
 
+    //これで $employment->start_date が自動的に Carbon になり、Bladeで ->format('Y/m/d') が使えるようになる。
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date'   => 'date',
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/EmploymentTerm.php
+++ b/app/Models/EmploymentTerm.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-
+use Illuminate\Database\Eloquent\Builder;
 
 class EmploymentTerm extends Model
 {
@@ -12,7 +12,7 @@ class EmploymentTerm extends Model
 
     protected $fillable = ['user_id', 'start_date', 'end_date', 'note'];
 
-    //これで $employment->start_date が自動的に Carbon になり、Bladeで ->format('Y/m/d') が使えるようになる。
+    // これで $employment->start_date が自動的に Carbon になり、Bladeで ->format('Y/m/d') が使えるようになる。
     protected $casts = [
         'start_date' => 'date',
         'end_date'   => 'date',
@@ -22,23 +22,26 @@ class EmploymentTerm extends Model
     {
         return $this->belongsTo(User::class);
     }
-    
+
     public function leavePeriods()
     {
         return $this->hasMany(LeavePeriod::class);
     }
 
-    public function scopeCurrentAt($q, ?string $date = null)
+    /** 今日の日付で有効な雇用期間を取得するスコープ */
+    public function scopeCurrentAt(Builder $q, $date = null): Builder
     {
-        $d = ($date ?? today()->toDateString());
-        return $q->whereDate('start_date', '<=', $d)
+        $d = ($date ?? today())->toDateString();
+        return $q->where('start_date', '<=', $d)
             ->where(function ($qq) use ($d) {
-                $qq->whereNull('end_date')->orWhereDate('end_date', '>=', $d);
+                $qq->whereNull('end_date')->orWhere('end_date', '>=', $d);
             });
     }
 
-    public function activeLeavePeriods()
+    /** 今日の日付で有効な休職期間を持つ雇用期間を取得するスコープ */
+    public function activeLeavePeriods($date = null): \Illuminate\Support\Collection
     {
-        return $this->leavePeriods->filter->isActive()->values();
+        return $this->leavePeriods->filter(fn($lp) => $lp->isActive($date))->values();// 引数いる場合
+        // $this->leavePeriods->filter->isActive()->values();も同じ意味ですが引数無に限定
     }
 }

--- a/app/Models/LeavePeriod.php
+++ b/app/Models/LeavePeriod.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class LeavePeriod extends Model
 {
@@ -21,19 +22,22 @@ class LeavePeriod extends Model
         return $this->belongsTo(EmploymentTerm::class);
     }
 
-    public function scopeCoversDate($q, ?string $date = null)
+    //** 今日の日付で有効な休職期間を取得するスコープ */
+    public function scopeCoversDate(Builder $q, $date = null): Builder
     {
-        $d = ($date ?? today()->toDateString());
-        return $q->whereDate('start_date', '<=', $d)
-            ->whereDate('end_date', '>=', $d);
+        $d = $date ?? today()->toDateString();//文字例のみ。
+        return $q->where('start_date', '<=', $d)
+            ->where(function ($qq) use ($d) {
+                $qq->whereNull('end_date')->orWhere('end_date', '>=', $d);
+            });
     }
 
-    public function isActive(): bool
+    /** 休職期間が今日の日付で有効かどうか */
+    public function isActive($date = null): bool
     {
-        $today = now()->startOfDay();
-        $started = $this->start_date?->startOfDay()->lte($today) ?? false;
-        $notEnded = is_null($this->end_date) || $this->end_date->endOfDay()->gte($today);
-
+        $d = ($date ?? today())->startOfDay();
+        $started  = $this->start_date?->startOfDay()->lte($d) ?? false;
+        $notEnded = is_null($this->end_date) || $this->end_date->endOfDay()->gte($d);
         return $started && $notEnded;
     }
 }

--- a/app/Models/LeavePeriod.php
+++ b/app/Models/LeavePeriod.php
@@ -10,7 +10,7 @@ class LeavePeriod extends Model
     use HasFactory;
 
     protected $fillable = ['employment_term_id', 'start_date', 'end_date', 'reason'];
-    
+
     protected $casts = [
         'start_date' => 'date',
         'end_date'   => 'date',
@@ -26,5 +26,14 @@ class LeavePeriod extends Model
         $d = ($date ?? today()->toDateString());
         return $q->whereDate('start_date', '<=', $d)
             ->whereDate('end_date', '>=', $d);
+    }
+
+    public function isActive(): bool
+    {
+        $today = now()->startOfDay();
+        $started = $this->start_date?->startOfDay()->lte($today) ?? false;
+        $notEnded = is_null($this->end_date) || $this->end_date->endOfDay()->gte($today);
+
+        return $started && $notEnded;
     }
 }

--- a/app/Models/LeavePeriod.php
+++ b/app/Models/LeavePeriod.php
@@ -10,6 +10,11 @@ class LeavePeriod extends Model
     use HasFactory;
 
     protected $fillable = ['employment_term_id', 'start_date', 'end_date', 'reason'];
+    
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date'   => 'date',
+    ];
 
     public function employmentTerm()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,6 +66,16 @@ class User extends Authenticatable
         return asset('image/' . ltrim($file, '/'));
     }
 
+    public function getGenderLabelAttribute(): string
+    {
+        return match ($this->gender) {
+            'male' => '男性',
+            'female' => '女性',
+            'other' => 'その他',
+            default => '未選択',
+        };
+    }
+
     public function employmentTerms()
     {
         return $this->hasMany(EmploymentTerm::class);
@@ -137,21 +147,21 @@ class User extends Authenticatable
 
         // 入社待ち（未来開始が1つでもあれば prehire 扱い）
         if ($this->employmentTerms()->whereDate('start_date', '>', $d)->exists()) {
-            return 'prehire';
+            return '入社待ち/prehire';
         }
 
         // 現在有効な雇用期間
         $term = $this->currentEmploymentTerm(today())->first();
         if (!$term) {
-            return 'terminated';
+            return '退職済み/terminated';
         }
 
         // 有効期間中に休職が重なっていれば on_leave
         if ($term->leavePeriods()->coversDate($d)->exists()) {
-            return 'on_leave';
+            return '休職中/on_leave';
         }
 
-        return 'active';
+        return '在籍中/active';
     }
 
     /** 通知や自動メールの基本判定 */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -76,6 +76,14 @@ class User extends Authenticatable
         };
     }
 
+    public function getRoleLabelAttribute(): string
+    {
+        return [
+            'admin'   => '管理者',
+            'general' => '一般',
+        ][$this->role] ?? $this->role;
+    }
+
     public function employmentTerms()
     {
         return $this->hasMany(EmploymentTerm::class);

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -170,7 +170,7 @@ $defaultUrl = asset('image/' . $defaultPictures[$user->gender]);
         <ul class="nav nav-tabs nav-justified mb-3">
             <li class="nav-item">
                 <a href="#" class="nav-link {{ Request::is('profile') || Request::is('profile/*') ? 'active' : '' }}">
-                    基本情報
+                    プロファイル
                 </a>
             </li>
             <li class="nav-item">
@@ -184,165 +184,10 @@ $defaultUrl = asset('image/' . $defaultPictures[$user->gender]);
                 </a>
             </li>
         </ul>
-
-        <div class="card mt-4">
-            <div class="card-header">
-                <h4>本人情報</h4>
-            </div>
-            <div class="card-body">
-                <table class="table table-bordered">
-                    <colgroup>
-                        <col style="width:140px;"> <!-- ← 好きな幅に -->
-                        <col>
-                    </colgroup>
-                    <tr>
-                        <th>社員コード</th>
-                        <td>{{ $user->employee_code }}</td>
-                    </tr>
-                    <tr>
-                        <th>名前</th>
-                        <td>{{ $user->name }}</td>
-                    </tr>
-                    <tr>
-                        <th>性別</th>
-                        <td>{{ $user->gender_label }}</td>
-                    </tr>
-                </table>
-                @if (Auth::user()->role === 'admin' && isset($user))
-                <div class="mt-3">
-                    <a href="" class="btn btn-secondary btn-block">本人情報を編集</a>
-                </div>
-                @endif
-            </div>
-        </div>
-
-        <div class="card mt-4">
-            <div class="card-header">
-                <h4>基本情報</h4>
-            </div>
-            <div class="card-body">
-                <table class="table table-bordered">
-                    <colgroup>
-                        <col style="width:140px;"> <!-- ← 好きな幅に -->
-                        <col>
-                    </colgroup>
-                    <th>Email</th>
-                    <td>
-                        <span id="email_display">{{ $user->email }}</span>
-                        <input type="text" id="email_input" class="form-control d-none" value="{{ $user->email }}">
-                    </td>
-                    <td style="width: 100px; text-align: center;">
-                        <button class="btn btn-sm btn-outline-secondary" id="email_edit" onclick="editField('email')">✏️</button>
-                        <button class="btn btn-sm btn-primary d-none" id="email_save" onclick="saveField('email')">✅</button>
-                        <button class="btn btn-sm btn-danger d-none" id="email_cancel" onclick="cancelField('email')">❌</button>
-                    </td>
-                    </tr>
-                    <tr>
-                        <th>電話番号</th>
-                        <td>
-                            <span id="phone_number_display">{{ $user->phone_number }}</span>
-                            <input type="text" id="phone_number_input" class="form-control d-none" value="{{ $user->phone_number }}">
-                        </td>
-                        <td style="width: 100px; text-align: center;">
-                            <button class="btn btn-sm btn-outline-secondary" id="phone_number_edit" onclick="editField('phone_number')">✏️</button>
-                            <button class="btn btn-sm btn-primary d-none" id="phone_number_save" onclick="saveField('phone_number')">✅</button>
-                            <button class="btn btn-sm btn-danger d-none" id="phone_number_cancel" onclick="cancelField('phone_number')">❌</button>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>住所</th>
-                        <td>
-                            <span id="address_display">{{ $user->address }}</span>
-                            <input type="text" id="address_input" class="form-control d-none" value="{{ $user->address }}">
-                        </td>
-                        <td style="width: 100px; text-align: center;">
-                            <button class="btn btn-sm btn-outline-secondary" id="address_edit" onclick="editField('address')">✏️</button>
-                            <button class="btn btn-sm btn-primary d-none" id="address_save" onclick="saveField('address')">✅</button>
-                            <button class="btn btn-sm btn-danger d-none" id="address_cancel" onclick="cancelField('address')">❌</button>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>自己紹介</th>
-                        <td>
-                            <span id="self_introduction_display">{{ $user->self_introduction }}</span>
-                            <input type="text" id="self_introduction_input" class="form-control d-none" value="{{ $user->self_introduction }}">
-                        </td>
-                        <td style="width: 100px; text-align: center;">
-                            <button class="btn btn-sm btn-outline-secondary" id="self_introduction_edit" onclick="editField('self_introduction')">✏️</button>
-                            <button class="btn btn-sm btn-primary d-none" id="self_introduction_save" onclick="saveField('self_introduction')">✅</button>
-                            <button class="btn btn-sm btn-danger d-none" id="self_introduction_cancel" onclick="cancelField('self_introduction')">❌</button>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </div>
-
-        {{-- 雇用情報 --}}
-        @php
-        // 雇用情報が複数ある場合に備えて最新開始日の1件を採用
-        $employment = optional($user->employmentTerms)->sortByDesc('start_date')->first();
-        @endphp
-        <div class="card mt-4">
-            <div class="card-header">
-                <h4>雇用情報</h4>
-            </div>
-            <div class="card-body">
-                <table class="table table-bordered profile-table">
-                    <colgroup>
-                        <col style="width:140px">
-                        <col>
-                    </colgroup>
-                    <tr>
-                        <th>雇用状態</th>
-                        <td>{{ $user->employment_state }}</td>
-                    </tr>
-                    <tr>
-                        <th>入社日</th>
-                        <td>{{ $employment?->start_date?->format('Y/m/d') ?? '—' }}</td>
-                    </tr>
-                    <tr>
-                        <th>退職日</th>
-                        <td>{{ $employment?->end_date?->format('Y/m/d') ?? '—' }}</td>
-                    </tr>
-                    <tr>
-                        <th>備考</th>
-                        <td>{{ $employment?->note ?? '—' }}</td>
-                    </tr>
-                </table>
-                @if (Auth::user()->role === 'admin' && isset($employment))
-                <div class="mt-3">
-                    <a href="" class="btn btn-secondary btn-block">雇用情報を編集</a>
-                </div>
-                @endif
-            </div>
-        </div>
-
-        {{-- 権限区分 --}}
-        @php
-        $roleLabels = ['admin' => '管理者', 'general' => '一般'];
-        @endphp
-        @if (Auth::user()->role === 'admin' && isset($user))
-        <div class="card mt-4">
-            <div class="card-header">
-                <h4>権限区分</h4>
-            </div>
-            <div class="card-body">
-                <table class="table table-bordered profile-table">
-                    <colgroup>
-                        <col style="width:140px">
-                        <col>
-                    </colgroup>
-                    <tr>
-                        <th>権限</th>
-                        <td>{{ $roleLabels[$user->role] ?? $user->role }}</td>
-                    </tr>
-                </table>
-                <div class="mt-3">
-                    <a href="" class="btn btn-secondary btn-block">権限を編集</a>
-                </div>
-            </div>
-        </div>
-        @endif
+        @include('user.profile.personal',   ['user' => $user])
+        @include('user.profile.basic',      ['user' => $user])
+        @include('user.profile.employment', ['user' => $user])
+        @include('user.profile.role',       ['user' => $user])
     </div>
 </div>
 

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -185,75 +185,47 @@ $defaultUrl = asset('image/' . $defaultPictures[$user->gender]);
             </li>
         </ul>
 
-        <div class="card">
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>本人情報</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered">
+                    <colgroup>
+                        <col style="width:140px;"> <!-- ← 好きな幅に -->
+                        <col>
+                    </colgroup>
+                    <tr>
+                        <th>社員コード</th>
+                        <td>{{ $user->employee_code }}</td>
+                    </tr>
+                    <tr>
+                        <th>名前</th>
+                        <td>{{ $user->name }}</td>
+                    </tr>
+                    <tr>
+                        <th>性別</th>
+                        <td>{{ $user->gender_label }}</td>
+                    </tr>
+                </table>
+                @if (Auth::user()->role === 'admin' && isset($user))
+                <div class="mt-3">
+                    <a href="" class="btn btn-secondary btn-block">本人情報を編集</a>
+                </div>
+                @endif
+            </div>
+        </div>
+
+        <div class="card mt-4">
             <div class="card-header">
                 <h4>基本情報</h4>
             </div>
             <div class="card-body">
                 <table class="table table-bordered">
-                    <tr>
-                        <th>社員コード</th>
-                        <td>
-                            <span id="employee_code_display">{{ $user->employee_code }}</span>
-                            <input type="text" id="employee_code_input" class="form-control d-none" value="{{ $user->employee_code }}">
-                        </td>
-                        @if(auth()->user()->role === 'admin')
-                        <td style="width: 100px; text-align: center;">
-                            <button class="btn btn-sm btn-outline-secondary" id="employee_code_edit" onclick="editField('employee_code')">✏️</button>
-                            <button class="btn btn-sm btn-primary d-none" id="employee_code_save" onclick="saveField('employee_code')">✅</button>
-                            <button class="btn btn-sm btn-danger d-none" id="employee_code_cancel" onclick="cancelField('employee_code')">❌</button>
-                        </td>
-                        @else
-                        <td></td>
-                        @endif
-                    </tr>
-                    <tr>
-                        <th>名前</th>
-                        <td>
-                            <span id="name_display">{{ $user->name }}</span>
-                            <input type="text" id="name_input" class="form-control d-none" value="{{ $user->name }}">
-                        </td>
-                        @if(auth()->user()->role === 'admin')
-                        <td style="width: 100px; text-align: center;">
-                            <button class="btn btn-sm btn-outline-secondary" id="name_edit" onclick="editField('name')">✏️</button>
-                            <button class="btn btn-sm btn-primary d-none" id="name_save" onclick="saveField('name')">✅</button>
-                            <button class="btn btn-sm btn-danger d-none" id="name_cancel" onclick="cancelField('name')">❌</button>
-                        </td>
-                        @else
-                        <td></td>
-                        @endif
-                    </tr>
-                    <tr>
-                        <th>性別</th>
-                        @php
-                        $genderLabels = [
-                        'unknown' => '未選択',
-                        'male' => '男性',
-                        'female' => '女性',
-                        'other' => 'その他',
-                        ];
-                        @endphp
-                        <td>
-                            {{-- 表示用（日本語ラベル） --}}
-                            <span id="gender_display">{{ $genderLabels[$user->gender] ?? '未選択' }}</span>
-                            {{-- 編集用（セレクト） --}}
-                            <select id="gender_input" class="form-select d-none">
-                                <option value="unknown" {{ $user->gender === 'unknown' ? 'selected' : '' }}>未選択</option>
-                                <option value="male" {{ $user->gender === 'male'    ? 'selected' : '' }}>男性</option>
-                                <option value="female" {{ $user->gender === 'female'  ? 'selected' : '' }}>女性</option>
-                                <option value="other" {{ $user->gender === 'other'   ? 'selected' : '' }}>その他</option>
-                            </select>
-                        </td>
-                        @if(auth()->user()->role === 'admin')
-                        <td style="width: 100px; text-align: center;">
-                            <button class="btn btn-sm btn-outline-secondary" id="gender_edit" onclick="editField('gender')">✏️</button>
-                            <button class="btn btn-sm btn-primary d-none" id="gender_save" onclick="saveField('gender')">✅</button>
-                            <button class="btn btn-sm btn-danger d-none" id="gender_cancel" onclick="cancelField('gender')">❌</button>
-                        </td>
-                        @else
-                        <td></td>
-                        @endif
-                    </tr>
+                    <colgroup>
+                        <col style="width:140px;"> <!-- ← 好きな幅に -->
+                        <col>
+                    </colgroup>
                     <th>Email</th>
                     <td>
                         <span id="email_display">{{ $user->email }}</span>
@@ -302,11 +274,75 @@ $defaultUrl = asset('image/' . $defaultPictures[$user->gender]);
                         </td>
                     </tr>
                 </table>
+            </div>
+        </div>
+
+        {{-- 雇用情報 --}}
+        @php
+        // 雇用情報が複数ある場合に備えて最新開始日の1件を採用
+        $employment = optional($user->employmentTerms)->sortByDesc('start_date')->first();
+        @endphp
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>雇用情報</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered profile-table">
+                    <colgroup>
+                        <col style="width:140px">
+                        <col>
+                    </colgroup>
+                    <tr>
+                        <th>雇用状態</th>
+                        <td>{{ $user->employment_state }}</td>
+                    </tr>
+                    <tr>
+                        <th>入社日</th>
+                        <td>{{ $employment?->start_date?->format('Y/m/d') ?? '—' }}</td>
+                    </tr>
+                    <tr>
+                        <th>退職日</th>
+                        <td>{{ $employment?->end_date?->format('Y/m/d') ?? '—' }}</td>
+                    </tr>
+                    <tr>
+                        <th>備考</th>
+                        <td>{{ $employment?->note ?? '—' }}</td>
+                    </tr>
+                </table>
+                @if (Auth::user()->role === 'admin' && isset($employment))
                 <div class="mt-3">
-                    <a href="" class="btn btn-secondary btn-block">情報の一括編集</a>
+                    <a href="" class="btn btn-secondary btn-block">雇用情報を編集</a>
+                </div>
+                @endif
+            </div>
+        </div>
+
+        {{-- 権限区分 --}}
+        @php
+        $roleLabels = ['admin' => '管理者', 'general' => '一般'];
+        @endphp
+        @if (Auth::user()->role === 'admin' && isset($user))
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>権限区分</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered profile-table">
+                    <colgroup>
+                        <col style="width:140px">
+                        <col>
+                    </colgroup>
+                    <tr>
+                        <th>権限</th>
+                        <td>{{ $roleLabels[$user->role] ?? $user->role }}</td>
+                    </tr>
+                </table>
+                <div class="mt-3">
+                    <a href="" class="btn btn-secondary btn-block">権限を編集</a>
                 </div>
             </div>
         </div>
+        @endif
     </div>
 </div>
 

--- a/resources/views/user/profile/basic.blade.php
+++ b/resources/views/user/profile/basic.blade.php
@@ -1,0 +1,61 @@
+        {{-- 基本情報 JSインライン編集--}}
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>基本情報</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered">
+                    <colgroup>
+                        <col style="width:140px;"> <!-- ← 好きな幅に -->
+                        <col>
+                    </colgroup>
+                    <th>Email</th>
+                    <td>
+                        <span id="email_display">{{ $user->email }}</span>
+                        <input type="text" id="email_input" class="form-control d-none" value="{{ $user->email }}">
+                    </td>
+                    <td style="width: 100px; text-align: center;">
+                        <button class="btn btn-sm btn-outline-secondary" id="email_edit" onclick="editField('email')">✏️</button>
+                        <button class="btn btn-sm btn-primary d-none" id="email_save" onclick="saveField('email')">✅</button>
+                        <button class="btn btn-sm btn-danger d-none" id="email_cancel" onclick="cancelField('email')">❌</button>
+                    </td>
+                    </tr>
+                    <tr>
+                        <th>電話番号</th>
+                        <td>
+                            <span id="phone_number_display">{{ $user->phone_number }}</span>
+                            <input type="text" id="phone_number_input" class="form-control d-none" value="{{ $user->phone_number }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="phone_number_edit" onclick="editField('phone_number')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="phone_number_save" onclick="saveField('phone_number')">✅</button>
+                            <button class="btn btn-sm btn-danger d-none" id="phone_number_cancel" onclick="cancelField('phone_number')">❌</button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>住所</th>
+                        <td>
+                            <span id="address_display">{{ $user->address }}</span>
+                            <input type="text" id="address_input" class="form-control d-none" value="{{ $user->address }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="address_edit" onclick="editField('address')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="address_save" onclick="saveField('address')">✅</button>
+                            <button class="btn btn-sm btn-danger d-none" id="address_cancel" onclick="cancelField('address')">❌</button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>自己紹介</th>
+                        <td>
+                            <span id="self_introduction_display">{{ $user->self_introduction }}</span>
+                            <input type="text" id="self_introduction_input" class="form-control d-none" value="{{ $user->self_introduction }}">
+                        </td>
+                        <td style="width: 100px; text-align: center;">
+                            <button class="btn btn-sm btn-outline-secondary" id="self_introduction_edit" onclick="editField('self_introduction')">✏️</button>
+                            <button class="btn btn-sm btn-primary d-none" id="self_introduction_save" onclick="saveField('self_introduction')">✅</button>
+                            <button class="btn btn-sm btn-danger d-none" id="self_introduction_cancel" onclick="cancelField('self_introduction')">❌</button>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>

--- a/resources/views/user/profile/employment.blade.php
+++ b/resources/views/user/profile/employment.blade.php
@@ -1,8 +1,4 @@
         {{-- 雇用情報 --}}
-        @php
-        // 雇用情報が複数ある場合に備えて最新開始日の1件を採用
-        $employment = optional($user->employmentTerms)->sortByDesc('start_date')->first();
-        @endphp
         <div class="card mt-4">
             <div class="card-header">
                 <h4>雇用情報</h4>
@@ -17,6 +13,18 @@
                         <th>雇用状態</th>
                         <td>{{ $user->employment_state }}</td>
                     </tr>
+                    @if($activeLeaves->isNotEmpty())
+                    @foreach($activeLeaves as $leave)
+                    <tr>
+                        <th>休職期間</th>
+                        <td>{{ $leave->start_date?->format('Y/m/d') ?? '—' }} 〜 {{ $leave->end_date?->format('Y/m/d') ?? '—' }}</td>
+                    </tr>
+                    <tr>
+                        <th>休職理由</th>
+                        <td>{{ $leave->reason ?? '—' }}</td>
+                    </tr>
+                    @endforeach
+                    @endif
                     <tr>
                         <th>入社日</th>
                         <td>{{ $employment?->start_date?->format('Y/m/d') ?? '—' }}</td>

--- a/resources/views/user/profile/employment.blade.php
+++ b/resources/views/user/profile/employment.blade.php
@@ -1,0 +1,39 @@
+        {{-- 雇用情報 --}}
+        @php
+        // 雇用情報が複数ある場合に備えて最新開始日の1件を採用
+        $employment = optional($user->employmentTerms)->sortByDesc('start_date')->first();
+        @endphp
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>雇用情報</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered profile-table">
+                    <colgroup>
+                        <col style="width:140px">
+                        <col>
+                    </colgroup>
+                    <tr>
+                        <th>雇用状態</th>
+                        <td>{{ $user->employment_state }}</td>
+                    </tr>
+                    <tr>
+                        <th>入社日</th>
+                        <td>{{ $employment?->start_date?->format('Y/m/d') ?? '—' }}</td>
+                    </tr>
+                    <tr>
+                        <th>退職日</th>
+                        <td>{{ $employment?->end_date?->format('Y/m/d') ?? '—' }}</td>
+                    </tr>
+                    <tr>
+                        <th>備考</th>
+                        <td>{{ $employment?->note ?? '—' }}</td>
+                    </tr>
+                </table>
+                @if (Auth::user()->role === 'admin' && isset($employment))
+                <div class="mt-3">
+                    <a href="" class="btn btn-secondary btn-block">雇用情報を編集</a>
+                </div>
+                @endif
+            </div>
+        </div>

--- a/resources/views/user/profile/personal.blade.php
+++ b/resources/views/user/profile/personal.blade.php
@@ -1,0 +1,31 @@
+        {{-- 本人情報 --}}
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>本人情報</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered">
+                    <colgroup>
+                        <col style="width:140px;"> <!-- ← 好きな幅に -->
+                        <col>
+                    </colgroup>
+                    <tr>
+                        <th>社員コード</th>
+                        <td>{{ $user->employee_code }}</td>
+                    </tr>
+                    <tr>
+                        <th>名前</th>
+                        <td>{{ $user->name }}</td>
+                    </tr>
+                    <tr>
+                        <th>性別</th>
+                        <td>{{ $user->gender_label }}</td>
+                    </tr>
+                </table>
+                @if (Auth::user()->role === 'admin' && isset($user))
+                <div class="mt-3">
+                    <a href="" class="btn btn-secondary btn-block">本人情報を編集</a>
+                </div>
+                @endif
+            </div>
+        </div>

--- a/resources/views/user/profile/role.blade.php
+++ b/resources/views/user/profile/role.blade.php
@@ -1,0 +1,27 @@
+        
+        {{-- 権限区分 --}}
+        @php
+        $roleLabels = ['admin' => '管理者', 'general' => '一般'];
+        @endphp
+        @if (Auth::user()->role === 'admin' && isset($user))
+        <div class="card mt-4">
+            <div class="card-header">
+                <h4>権限区分</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-bordered profile-table">
+                    <colgroup>
+                        <col style="width:140px">
+                        <col>
+                    </colgroup>
+                    <tr>
+                        <th>権限</th>
+                        <td>{{ $roleLabels[$user->role] ?? $user->role }}</td>
+                    </tr>
+                </table>
+                <div class="mt-3">
+                    <a href="" class="btn btn-secondary btn-block">権限を編集</a>
+                </div>
+            </div>
+        </div>
+        @endif

--- a/resources/views/user/profile/role.blade.php
+++ b/resources/views/user/profile/role.blade.php
@@ -1,8 +1,4 @@
-        
         {{-- 権限区分 --}}
-        @php
-        $roleLabels = ['admin' => '管理者', 'general' => '一般'];
-        @endphp
         @if (Auth::user()->role === 'admin' && isset($user))
         <div class="card mt-4">
             <div class="card-header">
@@ -16,7 +12,7 @@
                     </colgroup>
                     <tr>
                         <th>権限</th>
-                        <td>{{ $roleLabels[$user->role] ?? $user->role }}</td>
+                        <td>{{ $user->role_label }}</td>
                     </tr>
                 </table>
                 <div class="mt-3">


### PR DESCRIPTION
## [ユーザープロファイルの情報カテゴリを整理] (https://github.com/Jin6hara/LaravelSprout/commit/25a2e5479ca226bcefba35c5b228d0257b4eb3f7) 概要
- 情報カテゴリを下記の4つに変更

1. 本人情報→admin用、super adminの承認が必要、ログに残す
2. 基本情報→admin・general共通、JSインラインで編集可能
3. 雇用情報→admin用
4. 権限　　→admin用、super adminの承認が必要、ログに残す

## その他
- 下記により`$employment->start_date` が自動的に `Carbon` になり、Bladeで `->format('Y/m/d')` が使えるようになる。
```
Models/User
    protected $casts = [
        'start_date' => 'date',
        'end_date'   => 'date',
    ];
```
- 下記により英語値を日本語に変換
```
Models/User
    public function getGenderLabelAttribute(): string
    {
        return match ($this->gender) {
            'male' => '男性',
            'female' => '女性',
            'other' => 'その他',
            default => '未選択',
        };
    }
```
呼び出しは`{{ $user->gender_label }}`
get`GenderLabel`Attribute()→`gender_label`？（小文字化しアンダーバー着けて呼び出す？）

- 下記により第一カラムの分割線の調整をする
```
                    <colgroup>
                        <col style="width:140px;"> <!-- ← 好きな幅に -->
                        <col>
                    </colgroup>
```