### PR TITLE
✅Blade + Full Calendar式

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers;
+
+namespace App\Http\Controllers;
+
+use App\Models\Shift;//
+use App\Models\Holiday;//
+use App\Models\CoverageNeed;//
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CalendarController extends Controller
+{
+    public function index()
+    {
+        return view('calendar.index'); // BladeでFullCalendarを初期化
+    }
+
+    // FullCalendarが ?start=YYYY-MM-DD&end=YYYY-MM-DD を付けてGETします
+    public function events(Request $request)
+    {
+        $start = $request->query('start'); // 文字列（ISO）
+        $end   = $request->query('end');
+
+        $user = Auth::user();
+        $isAdmin = $user->hasRole('admin') || $user->hasRole('super_admin');
+
+        $events = [];
+
+        // 下記は燃料の入り口（サンプル）
+
+        // 祝日（全員に表示）
+        $holidays = Holiday::whereBetween('date', [$start, $end])->get();
+        foreach ($holidays as $h) {
+            $events[] = [
+                'id' => 'holiday-' . $h->id,
+                'title' => '祝日：' . $h->name,
+                'start' => $h->date->toDateString(),
+                'allDay' => true,
+                'display' => 'background', // 背景マーキング
+                'classNames' => ['fc-holiday'],
+            ];
+        }
+
+        if ($isAdmin) {
+            // 管理者：サブ募集（CoverageNeed）をイベントとして表示（件数をタイトルに）
+            $needs = CoverageNeed::whereBetween('date', [$start, $end])->get()
+                ->groupBy('date');
+
+            foreach ($needs as $date => $items) {
+                $count = $items->sum('needed');
+                $events[] = [
+                    'id' => 'need-' . $date,
+                    'title' => "サブ必要 {$count}件",
+                    'start' => $date,
+                    'allDay' => true,
+                    'classNames' => ['fc-need'],
+                    'extendedProps' => [
+                        'details' => $items->map(fn($it) => [
+                            'campus' => $it->campus,
+                            'needed' => $it->needed,
+                            'reason' => $it->reason
+                        ])->values(),
+                    ],
+                ];
+            }
+        } else {
+            // 講師：自分のシフト
+            $shifts = Shift::where('user_id', $user->id)
+                ->whereBetween('date', [$start, $end])
+                ->orderBy('date')
+                ->get();
+
+            foreach ($shifts as $s) {
+                $label = $s->type === 'overtime' ? '残業' : '通常';
+                $time  = ($s->start_time && $s->end_time) ? " {$s->start_time}–{$s->end_time}" : '';
+                $events[] = [
+                    'id' => 'shift-' . $s->id,
+                    'title' => "{$label}{$time} @{$s->location}",
+                    'start' => $s->date->toDateString(),
+                    'allDay' => true, // 日単位管理の想定。時間帯で出すなら allDay=false に
+                    'classNames' => [$s->type === 'overtime' ? 'fc-overtime' : 'fc-regular'],
+                    'extendedProps' => [
+                        'type' => $s->type,
+                        'location' => $s->location,
+                        'start_time' => $s->start_time,
+                        'end_time' => $s->end_time,
+                    ],
+                ];
+            }
+        }
+
+        return response()->json($events);
+    }
+}

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -1,0 +1,106 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">カレンダー</h2>
+  {{-- 役割ヒント --}}
+  @role('admin|super_admin')
+    <span class="badge text-bg-primary">管理者ビュー：サブ必要状況</span>
+  @else
+    <span class="badge text-bg-secondary">講師ビュー：自分のシフト</span>
+  @endrole
+</div>
+
+<div id="calendar"></div>
+
+<!-- 詳細モーダル -->
+<div class="modal fade" id="eventModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">詳細</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body" id="eventModalBody">
+        読み込み中…
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('styles')
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.css" rel="stylesheet">
+<style>
+  /* 祝日背景 */
+  .fc-holiday { background-color: rgba(255, 193, 7, 0.15) !important; }
+  /* 管理者のサブ必要イベント */
+  .fc-need { background-color: rgba(220, 53, 69, .15) !important; border: 1px solid rgba(220,53,69,.4) }
+  /* 講師のシフト */
+  .fc-regular { background-color: rgba(13,110,253,.12) !important; border: 1px solid rgba(13,110,253,.35) }
+  .fc-overtime { background-color: rgba(25,135,84,.12) !important; border: 1px solid rgba(25,135,84,.35) }
+  /* カレンダー高さ調整 */
+  #calendar { max-width: 1100px; margin: 0 auto; }
+</style>
+@endpush
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const calendarEl = document.getElementById('calendar');
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    locale: 'ja',
+    initialView: 'dayGridMonth',
+    height: 'auto',
+    firstDay: 0, // 0:日曜はじまり
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'dayGridMonth,timeGridWeek,listWeek'
+    },
+    buttonText: { today: '今日', month: '月', week: '週', day: '日', list: 'リスト' },
+    dayMaxEventRows: true,
+    navLinks: true,
+    nowIndicator: true,
+
+    // ここがLaravelのJSONエンドポイント
+    events: {
+      url: "{{ route('calendar.events') }}",
+      failure: () => alert('イベント取得に失敗しました')
+    },
+
+    // イベントクリック時にモーダル表示
+    eventClick(info) {
+      info.jsEvent.preventDefault();
+      const e = info.event;
+      const p = e.extendedProps || {};
+      let html = `<div class="mb-2"><strong>${e.title}</strong></div>`;
+      if (p.details) {
+        // 管理者: サブ必要の内訳表示
+        html += '<ul class="list-group">';
+        p.details.forEach(d => {
+          html += `<li class="list-group-item d-flex justify-content-between">
+                     <span>${d.campus} (${d.reason ?? '—'})</span>
+                     <span class="badge text-bg-danger">必要 ${d.needed}</span>
+                   </li>`;
+        });
+        html += '</ul>';
+      } else {
+        // 講師: シフト詳細
+        html += `<div>種別：${p.type ?? '—'}</div>`;
+        html += `<div>場所：${p.location ?? '—'}</div>`;
+        if (p.start_time || p.end_time) {
+          html += `<div>時間：${p.start_time ?? ''} 〜 ${p.end_time ?? ''}</div>`;
+        }
+      }
+      document.getElementById('eventModalBody').innerHTML = html;
+      const modal = new bootstrap.Modal(document.getElementById('eventModal'));
+      modal.show();
+    },
+  });
+
+  calendar.render();
+});
+</script>
+@endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
 <html lang="ja">
+
 <head>
     <meta charset="utf-8">
     <title>ルートハブ</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
     <!-- Bootstrap 5 CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- FontAwesome -->
     <script defer src="https://use.fontawesome.com/releases/v6.5.0/js/all.js"></script>
+    @stack('styles')
 </head>
+
 <body>
     @include('commons.header')
 
@@ -22,5 +26,7 @@
 
     <!-- JS Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    @stack('scripts')
 </body>
+
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\ProfilePhotoController;
 use App\Http\Controllers\RoleChangeController;
 use App\Http\Controllers\ApprovalController;
 use App\Http\Controllers\NotificationController;
-
+use App\Http\Controllers\CalendarController;
 
 /*
 |--------------------------------------------------------------------------
@@ -34,6 +34,8 @@ Route::middleware(['auth', 'role:general|admin|super_admin'])->group(function ()
     Route::get('/', function () {
         return view('welcome');
     })->name('welcome');
+    Route::get('/calendar', [CalendarController::class, 'index'])->name('calendar.index');
+    Route::get('/calendar/events', [CalendarController::class, 'events'])->name('calendar.events'); // JSON
 });
 
 //登録
@@ -81,6 +83,6 @@ Route::middleware(['auth', 'role:super_admin'])->group(function () {
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
     Route::post('/notifications/{notification}/read', [NotificationController::class, 'markAsRead'])->name('notifications.read');
     Route::post('/notifications/read-all', [NotificationController::class, 'markAllAsRead'])->name('notifications.readAll');
-        // クリック＝既読→詳細へ
-    Route::get('/notifications/{notification}/go', [NotificationController::class, 'go'])->name('notifications.go');// name('approvals.show')の内容と連携。
+    // クリック＝既読→詳細へ
+    Route::get('/notifications/{notification}/go', [NotificationController::class, 'go'])->name('notifications.go'); // name('approvals.show')の内容と連携。
 });


### PR DESCRIPTION
## 将来表示したいもの
**講師側** 
①Rosterの表示 
まずは共通祝日、そしてパターン。 この二つ合わせて初めて講師に渡すrosterとなる。rosterの表示はここで完了。
②各曜日のシフト情報を出勤日に表示させる。 
③有給を取得したらカレンダーに反映します。（上書き？） 
④有休を含まない非出勤日にシフトを受け取るとカレンダーにOTシフトとして反映します。（上書き？） 【

**管理者側** 
⑤毎日の代講要員を表示します。（代講要員が③で有休をとると消えます。）（代講要員は普通のシフトであり、イレギュラー出勤日の場合のシフトでもあります。） 
⑥毎日の代行シフトを表示します。レギュラーシフト持つ人がは③で有休ををると反映されます。 
⑦（⑥-⑤）で足りないサブを計算します。

※Rosterは保存せず“計算で出す”→ DBが肥大化しない？