### PR TITLE
Userモデルへリレーション追加、expenseテーブルのカラム調整

### DIFF
--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -43,10 +43,6 @@ class Expense extends Model
         return $this->belongsTo(ExpenseReport::class, 'expense_report_id');
     }
 
-    public function user()
-    {
-        return $this->belongsTo(User::class);
-    }
 
     public function commuterPass()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -106,7 +106,7 @@ class User extends Authenticatable
         $map = [
             'general'      => '一般',
             'admin'        => '管理者',
-            'super_admin'  => 'スーパー管理者', 
+            'super_admin'  => 'スーパー管理者',
         ];
 
         return $map[$role] ?? $role; // 未定義ロールは英字のまま表示
@@ -205,5 +205,30 @@ class User extends Authenticatable
     {
         $state = $this->employment_state; // 上のアクセサで取得
         return $state === 'active';
+    }
+
+    public function expenseReports()
+    {
+        return $this->hasMany(ExpenseReport::class);
+    }
+
+    public function commuterPasses()
+    {
+        return $this->hasMany(CommuterPass::class);
+    }
+
+    /**
+     * ユーザーに紐づく全Expense（ExpenseReport 経由）
+     */
+    public function expenses()
+    {
+        return $this->hasManyThrough(
+            Expense::class,         // 目標
+            ExpenseReport::class,   // 中間
+            'user_id',              // ExpenseReport 側のFK（users.id を指す）
+            'expense_report_id',    // Expense 側のFK（expense_reports.id を指す）
+            'id',                   // User ローカルキー
+            'id'                    // ExpenseReport ローカルキー
+        );
     }
 }

--- a/database/migrations/2025_09_17_144321_create_commuting_expenses_table.php
+++ b/database/migrations/2025_09_17_144321_create_commuting_expenses_table.php
@@ -63,7 +63,6 @@ return new class extends Migration
         Schema::create('expenses', function (Blueprint $t) {
             $t->id();
 
-            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
             $t->foreignId('expense_report_id')
                 ->constrained('expense_reports')
                 ->cascadeOnDelete();


### PR DESCRIPTION
## [Userモデルへリレーション追加、expenseテーブルのカラム調整] (https://github.com/Jin6hara/LaravelSprout/commit/c7ea8f64cd2800d60541338864b36a170c2d946e)
- expenses_tableのuser_idカラムいらないので削除。
- Userモデルへリレーション定義の追加
- ExpenseからUserへのリレーション削除