### PR TITLE
交通費提出後、編集ボタン非表示、ロジック処理も凍結

### DIFF
--- a/app/Http/Controllers/ExpenseApiController.php
+++ b/app/Http/Controllers/ExpenseApiController.php
@@ -12,6 +12,20 @@ use App\Enums\ExpenseReportStatus;
 
 class ExpenseApiController extends Controller
 {
+    // 共有: ロック検査
+    private function abortIfLocked(ExpenseReport $report)
+    {
+        // 提出以降はロック（必要に応じてapproved/paidも）
+        $lockedStatuses = [
+            ExpenseReportStatus::SUBMITTED->value,
+            ExpenseReportStatus::APPROVED->value,
+            ExpenseReportStatus::PAID->value,
+        ];
+        if (in_array($report->status, $lockedStatuses, true)) {
+            abort(423, 'This expense report is locked (submitted).');
+        }
+    }
+
     // 追加
     public function store(Request $req)
     {
@@ -34,6 +48,8 @@ class ExpenseApiController extends Controller
         if (method_exists($req->user(), 'isAdmin') && !$req->user()->isAdmin()) {
             abort_unless($req->user()->id === $report->user_id, 403);
         }
+
+        $this->abortIfLocked($report); 
 
         // 月内チェック
         $d = Carbon::parse($data['expense_date']);
@@ -69,6 +85,7 @@ class ExpenseApiController extends Controller
         if (method_exists($req->user(), 'isAdmin') && !$req->user()->isAdmin()) {
             abort_unless($req->user()->id === $report->user_id, 403);
         }
+        $this->abortIfLocked($report); 
 
         $data = $req->validate([
             'station_from'      => ['nullable', 'string', 'max:255'],
@@ -99,12 +116,13 @@ class ExpenseApiController extends Controller
         if (method_exists($req->user(), 'isAdmin') && !$req->user()->isAdmin()) {
             abort_unless($req->user()->id === $report->user_id, 403);
         }
+        $this->abortIfLocked($report); 
 
         $expense->delete();
         return response()->json(['ok' => true]);
     }
 
-        public function submitReport(ExpenseReport $report, Request $request)
+    public function submitReport(ExpenseReport $report, Request $request)
     {
         // 認可：本人 or 管理者（運用に合わせて）
         if (method_exists($request->user(), 'isAdmin')) {

--- a/resources/views/expenses/edit.blade.php
+++ b/resources/views/expenses/edit.blade.php
@@ -99,6 +99,8 @@
       <div class="total">合計: <strong id="sumCost">{{ number_format($report->total_amount) }}</strong> 円</div>
     </div>
     <div class="mt-2 d-flex align-items-center gap-2">
+      @if($report->status === \App\Enums\ExpenseReportStatus::DRAFT)
+      {{-- 下のスクリプトで利用 --}}
       <input type="date" id="pickDate" class="form-control form-control-sm" style="width: 160px;">
       <button id="addByDateBtn" class="btn btn-success btn-sm">＋指定日を追加</button>
       <button id="saveBtn" class="btn btn-primary btn-sm">保存</button>
@@ -106,6 +108,7 @@
       <div class="ms-auto"></div>
       {{-- ★ 追加：提出ボタン --}}
       <button id="submitBtn" class="btn btn-warning btn-sm">提出</button>
+      @endif
     </div>
     @else
     <div class="p-2">
@@ -197,6 +200,7 @@ document.addEventListener('DOMContentLoaded', function () {
   document.addEventListener('DOMContentLoaded', function() {
     const eventOnMap = @json($eventOnMap ?? []);
     const initialRows = @json($rows);
+    const isLocked = @json(($report->submitted_at ?? null) !== null); // ★追加
     const reportId = @json($report->id ?? null);
     const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
 
@@ -306,6 +310,8 @@ document.addEventListener('DOMContentLoaded', function () {
           delBtn.textContent = 'ー';
           wrap.appendChild(addBtn);
           wrap.appendChild(delBtn);
+
+          if (isLocked) { addBtn.disabled = true; delBtn.disabled = true; return wrap; } // ★追加
 
           addBtn.addEventListener('click', async () => {
             const base = p.data;


### PR DESCRIPTION
## [交通費提出後、編集ボタン非表示、ロジック処理も凍結]　(https://github.com/Jin6hara/LaravelSprout/commit/e17f1c99071f6e60b0a14e1b94e935fc00d396b2)
１．UIの面でボタンをなくす。ボタンのロジックも凍結。
２．フロント側の行の"+"と"-"は直接データベース叩くため、凍結。

- 提出後の編集が必要の際はsubmitted_atをNullにする。statusで判断しようと思ったが、submitted_atはより良い参考情報の為、それで管理することにした。

## NG点
※ グリッドの入力ができてしまう。