### PR TITLE
! 氏名コード桁数と名前の構造を変更

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,7 +21,9 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
+        'family_name',
+        'first_middle_name',
+        'name_in_kana',
         'email',
         'employee_code',
         'password',
@@ -62,6 +64,19 @@ class User extends Authenticatable
      * @see https://spatie.be/docs/laravel-permission/v5/basic-usage/guards-and-multi-auth#guard_name
      */
     protected string $guard_name = 'web';
+
+    // family_name, first_middle_name のどちらかが更新されたら name は自動更新する
+    public function setFamilyNameAttribute($value)
+    {
+        $this->attributes['family_name'] = $value;
+        $this->attributes['name'] = trim($value . ' ' . ($this->first_middle_name ?? ''));
+    }
+
+    public function setFirstMiddleNameAttribute($value)
+    {
+        $this->attributes['first_middle_name'] = $value;
+        $this->attributes['name'] = trim(($this->family_name ?? '') . ' ' . $value);
+    }
 
     public function getRouteKeyName()
     {

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -13,7 +13,10 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('family_name');
+            $table->string('first_middle_name')->nullable();
+            $table->string('name_in_kana')->nullable();
+            $table->string('name'); // ←既存互換用、結合した値を保持
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
@@ -24,7 +27,7 @@ return new class extends Migration
             $table->text('self_introduction')->nullable();
             $table->softDeletes();
             // 交通費精算に関連する最低限の情報
-            $table->string('employee_code', 5)->unique();// 社員コード
+            $table->string('employee_code', 6)->unique(); // 社員コード
             $table->string('address')->nullable(); // 自宅など出発地の参考に
             $table->string('phone_number')->nullable(); // 緊急連絡や照会用
         });

--- a/database/seeders/EmploymentTermsSeeder.php
+++ b/database/seeders/EmploymentTermsSeeder.php
@@ -11,7 +11,7 @@ class EmploymentTermsSeeder extends Seeder
     public function run(): void
     {
         for ($i = 1; $i <= 19; $i++) {
-            $user = User::where('employee_code', str_pad($i, 5, '0', STR_PAD_LEFT))->first();
+            $user = User::where('employee_code', str_pad($i, 6, '0', STR_PAD_LEFT))->first();
             if (!$user) continue;
 
             if ($i >= 1 && $i <= 13) {

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -31,7 +31,8 @@ class UsersSeeder extends Seeder
             $timestamp = now()->addMinutes(10 * $i);
 
             User::create([
-                'name' => "{$i}hara",
+                'family_name' => "{$i}hara",
+                'first_middle_name' => "Jim",
                 'email' => "job{$i}hara@gmail.com",
                 'password' => Hash::make('laravel'),
                 'created_at' => $timestamp,
@@ -40,7 +41,7 @@ class UsersSeeder extends Seeder
                 'profile_picture' => null,
                 'self_introduction' => "私の名前は{$i}haraです。",
                 // 🔽 追加項目
-                'employee_code' => str_pad($i, 5, '0', STR_PAD_LEFT), // 00001〜、5桁
+                'employee_code' => str_pad($i, 6, '0', STR_PAD_LEFT), // 000001〜、6桁
                 'address' => "大阪府大阪市テスト区ララベル{$i}丁目",
                 'phone_number' => str_pad("0901234" . $i, 11, '0', STR_PAD_RIGHT)//11桁
             ]);


### PR DESCRIPTION
## [氏名コード桁数と名前の構造を変更] (https://github.com/Jin6hara/LaravelSprout/commit/e6ccc29171ab5545ea1475d6dfe451ee9d3e1adf)
- nameはfamily_nameとfirst_mid_nameにより自動入力される。
- 氏名コードを5桁から6桁に変更

## 将来やること
- 雇用形態により、非常勤講師のORDとLRDを完璧に予定表に反映させる。それにより、OTはLRD優先とできる。
- 住所と自己紹介はいらない、必要なのはRoute Declarationを簡単にし、且つ交通費精算時に素早く価格を表示させる仕組み（後日）検討。