### PR TITLE
Feature/jin6/get subs total

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Observers\LeaveObserver;
 use App\Services\Calendar\ForecastResolver;
 use App\Services\Calendar\Providers\HolidayProvider;
 use App\Services\Calendar\Providers\ClosureProvider;
+use App\Services\Calendar\Providers\SubCountProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -41,6 +42,7 @@ class AppServiceProvider extends ServiceProvider
             $providers = [
                 $app->make(HolidayProvider::class),
                 $app->make(ClosureProvider::class),
+                $app->make(SubCountProvider::class), 
             ];
             return new ForecastResolver($providers);
         });

--- a/app/Services/Calendar/ForecastResolver.php
+++ b/app/Services/Calendar/ForecastResolver.php
@@ -16,8 +16,8 @@ class ForecastResolver
     public function __construct(iterable $providers)
     {
         $this->providers = is_array($providers) ? $providers : iterator_to_array($providers);
-        $this->meta  = config('calendar.providers', []);
-        $this->rules = config('calendar.rules', []);
+        $this->meta  = config('calendar_forecast.providers', []);
+        $this->rules = config('calendar_forecast.rules', []);
     }
 
     public function build(?User $user, Carbon $start, Carbon $end): array
@@ -39,7 +39,7 @@ class ForecastResolver
                 // FC配列化
                 $arr = method_exists($ev, 'toArray') ? $ev->toArray() : get_object_vars($ev);
                 $arr['extendedProps'] = $arr['extendedProps'] ?? [];
-                $arr['extendedProps']['level'] = $arr['extendedProps']['level'] ?? $level;
+                $arr['extendedProps']['level'] = $level;
 
                 // 背景指定の補完
                 if (!isset($arr['display']) && $type === EventType::BACKGROUND) {

--- a/app/Services/Calendar/ForecastResolver.php
+++ b/app/Services/Calendar/ForecastResolver.php
@@ -11,19 +11,19 @@ class ForecastResolver
     /** @var CalendarEventProvider[] */
     private array $providers = [];
     private array $meta;
+    private array $rules;
 
     public function __construct(iterable $providers)
     {
         $this->providers = is_array($providers) ? $providers : iterator_to_array($providers);
-        $this->meta = config('calendar.providers', []);
+        $this->meta  = config('calendar.providers', []);
+        $this->rules = config('calendar.rules', []);
     }
 
     public function build(?User $user, Carbon $start, Carbon $end): array
     {
-        $holidays = [];
-        $closures = [];
+        $daily = []; // 'YYYY-MM-DD' => ['by_level' => [level => [event,array...]]]
 
-        // 1) 収集 + 正規化（provider名を埋めておく）
         foreach ($this->providers as $p) {
             $cls = get_class($p);
             $defaults = $this->meta[$cls] ?? [];
@@ -31,70 +31,53 @@ class ForecastResolver
             foreach ($p->provide($user, $start, $end) as $ev) {
                 if (is_array($ev)) $ev = (object)$ev;
 
-                $ev->level     = $defaults['level'] ?? ($ev->level ?? 9);
-                $ev->type      = $ev->type ?? ($defaults['type'] ?? EventType::BACKGROUND);
-                $ev->planGroup = $defaults['plan'] ?? ($ev->planGroup ?? PlanGroup::REGULAR_PLAN);
+                // 既定適用（config最優先）
+                $level     = $defaults['level'] ?? ($ev->level ?? 9);
+                $type      = $ev->type ?? ($defaults['type'] ?? EventType::BACKGROUND);
+                $planGroup = $defaults['plan'] ?? ($ev->planGroup ?? PlanGroup::REGULAR_PLAN);
 
-                // FC配列へ
+                // FC配列化
                 $arr = method_exists($ev, 'toArray') ? $ev->toArray() : get_object_vars($ev);
+                $arr['extendedProps'] = $arr['extendedProps'] ?? [];
+                $arr['extendedProps']['level'] = $arr['extendedProps']['level'] ?? $level;
 
                 // 背景指定の補完
-                if (!isset($arr['display']) && ($ev->type === EventType::BACKGROUND)) {
+                if (!isset($arr['display']) && $type === EventType::BACKGROUND) {
                     $arr['display'] = 'background';
                 }
-                $arr['allDay'] = $arr['allDay'] ?? true;
 
-                // meta補完
-                $arr['extendedProps'] = $arr['extendedProps'] ?? [];
-                $arr['extendedProps']['level'] = $arr['extendedProps']['level'] ?? $ev->level;
-                $arr['extendedProps']['_provider'] = $arr['extendedProps']['_provider']
-                    ?? class_basename($cls); // "HolidayProvider" / "ClosureProvider" など
+                // --- ここが重要：全イベントを「日割り(single-day)」に展開 ---
+                [$S, $E] = $this->eventRange($arr, $start, $end); // [start, endExclusive]
+                $cur = $S->copy();
+                while ($cur < $E) {
+                    $d = $cur->toDateString();
 
-                // 振り分け
-                $prov = $arr['extendedProps']['_provider'];
-                if (stripos($prov, 'Holiday') !== false) {
-                    $holidays[] = $arr;
-                } elseif (stripos($prov, 'Closure') !== false) {
-                    $closures[] = $arr;
-                } else {
-                    // 念のため：他が混入しても無視せず返したければここで扱う
+                    $dayEvent = $arr;
+                    $dayEvent['start'] = $d;
+                    unset($dayEvent['end']); // 1日単位化
+                    $daily[$d]['by_level'][$level][] = $dayEvent;
+
+                    $cur->addDay();
                 }
             }
         }
 
-        // 2) 祝日の日付セットを作る (endは排他的)
-        $holidayDates = [];
-        foreach ($holidays as $h) {
-            [$hs, $he] = $this->eventRange($h);
-            $d = $hs->copy();
-            while ($d < $he) {
-                $holidayDates[$d->toDateString()] = true;
-                $d->addDay();
+        // --- その日で「最小 level のイベントだけ」採用（holiday untouchable対応）---
+        $out = [];
+        foreach ($daily as $d => $bucket) {
+            if (empty($bucket['by_level'])) continue;
+
+            $levels = array_keys($bucket['by_level']);
+            sort($levels);
+            $minLevel = ($this->rules['holiday_untouchable'] ?? true) && in_array(1, $levels, true) ? 1 : $levels[0];
+
+            foreach ($bucket['by_level'][$minLevel] as $ev) {
+                $out[] = $ev;
             }
         }
 
-        // 3) 会社休暇から「祝日の当日」を切り抜く（分割）
-        $closureSegments = [];
-        foreach ($closures as $c) {
-            [$cs, $ce] = $this->eventRange($c); // [start, endExclusive]
-
-            // 単日 or 期間
-            $segments = $this->splitRangeExcludingDates($cs, $ce, $holidayDates);
-            if (empty($segments)) {
-                // 全日が祝日で埋まっているなら何も出さない
-                continue;
-            }
-            foreach ($segments as [$ss, $se]) {
-                $seg = $c;
-                $seg['start'] = $ss->toDateString();
-                $seg['end']   = $se->toDateString(); // FC allDay の end は排他的
-                $closureSegments[] = $seg;
-            }
-        }
-
-        // 4) 祝日 + 分割済み会社休暇 を統合・安定ソート
-        $events = array_merge($holidays, $closureSegments);
-        usort($events, function ($a, $b) {
+        // 安定ソート：level → date → title
+        usort($out, function ($a, $b) {
             $al = $a['extendedProps']['level'] ?? 9;
             $bl = $b['extendedProps']['level'] ?? 9;
             if ($al !== $bl) return $al <=> $bl;
@@ -103,57 +86,28 @@ class ForecastResolver
             $bd = substr(($b['start'] ?? ''), 0, 10);
             if ($ad !== $bd) return strcmp($ad, $bd);
 
-            $as = $a['start'] ?? '';
-            $bs = $b['start'] ?? '';
-            if ($as !== $bs) return strcmp($as, $bs);
-
             return strcmp(($a['title'] ?? ''), ($b['title'] ?? ''));
         });
 
-        return $events;
+        return $out;
     }
 
-    /** @return array{0:Carbon,1:Carbon} [start, endExclusive] */
-    private function eventRange(array $ev): array
+    /** @return array{0:Carbon,1:Carbon} [start, endExclusive] （クエリ範囲にクランプ）*/
+    private function eventRange(array $ev, Carbon $reqStart, Carbon $reqEnd): array
     {
-        $s = Carbon::parse(substr(($ev['start'] ?? ''), 0, 10) ?: now()->toDateString())->startOfDay();
-        // end が無ければ単日 → endExclusive = s + 1day
+        $s = Carbon::parse(substr(($ev['start'] ?? ''), 0, 10) ?: $reqStart->toDateString())->startOfDay();
         $e = !empty($ev['end'])
             ? Carbon::parse(substr($ev['end'], 0, 10))->startOfDay()
             : $s->copy()->addDay();
-        return [$s, $e];
-    }
 
-    /**
-     * 指定の [start, endExclusive) から、blacklist（日付文字列）の日を除外し、
-     * 連続区間ごとの [segStart, segEndExclusive] を返す
-     * @param array<string,bool> $blacklist
-     * @return array{0:Carbon,1:Carbon}[]
-     */
-    private function splitRangeExcludingDates(Carbon $start, Carbon $endExclusive, array $blacklist): array
-    {
-        $segments = [];
-        $cursor = $start->copy();
-        $segStart = null;
+        // リクエスト範囲にクランプ（reqEnd は排他）
+        $S = $s->lessThan($reqStart) ? $reqStart->copy()->startOfDay() : $s;
+        $E = $e->greaterThan($reqEnd) ? $reqEnd->copy()->startOfDay() : $e;
 
-        while ($cursor < $endExclusive) {
-            $day = $cursor->toDateString();
-            $isBlocked = isset($blacklist[$day]);
+        if ($E <= $S) {
+            $E = $S->copy()->addDay();
+        } // 念のため
 
-            if ($isBlocked) {
-                if ($segStart) {
-                    // 直前までを区切る
-                    $segments[] = [$segStart, $cursor->copy()];
-                    $segStart = null;
-                }
-            } else {
-                if (!$segStart) $segStart = $cursor->copy();
-            }
-            $cursor->addDay();
-        }
-        if ($segStart) {
-            $segments[] = [$segStart, $endExclusive->copy()];
-        }
-        return $segments;
+        return [$S, $E];
     }
 }

--- a/app/Services/Calendar/Providers/SubCountProvider.php
+++ b/app/Services/Calendar/Providers/SubCountProvider.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Services\Calendar\Providers;
+
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use App\Services\Calendar\Contracts\CalendarEventProvider;
+use App\Services\Calendar\CandidateEvent;
+
+class SubCountProvider implements CalendarEventProvider
+{
+    /** @return array<CandidateEvent> */
+    public function provide(User $user, Carbon $start, Carbon $end): array
+    {
+        $startDate = $start->toDateString();
+        // FullCalendar の end は排他なので -1 日を SQL 上限に使う
+        $endDate   = $end->copy()->subDay()->toDateString();
+
+        // === Sub 判定キーワード ==========================================
+        $kw = (array) config('calendar_forecast.sub_keywords', ['sub', 'SUB', 'Sub']);
+        $isSubName = function (?string $name) use ($kw): bool {
+            if (!$name) return false;
+            foreach ($kw as $w) {
+                if (mb_stripos($name, $w) !== false) return true;
+            }
+            return false;
+        };
+
+        // === (0) 欠席ユーザー（全休のみ）を日別に収集 =====================
+        // 期間が重なる approved のみ。全日: time_start/time_end が両方 NULL
+        $rangeS = $start->copy()->startOfDay();
+        $rangeE = $end->copy()->startOfDay(); // 排他
+
+        $leaveRows = DB::table('leaves')
+            ->select('user_id', 'start_date', 'end_date', 'time_start', 'time_end', 'status')
+            ->where('status', 'approved')
+            ->whereDate('start_date', '<=', $endDate)
+            ->where(function ($q) use ($startDate) {
+                $q->whereNull('end_date')->orWhereDate('end_date', '>=', $startDate);
+            })
+            ->get();
+
+        /** @var array<string, array<int,bool>> $leaveUsersByDate */
+        $leaveUsersByDate = [];
+        foreach ($leaveRows as $lv) {
+            // 全休のみ除外対象（部分休はカウント対象）
+            if (!is_null($lv->time_start) || !is_null($lv->time_end)) {
+                continue;
+            }
+            $ls = Carbon::parse($lv->start_date)->startOfDay();
+            $le = $lv->end_date
+                ? Carbon::parse($lv->end_date)->startOfDay()->addDay() // 排他
+                : $ls->copy()->addDay();
+
+            // 集計範囲とクランプ
+            $S = $ls->greaterThan($rangeS) ? $ls : $rangeS;
+            $E = $le->lessThan($rangeE) ? $le : $rangeE;
+            if ($E <= $S) continue;
+
+            $cur = $S->copy();
+            while ($cur < $E) {
+                $d = $cur->toDateString();
+                $leaveUsersByDate[$d][(int)$lv->user_id] = true;
+                $cur->addDay();
+            }
+        }
+
+        // === (A) events: schedule_change & sub校名 & assigned_user_id ======
+        $events = DB::table('events')
+            ->select('event_date', 'source_schedule_line_id', 'assigned_user_id', 'school_name')
+            ->whereBetween('event_date', [$startDate, $endDate])
+            ->where('type', 'schedule_change')
+            ->whereNotNull('assigned_user_id')
+            ->where(function ($q) use ($kw) {
+                foreach ($kw as $w) $q->orWhere('school_name', 'like', "%{$w}%");
+            })
+            ->get();
+
+        $eventCountByDate = [];                 // 日別のイベント人数
+        $eventUsersByDateLine = [];             // [date][line_id][user_id] = true（line重複控除用）
+        foreach ($events as $e) {
+            if (!$isSubName($e->school_name)) continue; // 最終ガード
+            $d = Carbon::parse($e->event_date)->toDateString();
+            $uid = (int)$e->assigned_user_id;
+
+            // 欠席(全休)ユーザーはイベント由来でもカウントしない
+            if (!empty($leaveUsersByDate[$d][$uid])) {
+                continue;
+            }
+
+            $eventCountByDate[$d] = ($eventCountByDate[$d] ?? 0) + 1;
+
+            if (!empty($e->source_schedule_line_id)) {
+                $lid = (int)$e->source_schedule_line_id;
+                $eventUsersByDateLine[$d][$lid][$uid] = true; // set
+            }
+        }
+
+        // === (B) rest_pattern_adjustments: work_instead を “人数” で集計 ===
+        // rpa.date 当日に rpa.rest_pattern_id がアサインされている DISTINCT user_id
+        // → さらに欠席ユーザーを除外
+        $adjUsersRows = DB::table('rest_pattern_adjustments as rpa')
+            ->join('user_rest_patterns as urp', 'urp.rest_pattern_id', '=', 'rpa.rest_pattern_id')
+            ->whereBetween('rpa.date', [$startDate, $endDate])
+            ->where('rpa.kind', 'work_instead')
+            ->where('rpa.is_active', true)
+            // urp の適用期間に rpa.date が含まれる
+            ->whereColumn('urp.start_date', '<=', 'rpa.date')
+            ->where(function ($q) {
+                $q->whereNull('urp.end_date')
+                    ->orWhereColumn('urp.end_date', '>=', 'rpa.date');
+            })
+            ->select('rpa.date', 'urp.user_id')
+            ->get();
+
+        $adjCounts = []; // [date] => 人数
+        $adjUsersPerDate = []; // set (distinct)
+        foreach ($adjUsersRows as $row) {
+            $d = Carbon::parse($row->date)->toDateString();
+            $uid = (int)$row->user_id;
+
+            // 欠席(全休)ユーザーを除外
+            if (!empty($leaveUsersByDate[$d][$uid])) {
+                continue;
+            }
+
+            $adjUsersPerDate[$d][$uid] = true;
+        }
+        foreach ($adjUsersPerDate as $d => $set) {
+            $adjCounts[$d] = count($set);
+        }
+
+        // === (C) schedule_lines: sub校名 & 期間/DOW一致（“当日割当の人数”） =====
+        //   1) line の schedule_id に対し、当日有効な user_schedule_assignments を集めて
+        //      DISTINCT user_id を求める
+        //   2) 同日同 line でイベント化された user は控除
+        //   3) 欠席(全休)ユーザーは控除
+        $lines = DB::table('schedule_lines')
+            ->select('id', 'schedule_id', 'dow', 'school_name', 'effective_start', 'effective_end')
+            ->whereDate('effective_start', '<=', $endDate)
+            ->whereDate('effective_end', '>=', $startDate)
+            ->where(function ($q) use ($kw) {
+                foreach ($kw as $w) $q->orWhere('school_name', 'like', "%{$w}%");
+            })
+            ->get()
+            ->filter(fn($ln) => $isSubName($ln->school_name)) // 最終ガード
+            ->values();
+
+        $scheduleIds = $lines->pluck('schedule_id')->unique()->all();
+        $assignments = empty($scheduleIds)
+            ? collect()
+            : DB::table('user_schedule_assignments')
+            ->select('user_id', 'schedule_id', 'start_date', 'end_date')
+            ->whereIn('schedule_id', $scheduleIds)
+            ->whereDate('start_date', '<=', $endDate)
+            ->where(function ($q) use ($startDate) {
+                $q->whereNull('end_date')->orWhereDate('end_date', '>=', $startDate);
+            })
+            ->get();
+
+        $assignBySchedule = [];
+        foreach ($assignments as $a) {
+            $assignBySchedule[$a->schedule_id][] = [
+                'user_id'    => (int)$a->user_id,
+                'start_date' => $a->start_date,
+                'end_date'   => $a->end_date, // null 可
+            ];
+        }
+
+        $dbDowOf = fn(Carbon $d): int => $d->dayOfWeek; // 0=Sun..6=Sat 前提
+        $lineCountByDate = [];
+
+        foreach ($lines as $ln) {
+            $effS = Carbon::parse($ln->effective_start)->startOfDay();
+            $effE = Carbon::parse($ln->effective_end)->startOfDay()->addDay(); // 排他
+
+            // line の有効期間 ∩ 集計期間
+            $segS = $effS->greaterThan($rangeS) ? $effS : $rangeS;
+            $segE = $effE->lessThan($rangeE) ? $effE : $rangeE;
+            if ($segE <= $segS) continue;
+
+            $as = $assignBySchedule[$ln->schedule_id] ?? [];
+
+            $cur = $segS->copy();
+            while ($cur < $segE) {
+                if ($dbDowOf($cur) === (int)$ln->dow) {
+                    $d = $cur->toDateString();
+
+                    // 1) 当日有効な割当ユーザー集合
+                    $users = [];
+                    foreach ($as as $rec) {
+                        if ($rec['start_date'] <= $d && (is_null($rec['end_date']) || $rec['end_date'] >= $d)) {
+                            $users[$rec['user_id']] = true;
+                        }
+                    }
+
+                    // 2) 同日同 line のイベント化ユーザーを控除
+                    if (!empty($eventUsersByDateLine[$d][$ln->id])) {
+                        foreach (array_keys($eventUsersByDateLine[$d][$ln->id]) as $uid) {
+                            unset($users[$uid]);
+                        }
+                    }
+
+                    // 3) 欠席(全休)ユーザーを控除
+                    if (!empty($leaveUsersByDate[$d])) {
+                        foreach (array_keys($leaveUsersByDate[$d]) as $uid) {
+                            unset($users[$uid]);
+                        }
+                    }
+
+                    $n = count($users);
+                    if ($n > 0) {
+                        $lineCountByDate[$d] = ($lineCountByDate[$d] ?? 0) + $n;
+                    }
+                }
+                $cur->addDay();
+            }
+        }
+
+        // === (D) 出力（CandidateEvent[]） ================================
+        $out = [];
+        $cur = $rangeS->copy();
+        while ($cur < $rangeE) {
+            $d = $cur->toDateString();
+            $total =
+                ($lineCountByDate[$d]  ?? 0) +  // line × 当日割当人数（イベント化/欠席控除後）
+                ($adjCounts[$d]        ?? 0) +  // RWD 人数（欠席控除後）
+                ($eventCountByDate[$d] ?? 0);   // イベント人数（欠席控除済）
+
+            if ($total > 0) {
+                $out[] = new CandidateEvent([
+                    'title' => 'Sub ' . $total,
+                    'start' => $d,
+                    'allDay' => true,
+                    'classNames' => ['ev-subcount'],
+                    'extendedProps' => [
+                        'category' => 'subcount',
+                        'count'    => $total,
+                    ],
+                ]);
+            }
+            $cur->addDay();
+        }
+
+        return $out;
+    }
+}

--- a/app/Services/Calendar/Providers/SubCountProvider.php
+++ b/app/Services/Calendar/Providers/SubCountProvider.php
@@ -14,24 +14,19 @@ class SubCountProvider implements CalendarEventProvider
     public function provide(User $user, Carbon $start, Carbon $end): array
     {
         $startDate = $start->toDateString();
-        // FullCalendar の end は排他なので -1 日を SQL 上限に使う
-        $endDate   = $end->copy()->subDay()->toDateString();
+        $endDate   = $end->copy()->subDay()->toDateString(); // FC end は排他
 
-        // === Sub 判定キーワード ==========================================
-        $kw = (array) config('calendar_forecast.sub_keywords', ['sub', 'SUB', 'Sub']);
+        // === Sub 判定 ===
+        $kw = (array) config('calendar.sub_keywords', ['sub', 'SUB', 'サブ', '代行']);
         $isSubName = function (?string $name) use ($kw): bool {
             if (!$name) return false;
-            foreach ($kw as $w) {
-                if (mb_stripos($name, $w) !== false) return true;
-            }
+            foreach ($kw as $w) if (mb_stripos($name, $w) !== false) return true;
             return false;
         };
 
-        // === (0) 欠席ユーザー（全休のみ）を日別に収集 =====================
-        // 期間が重なる approved のみ。全日: time_start/time_end が両方 NULL
+        // === 欠席(全休)ユーザー 日別集合 ===
         $rangeS = $start->copy()->startOfDay();
         $rangeE = $end->copy()->startOfDay(); // 排他
-
         $leaveRows = DB::table('leaves')
             ->select('user_id', 'start_date', 'end_date', 'time_start', 'time_end', 'status')
             ->where('status', 'approved')
@@ -41,34 +36,25 @@ class SubCountProvider implements CalendarEventProvider
             })
             ->get();
 
-        /** @var array<string, array<int,bool>> $leaveUsersByDate */
-        $leaveUsersByDate = [];
+        $leaveUsersByDate = []; // [date][user_id] = true
         foreach ($leaveRows as $lv) {
-            // 全休のみ除外対象（部分休はカウント対象）
-            if (!is_null($lv->time_start) || !is_null($lv->time_end)) {
-                continue;
-            }
-            $ls = Carbon::parse($lv->start_date)->startOfDay();
-            $le = $lv->end_date
-                ? Carbon::parse($lv->end_date)->startOfDay()->addDay() // 排他
-                : $ls->copy()->addDay();
+            // 全休のみ除外対象
+            if (!is_null($lv->time_start) || !is_null($lv->time_end)) continue;
 
-            // 集計範囲とクランプ
+            $ls = Carbon::parse($lv->start_date)->startOfDay();
+            $le = $lv->end_date ? Carbon::parse($lv->end_date)->startOfDay()->addDay() : $ls->copy()->addDay();
             $S = $ls->greaterThan($rangeS) ? $ls : $rangeS;
             $E = $le->lessThan($rangeE) ? $le : $rangeE;
             if ($E <= $S) continue;
 
-            $cur = $S->copy();
-            while ($cur < $E) {
-                $d = $cur->toDateString();
-                $leaveUsersByDate[$d][(int)$lv->user_id] = true;
-                $cur->addDay();
+            for ($d=$S->copy(); $d < $E; $d->addDay()) {
+                $leaveUsersByDate[$d->toDateString()][(int)$lv->user_id] = true;
             }
         }
 
-        // === (A) events: schedule_change & sub校名 & assigned_user_id ======
+        // === (A) events: schedule_change & sub校名 & assigned_user_id ===
         $events = DB::table('events')
-            ->select('event_date', 'source_schedule_line_id', 'assigned_user_id', 'school_name')
+            ->select('id', 'event_date', 'source_schedule_line_id', 'assigned_user_id', 'school_name')
             ->whereBetween('event_date', [$startDate, $endDate])
             ->where('type', 'schedule_change')
             ->whereNotNull('assigned_user_id')
@@ -77,65 +63,50 @@ class SubCountProvider implements CalendarEventProvider
             })
             ->get();
 
-        $eventCountByDate = [];                 // 日別のイベント人数
-        $eventUsersByDateLine = [];             // [date][line_id][user_id] = true（line重複控除用）
+        $eventUsersCounted   = []; // [date][user_id]=true
+        $eventUsersAbsent    = []; // [date][user_id]=true
+        $eventUsersByDateLine = []; // [date][line_id][user_id]=true
         foreach ($events as $e) {
-            if (!$isSubName($e->school_name)) continue; // 最終ガード
-            $d = Carbon::parse($e->event_date)->toDateString();
+            if (!$isSubName($e->school_name)) continue;
+            $d   = Carbon::parse($e->event_date)->toDateString();
             $uid = (int)$e->assigned_user_id;
 
-            // 欠席(全休)ユーザーはイベント由来でもカウントしない
             if (!empty($leaveUsersByDate[$d][$uid])) {
-                continue;
+                $eventUsersAbsent[$d][$uid] = true;
+            } else {
+                $eventUsersCounted[$d][$uid] = true;
             }
-
-            $eventCountByDate[$d] = ($eventCountByDate[$d] ?? 0) + 1;
-
             if (!empty($e->source_schedule_line_id)) {
-                $lid = (int)$e->source_schedule_line_id;
-                $eventUsersByDateLine[$d][$lid][$uid] = true; // set
+                $eventUsersByDateLine[$d][(int)$e->source_schedule_line_id][$uid] = true;
             }
         }
 
-        // === (B) rest_pattern_adjustments: work_instead を “人数” で集計 ===
-        // rpa.date 当日に rpa.rest_pattern_id がアサインされている DISTINCT user_id
-        // → さらに欠席ユーザーを除外
-        $adjUsersRows = DB::table('rest_pattern_adjustments as rpa')
+        // === (B) rest_pattern_adjustments: work_instead を “人数”で ===
+        $adjRows = DB::table('rest_pattern_adjustments as rpa')
             ->join('user_rest_patterns as urp', 'urp.rest_pattern_id', '=', 'rpa.rest_pattern_id')
             ->whereBetween('rpa.date', [$startDate, $endDate])
             ->where('rpa.kind', 'work_instead')
             ->where('rpa.is_active', true)
-            // urp の適用期間に rpa.date が含まれる
             ->whereColumn('urp.start_date', '<=', 'rpa.date')
             ->where(function ($q) {
-                $q->whereNull('urp.end_date')
-                    ->orWhereColumn('urp.end_date', '>=', 'rpa.date');
+                $q->whereNull('urp.end_date')->orWhereColumn('urp.end_date', '>=', 'rpa.date');
             })
             ->select('rpa.date', 'urp.user_id')
             ->get();
 
-        $adjCounts = []; // [date] => 人数
-        $adjUsersPerDate = []; // set (distinct)
-        foreach ($adjUsersRows as $row) {
-            $d = Carbon::parse($row->date)->toDateString();
+        $rwdUsersCounted = []; // [date][user_id]=true
+        $rwdUsersAbsent  = []; // [date][user_id]=true
+        foreach ($adjRows as $row) {
+            $d   = Carbon::parse($row->date)->toDateString();
             $uid = (int)$row->user_id;
-
-            // 欠席(全休)ユーザーを除外
             if (!empty($leaveUsersByDate[$d][$uid])) {
-                continue;
+                $rwdUsersAbsent[$d][$uid] = true;
+            } else {
+                $rwdUsersCounted[$d][$uid] = true;
             }
-
-            $adjUsersPerDate[$d][$uid] = true;
-        }
-        foreach ($adjUsersPerDate as $d => $set) {
-            $adjCounts[$d] = count($set);
         }
 
-        // === (C) schedule_lines: sub校名 & 期間/DOW一致（“当日割当の人数”） =====
-        //   1) line の schedule_id に対し、当日有効な user_schedule_assignments を集めて
-        //      DISTINCT user_id を求める
-        //   2) 同日同 line でイベント化された user は控除
-        //   3) 欠席(全休)ユーザーは控除
+        // === (C) schedule_lines: “当日割当ユーザー数”で（イベント化＆欠席控除） ===
         $lines = DB::table('schedule_lines')
             ->select('id', 'schedule_id', 'dow', 'school_name', 'effective_start', 'effective_end')
             ->whereDate('effective_start', '<=', $endDate)
@@ -144,13 +115,12 @@ class SubCountProvider implements CalendarEventProvider
                 foreach ($kw as $w) $q->orWhere('school_name', 'like', "%{$w}%");
             })
             ->get()
-            ->filter(fn($ln) => $isSubName($ln->school_name)) // 最終ガード
+            ->filter(fn($ln) => $isSubName($ln->school_name))
             ->values();
 
         $scheduleIds = $lines->pluck('schedule_id')->unique()->all();
-        $assignments = empty($scheduleIds)
-            ? collect()
-            : DB::table('user_schedule_assignments')
+        $assignments = empty($scheduleIds) ? collect() :
+            DB::table('user_schedule_assignments')
             ->select('user_id', 'schedule_id', 'start_date', 'end_date')
             ->whereIn('schedule_id', $scheduleIds)
             ->whereDate('start_date', '<=', $endDate)
@@ -168,8 +138,12 @@ class SubCountProvider implements CalendarEventProvider
             ];
         }
 
-        $dbDowOf = fn(Carbon $d): int => $d->dayOfWeek; // 0=Sun..6=Sat 前提
-        $lineCountByDate = [];
+        $dbDowOf = fn(Carbon $d): int => $d->dayOfWeek; // 0..6 (Sun..Sat)
+        $lineUsersCounted = []; // [date][user_id]=true
+        $lineUsersAbsent  = []; // [date][user_id]=true
+
+        $rangeS = $start->copy()->startOfDay();
+        $rangeE = $end->copy()->startOfDay(); // 排他
 
         foreach ($lines as $ln) {
             $effS = Carbon::parse($ln->effective_start)->startOfDay();
@@ -182,65 +156,98 @@ class SubCountProvider implements CalendarEventProvider
 
             $as = $assignBySchedule[$ln->schedule_id] ?? [];
 
-            $cur = $segS->copy();
-            while ($cur < $segE) {
-                if ($dbDowOf($cur) === (int)$ln->dow) {
-                    $d = $cur->toDateString();
+            for ($cur=$segS->copy(); $cur < $segE; $cur->addDay()) {
+                if ($dbDowOf($cur) !== (int)$ln->dow) continue;
+                $d = $cur->toDateString();
 
-                    // 1) 当日有効な割当ユーザー集合
-                    $users = [];
-                    foreach ($as as $rec) {
-                        if ($rec['start_date'] <= $d && (is_null($rec['end_date']) || $rec['end_date'] >= $d)) {
-                            $users[$rec['user_id']] = true;
-                        }
-                    }
-
-                    // 2) 同日同 line のイベント化ユーザーを控除
-                    if (!empty($eventUsersByDateLine[$d][$ln->id])) {
-                        foreach (array_keys($eventUsersByDateLine[$d][$ln->id]) as $uid) {
-                            unset($users[$uid]);
-                        }
-                    }
-
-                    // 3) 欠席(全休)ユーザーを控除
-                    if (!empty($leaveUsersByDate[$d])) {
-                        foreach (array_keys($leaveUsersByDate[$d]) as $uid) {
-                            unset($users[$uid]);
-                        }
-                    }
-
-                    $n = count($users);
-                    if ($n > 0) {
-                        $lineCountByDate[$d] = ($lineCountByDate[$d] ?? 0) + $n;
+                // 当日有効な割当ユーザー set
+                $users = [];
+                foreach ($as as $rec) {
+                    if ($rec['start_date'] <= $d && (is_null($rec['end_date']) || $rec['end_date'] >= $d)) {
+                        $users[$rec['user_id']] = true;
                     }
                 }
-                $cur->addDay();
+                // 同日同 line でイベント化 → 控除
+                if (!empty($eventUsersByDateLine[$d][$ln->id])) {
+                    foreach (array_keys($eventUsersByDateLine[$d][$ln->id]) as $uid) {
+                        unset($users[$uid]);
+                    }
+                }
+
+                // 欠席者とそれ以外に分ける
+                foreach (array_keys($users) as $uid) {
+                    if (!empty($leaveUsersByDate[$d][$uid])) {
+                        $lineUsersAbsent[$d][$uid] = true;
+                    } else {
+                        $lineUsersCounted[$d][$uid] = true;
+                    }
+                }
             }
         }
 
-        // === (D) 出力（CandidateEvent[]） ================================
-        $out = [];
-        $cur = $rangeS->copy();
-        while ($cur < $rangeE) {
-            $d = $cur->toDateString();
-            $total =
-                ($lineCountByDate[$d]  ?? 0) +  // line × 当日割当人数（イベント化/欠席控除後）
-                ($adjCounts[$d]        ?? 0) +  // RWD 人数（欠席控除後）
-                ($eventCountByDate[$d] ?? 0);   // イベント人数（欠席控除済）
+        // === (D) ユーザー名解決（まとめて 1 クエリ） ===
+        $allIds = [];
+        $collect = function (&$arr) use (&$allIds) {
+            foreach ($arr as $d => $set) foreach (array_keys($set) as $uid) $allIds[$uid] = true;
+        };
+        $collect($eventUsersCounted); $collect($eventUsersAbsent);
+        $collect($rwdUsersCounted);   $collect($rwdUsersAbsent);
+        $collect($lineUsersCounted);  $collect($lineUsersAbsent);
 
-            if ($total > 0) {
-                $out[] = new CandidateEvent([
-                    'title' => 'Sub ' . $total,
-                    'start' => $d,
-                    'allDay' => true,
-                    'classNames' => ['ev-subcount'],
-                    'extendedProps' => [
-                        'category' => 'subcount',
-                        'count'    => $total,
+        $nameById = empty($allIds) ? [] :
+            DB::table('users')->whereIn('id', array_keys($allIds))->pluck('name', 'id')->map(fn($n) => (string)$n)->toArray();
+
+        // === (E) 出力：明細を extendedProps に格納 ===
+        $out = [];
+        for ($d=$rangeS->copy(); $d < $rangeE; $d->addDay()) {
+            $day = $d->toDateString();
+
+            $count_event = isset($eventUsersCounted[$day]) ? count($eventUsersCounted[$day]) : 0;
+            $count_line  = isset($lineUsersCounted[$day])  ? count($lineUsersCounted[$day])  : 0;
+            $count_rwd   = isset($rwdUsersCounted[$day])   ? count($rwdUsersCounted[$day])   : 0;
+
+            $total = $count_event + $count_line + $count_rwd;
+            if ($total <= 0) continue;
+
+            $makeList = function ($set) use ($nameById) {
+                $arr = [];
+                foreach (array_keys($set ?? []) as $uid) {
+                    $arr[] = ['id' => (int)$uid, 'name' => $nameById[$uid] ?? ('#'.$uid)];
+                }
+                // 名前で安定ソート
+                usort($arr, fn($a,$b)=>strcmp($a['name'],$b['name']));
+                return $arr;
+            };
+
+            $users = [
+                'event'        => $makeList($eventUsersCounted[$day] ?? []),
+                'line'         => $makeList($lineUsersCounted[$day]  ?? []),
+                'work_instead' => $makeList($rwdUsersCounted[$day]   ?? []),
+            ];
+            $absent_users = [
+                'event'        => $makeList($eventUsersAbsent[$day] ?? []),
+                'line'         => $makeList($lineUsersAbsent[$day]  ?? []),
+                'work_instead' => $makeList($rwdUsersAbsent[$day]   ?? []),
+            ];
+
+            $out[] = new CandidateEvent([
+                'title' => 'Sub ' . $total,
+                'start' => $day,
+                'allDay' => true,
+                'classNames' => ['ev-subcount'],
+                'extendedProps' => [
+                    'category' => 'subcount',
+                    'count' => $total,
+                    'count_breakdown' => [
+                        'event' => $count_event,
+                        'line' => $count_line,
+                        'work_instead' => $count_rwd,
                     ],
-                ]);
-            }
-            $cur->addDay();
+                    // 明細
+                    'users' => $users,                 // 各カテゴリの“カウント対象”ユーザー
+                    'absent_users' => $absent_users,   // 各カテゴリの“欠席で除外された”ユーザー
+                ],
+            ]);
         }
 
         return $out;

--- a/config/calendar_forecast.php
+++ b/config/calendar_forecast.php
@@ -8,6 +8,7 @@ return [
         // REGULAR PLAN
         App\Services\Calendar\Providers\HolidayProvider::class    => ['level' => 1, 'type' => EventType::BACKGROUND, 'plan' => PlanGroup::REGULAR_PLAN],
         App\Services\Calendar\Providers\ClosureProvider::class    => ['level' => 4, 'type' => EventType::BACKGROUND, 'plan' => PlanGroup::REGULAR_PLAN],
+        App\Services\Calendar\Providers\SubCountProvider::class   => ['level' => 5, 'type' => EventType::BACKGROUND, 'plan' => PlanGroup::REGULAR_PLAN],
     ],
 
     'rules' => [
@@ -16,4 +17,9 @@ return [
         'on_adds_to_background'         => true,
         'holiday_untouchable'           => true,
     ],
+];
+
+return [
+    // 「Sub」を示す school_name の含意キーワード（適宜追加/変更可）
+    'sub_keywords' => ['sub', 'SUB', 'Sub'],
 ];

--- a/public/css/forecast-custom.css
+++ b/public/css/forecast-custom.css
@@ -1,0 +1,154 @@
+/* 今日の日付背景 */
+.fc-day-today {
+  outline-offset: -2px;
+  animation: today-glow-inset 2s infinite;
+}
+
+@keyframes today-glow-inset {
+  20% {
+    box-shadow: inset 0 0 3px 2px rgba(255, 128, 128, 0.5);
+  }
+
+  50% {
+    box-shadow: inset 0 0 15px 6px rgba(255, 180, 180, 0.53);
+  }
+
+  100% {
+    box-shadow: inset 0 0 3px 2px rgba(254, 255, 180, 0.53);
+  }
+}
+
+/* (適用中)祝日背景 */
+.fc-holiday {
+  background-color: rgba(255, 122, 122, 0.54) !important;
+  border: 1px solid rgba(255, 255, 255, 1) !important;
+}
+
+/* 上記"!important"を外すと下記が適用される */
+.fc-holiday {
+  animation: rainbow-bg 3s linear infinite;
+}
+
+@keyframes rainbow-bg {
+  0% {
+    background-color: #ffaaaa;
+  }
+
+  20% {
+    background-color: #ffd700;
+  }
+
+  40% {
+    background-color: #aaffaa;
+  }
+
+  60% {
+    background-color: #aaaaff;
+  }
+
+  80% {
+    background-color: #ffaaff;
+  }
+
+  100% {
+    background-color: #ffaaaa;
+  }
+}
+
+/* 背景イベントでもクリック/hover可能にする(Sub) */
+.fc .fc-bg-event {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+/* ユーザー休日: 法定休（背景青・区別しやすい色） */
+.fc-off-statutory {
+  background-color: rgba(107, 107, 107, 0.47) !important;
+  border: 1px solid rgba(255, 255, 255, 1) !important;
+}
+
+/* ユーザー休日: 所定休（背景薄青・区別しやすい色） */
+.fc-off-prescribed {
+  background-color: rgba(173, 173, 173, 0.51) !important;
+  border: 1px solid rgba(255, 255, 255, 1) !important;
+}
+
+/* 会社休業日 */
+.fc-company-break {
+  background-color: rgba(173, 173, 173, 0.51) !important;
+  border: 1px solid rgba(255, 255, 255, 1) !important;
+  font-weight: 600;
+}
+
+/* RWD（黄色）/ ORDは所定休と同じ色=fc-off-prescribed を使用 */
+.fc-rwd {
+  background-color: rgba(230, 226, 0, 0.5) !important;
+  border: 1px solid rgba(105, 107, 0, 0.45) !important;
+  font-weight: 600;
+}
+
+/* Regular shift (level5) */
+.fc-regular-shift {
+  background-color: rgba(0, 255, 13, 0.5) !important;
+  border: 1px solid rgba(25, 135, 84, .35) !important;
+}
+
+.fc-regular-shift-sub {
+  background-color: rgba(230, 226, 0, 0.5) !important;
+  border: 1px solid rgba(105, 107, 0, 0.45) !important;
+  font-weight: 600;
+}
+
+/* （未使用）Overtime shift  */
+.fc-overtime {
+  background-color: rgba(25, 135, 84, .12) !important;
+  border: 1px solid rgba(25, 135, 84, .35)
+}
+
+/* カレンダー高さ調整 */
+#calendar {
+  max-width: auto;
+  margin: 30 auto;
+}
+
+/* カレンダーセル内余白を-1にする */
+.fc .fc-daygrid-day-frame {
+  padding: -1px;
+}
+
+/* カレンダー曜日ヘッダーの下線を消す、色を黒く、文字を小さく */
+.fc-col-header-cell-cushion {
+  text-decoration: none !important;
+  color: #222 !important;
+  font-size: 0.95em !important;
+}
+
+/* カレンダー日付（数字）の色を黒く、文字を小さく、underline消す */
+.fc-daygrid-day-number {
+  margin-top: -2px !important;
+  color: #222 !important;
+  font-size: 0.90em !important;
+  text-decoration: none !important;
+}
+
+/* イベント全体（枠） */
+.fc-daygrid-event {
+  margin-top: -2px;
+  /* イベントの上部余白（セル内の日付数字との間隔）[-2] */
+  white-space: nowrap;
+  /* イベントテキストの折り返しを禁止（1行表示）[pre-line] */
+  overflow: hidden;
+  /* 内容が枠を超えた場合は非表示にする [pre-line, scroll]*/
+  text-overflow: ellipsis;
+  /* 枠を超えた場合「...」で省略表示する [clip] */
+  font-size: 0.90em;
+  /* イベント文字サイズ（基準の90%で少し小さめ） */
+  padding: 0px 0px;
+  /* イベント枠内の上下左右余白を0pxにする */
+  border-radius: 6px;
+  /* イベント枠の角丸指定（6px） */
+  box-sizing: border-box;
+  /* パディング・ボーダーを含めて幅・高さを計算 */
+  max-width: 95%;
+  /* イベント枠の最大幅（セル幅の95%まで） */
+}

--- a/public/js/forecast.js
+++ b/public/js/forecast.js
@@ -1,6 +1,51 @@
-// public/js/forecast.js
 document.addEventListener('DOMContentLoaded', function () {
     const calendarEl = document.getElementById('calendar');
+    console.log('[forecast.js] loaded');
+    function openSubModal(ev) {
+        console.log('[forecast.js] openSubModal', ev.extendedProps); // ← 追加
+        // ...（モーダル生成はそのまま）
+    }
+
+    // ---- Sub 明細モーダル ----
+    function openSubModal(ev) {
+        const p = ev.extendedProps || {};
+        const bd = p.count_breakdown || {};
+        const users = p.users || {};
+        const absent = p.absent_users || {};
+
+        const pill = (name) => `<span class="badge text-bg-secondary me-1 mb-1">${name}</span>`;
+        const group = (title, list) => {
+            const body = (list || []).length ? list.map(u => pill(u.name)).join('') : '<span class="text-muted">—</span>';
+            return `<div class="mb-2">
+      <div class="fw-semibold small text-uppercase text-muted">${title}</div>
+      <div>${body}</div>
+    </div>`;
+        };
+
+        let html = `<div class="mb-2"><strong>${ev.title}</strong></div>`;
+        html += `<div class="mb-2 small text-muted">
+    Event:${bd.event ?? 0} / Line:${bd.line ?? 0} / WorkInstead:${bd.work_instead ?? 0}
+  </div>`;
+        html += `<h6 class="mt-3">サブ（対象者）</h6>`;
+        html += group('イベント由来', users.event);
+        html += group('スケジュール由来', users.line);
+        html += group('Work Instead', users.work_instead);
+        html += `<h6 class="mt-3">欠席サブ（除外）</h6>`;
+        html += group('イベント由来', absent.event);
+        html += group('スケジュール由来', absent.line);
+        html += group('Work Instead', absent.work_instead);
+
+        document.getElementById('eventModalBody').innerHTML = html;
+
+        const modalEl = document.getElementById('eventModal');
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl); // ← 再利用
+        modal.show();
+    }
+
+    // これで十分（背景イベントでも eventClick が飛びます）
+    function isSubEvt(ev) {
+        return ev?.extendedProps?.category === 'subcount' || !!ev?.extendedProps?.users;
+    }
     const calendar = new FullCalendar.Calendar(calendarEl, {
         locale: 'ja',
         initialView: 'dayGridMonth',
@@ -11,11 +56,7 @@ document.addEventListener('DOMContentLoaded', function () {
         slotMinTime: '09:00:00',
         slotMaxTime: '23:00:00',
         eventOrder: "extendedProps.category,title,start",
-        headerToolbar: {
-            left: 'prev,next today',
-            center: 'title',
-            right: 'dayGridMonth,timeGridWeek,listWeek'
-        },
+        headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,listWeek' },
         buttonText: { today: '今日', month: '月', week: '週', day: '日', list: 'リスト' },
         dayMaxEventRows: true,
         navLinks: true,
@@ -33,14 +74,33 @@ document.addEventListener('DOMContentLoaded', function () {
         },
 
         eventContent(arg) {
-            // 背景イベント中心なのでタイトルをシンプルに
             return { html: arg.event.title };
         },
 
+        // 背景イベントは eventClick が発火しないことがあるため DOM に直接 click を bind
+        eventDidMount(info) {
+            if (isSubEvt(info.event)) {
+                info.el.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    console.log('[forecast.js] bg click', info.event.title); // ← 追加
+                    openSubModal(info.event);
+                });
+            }
+        },
+
+        // ★ eventDidMount での click 付与は削除 or 無効化（二重起動防止）
+        // eventDidMount(info) { /* なし */ }
         eventClick(info) {
-            info.jsEvent.preventDefault();
-            const e = info.event;
-            const p = e.extendedProps || {};
+            const ev = info.event;
+            if (isSubEvt(ev)) {
+                info.jsEvent?.preventDefault();
+                info.jsEvent?.stopPropagation();
+                openSubModal(ev);
+                return;
+            }
+
+            // 既存の汎用表示（祝日・会社休暇）
+            const e = info.event, p = e.extendedProps || {};
             let html = `<div class="mb-2"><strong>${e.title}</strong></div>`;
             html += `<div>種別：${p.kind ?? '—'}</div>`;
             if (p.closure_code) html += `<div>区分：${p.closure_code}</div>`;

--- a/resources/views/calendar/forecast.blade.php
+++ b/resources/views/calendar/forecast.blade.php
@@ -25,13 +25,13 @@
 
 @push('styles')
 <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.css" rel="stylesheet">
-<link href="{{ asset('css/fullcalendar-custom.css') }}" rel="stylesheet">
+<link href="{{ asset('css/forecast-custom.css') }}" rel="stylesheet">
 @endpush
 
 @push('scripts')
-<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js"></script>
-<script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js"></script>
+  <script>
     window.calendarEventsUrl = "{{ route('calendar.forecast.events') }}";
-</script>
-<script src="{{ asset('js/forecast.js') }}"></script>
+  </script>
+  <script src="{{ asset('js/forecast.js') }}?v={{ filemtime(public_path('js/forecast.js')) }}"></script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,7 +48,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/calendar/{user}', [CalendarController::class, 'index'])->middleware('role:admin|super_admin')->name('calendar.index.user');
 });
 
-// routes/web.php
+// Forecast関連
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/forecast', [CalendarController::class, 'forecast'])
         ->name('calendar.forecast');


### PR DESCRIPTION
## [各日のSub数を3つのソースからカウント（欠席サブは除く）] (https://github.com/Jin6hara/LaravelSprout/commit/d126a5ede70eb5c1e89d8bdf5c4b2afe0f713f73)
- CalenderResolverは使用していない。
一か月分の7種の値の取得と整理を140名の講師に行い、そこからカウントするのは不効率の為。
- サブシフトを定義するテーブルを定義し、遡ってユーザーを取得。取得されたユーザーが欠席の場合、合計には含まれない。

## [Subの詳細を表示するように実装] (https://github.com/Jin6hara/LaravelSprout/commit/1730a053599a36f60ee568dd7814801ca58c2e4f)
- サブはどのソースからカウントされており、誰が欠席かを表示するように設定。