### PR TITLE
[続く...] 欠席管理：カレンダー、編集

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-namespace App\Http\Controllers;
-
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use App\Models\User;
@@ -67,6 +65,26 @@ class CalendarController extends Controller
     public function forecastEvents(
         \Illuminate\Http\Request $request,
         \App\Services\Calendar\ForecastResolver $resolver
+    ) {
+        $user  = auth()->user(); // 祝日/会社休みはユーザーに依存しないが、将来の拡張のため合わせておく
+        $start = \Carbon\Carbon::parse($request->query('start'));
+        $end   = \Carbon\Carbon::parse($request->query('end'));
+
+        $events = $resolver->build($user, $start, $end);
+        return response()->json($events);
+    }
+
+    public function leave()
+    {
+        // index.blade.php と同じレイアウト・構成を流用
+        // 役割バッジなどもそのままでOK
+        $viewUser = auth()->user();
+        return view('calendar.leave', compact('viewUser'));
+    }
+
+    public function leaveEvents(
+        \Illuminate\Http\Request $request,
+        \App\Services\Calendar\LeaveResolver $resolver
     ) {
         $user  = auth()->user(); // 祝日/会社休みはユーザーに依存しないが、将来の拡張のため合わせておく
         $start = \Carbon\Carbon::parse($request->query('start'));

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -294,6 +294,10 @@ class EventAssignController extends Controller
         $okCount = collect($results)->where('ok', true)->count();
         $ngCount = count($results) - $okCount;
 
+        // ✅ JSON返却でもフラッシュを仕込む
+        $flash = $ngCount ? "一部保存に失敗しました（保存: {$okCount} / 失敗: {$ngCount}）" : "すべて保存しました（{$okCount} 件）";
+        session()->flash('status', $flash);
+
         return response()->json([
             'ok'      => $ngCount === 0,
             'updated' => $okCount,

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -4,7 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreLeaveRequest;
 use App\Models\Leave;
+use App\Models\User;
 use App\Services\LeaveBalanceService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class LeaveController extends Controller
@@ -58,5 +61,78 @@ class LeaveController extends Controller
         });
 
         return back()->with('success', '申請を取り消しました。');
+    }
+
+    /**
+     * 欠席報告画面
+     * - 一般ユーザー：自分のみ
+     * - 管理者(admin|super_admin)：誰のページでも閲覧可能（そのユーザーのデータのみ表示）
+     */
+    public function absence(Request $request, User $user)
+    {
+        $viewer = Auth::user();
+        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
+        if (!$isAdmin && $viewer->id !== $user->id) {
+            abort(403);
+        }
+
+        // そのユーザーの leave をすべて表示（必要なら期間フィルタを追加）
+        $leaves = Leave::query()
+            ->where('user_id', $user->id)
+            ->whereIn('kind', ['absence', 'absense_to_paid', 'other'])
+            ->orderByDesc('start_date')
+            ->get();
+
+        // 表示名マッピング（ご指定）
+        $kindLabels = [
+            'absence'          => 'Unpaid Leave',
+            'absense_to_paid'  => 'ALP',     // ※ご指定のスペルに合わせています
+            'other'            => 'Others',
+        ];
+
+        // Handle Type はセレクト式（必要に応じて差し替え）
+        $handleTypeOptions = [
+            'self_cover' => 'Self Cover',
+            'makeup'     => 'Make-up Lesson',
+            'refund'     => 'Refund',
+            'other'      => 'Other',
+        ];
+
+        return view('calendar.absenceReport', compact('user', 'leaves', 'kindLabels', 'handleTypeOptions'));
+    }
+
+    /**
+     * 欠席の自己報告（Reason + Handle Type）
+     * - 対象：kind=absence かつ reason/handle_type が両方 null のもの
+     * - 送信後は編集不可（＝両方値が入ったらSubmittedとみなす）
+     */
+    public function report(Request $request, Leave $leave)
+    {
+        $viewer = Auth::user();
+        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
+        if (!$isAdmin && $viewer->id !== $leave->user_id) {
+            abort(403);
+        }
+
+        // ルール：kind=absence、かつ 両方null のときのみ提出可
+        if ($leave->kind !== 'absence') {
+            return back()->with('error', 'This leave is not target for absence self-report.');
+        }
+        if (!is_null($leave->reason) || !is_null($leave->handle_type)) {
+            return back()->with('error', 'Already submitted.');
+        }
+
+        // バリデーション
+        $validated = $request->validate([
+            'reason'       => ['required', 'string', 'max:1000'],
+            'handle_type'  => ['required', 'in:self_cover,makeup,refund,other'],
+        ]);
+
+        // 保存（両方が埋まったら Submitted として扱う）
+        $leave->reason = $validated['reason'];
+        $leave->handle_type = $validated['handle_type'];
+        $leave->save();
+
+        return back()->with('success', 'Submitted.');
     }
 }

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Leave;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Carbon\Carbon;
+use Illuminate\Validation\Rule;
+
+
+class LeaveManageController extends Controller
+{
+    /**
+     * Leaveの月次一覧（管理者用）
+     * - 月/ユーザーで絞り込み
+     * - イベントカード風スタイルで各行を編集UI化
+     */
+    public function edit(Request $request)
+    {
+        $viewer = Auth::user();
+        if (!$viewer->hasRole(['admin', 'super_admin'])) {
+            abort(403);
+        }
+
+        // クエリ: month（YYYY-MM）, user_id
+        $month = (string)($request->input('month', now()->format('Y-m')));
+        $userId = $request->integer('user_id') ?: null;
+
+        // 月→期間
+        try {
+            [$y, $m] = explode('-', $month);
+            $periodStart = Carbon::createFromDate((int)$y, (int)$m, 1)->startOfMonth();
+        } catch (\Throwable $e) {
+            $periodStart = now()->startOfMonth();
+            $month = $periodStart->format('Y-m');
+        }
+        $periodEnd = (clone $periodStart)->endOfMonth();
+
+        // ユーザー選択用
+        $userOptions = User::query()
+            ->select('id', 'first_name', 'family_name', 'employee_code')
+            ->orderBy('employee_code')
+            ->get();
+
+        // 一覧取得（start_dateが月内にかかるもの中心、end_dateも考慮）
+        $leaves = Leave::query()
+            ->when($userId, fn($q) => $q->where('user_id', $userId))
+            ->where(function ($q) use ($periodStart, $periodEnd) {
+                // 期間重なり（start<=月末 && (end>=月初 || end nullでstartが月内)）
+                $q->whereDate('start_date', '<=', $periodEnd->toDateString())
+                    ->where(function ($qq) use ($periodStart) {
+                        $qq->whereDate('end_date', '>=', $periodStart->toDateString())
+                            ->orWhereNull('end_date');
+                    });
+            })
+            ->with('user:id,first_name,family_name,employee_code')
+            ->orderBy('start_date')
+            ->orderBy('time_start')
+            ->get();
+
+        // セレクト用オプション
+        $kindOptions = [
+            'paid'            => 'ALP',
+            'absense_to_paid' => 'MT → ALP',
+            'special'         => 'Special',
+            'absence'         => 'MT',
+            'adjustment'      => 'Adjustment',
+            'left_early'      => 'Left Early',
+            'late'            => 'Late',
+            'other'           => 'Other',
+        ];
+        $excusedOptions = [
+            'excused'   => 'Excused',
+            'unexcused' => 'Unexcused',
+        ];
+        $statusOptions = [
+            'approved' => 'Approved',
+            'pending'  => 'Pending',
+            'rejected' => 'Rejected',
+            'other'    => 'Other',
+        ];
+
+        // Blade内で使う簡易フォーマッタ
+        $fmtDate = fn($v) => $v ? Carbon::parse($v)->format('Y-m-d') : '';
+        $fmtTime = fn($v) => $v ? Carbon::parse($v)->format('H:i') : '';
+
+        return view('calendar.leaveEdit', [
+            'month'          => $month,
+            'periodStart'    => $periodStart,
+            'periodEnd'      => $periodEnd,
+            'leaves'         => $leaves,
+            'userOptions'    => $userOptions,
+            'kindOptions'    => $kindOptions,
+            'excusedOptions' => $excusedOptions,
+            'statusOptions'  => $statusOptions,
+            'fmtDate'        => $fmtDate,
+            'fmtTime'        => $fmtTime,
+        ]);
+    }
+
+    /** 保存（更新） */
+    public function update(Request $request, Leave $leave)
+    {
+        // 権限（念のため。ルートにもmiddlewareあり）
+        if (!Auth::user()->hasRole(['admin', 'super_admin'])) {
+            abort(403);
+        }
+
+        $data = $this->validateLeave($request);
+
+        // ビジネスルール（時間の一貫性：片方のみ指定 → バリデーションで弾く）
+        // 追加チェック（任意）：time_start < time_end
+        if (!empty($data['time_start']) && !empty($data['time_end'])) {
+            $ts = Carbon::createFromFormat('H:i', $data['time_start']);
+            $te = Carbon::createFromFormat('H:i', $data['time_end']);
+            if ($te->lessThanOrEqualTo($ts)) {
+                return $this->respondValidationError($request, [
+                    'time_end' => ['End time must be after Start time.'],
+                ]);
+            }
+        }
+
+        $leave->fill($data);
+        $leave->save();
+
+        if ($request->wantsJson()) {
+            return response()->json([
+                'ok' => true,
+                'message' => 'Leave updated.',
+                'leave' => $leave->fresh(),
+            ]);
+        }
+
+        return back()->with('status', 'Leave updated.');
+    }
+
+    /** 削除 */
+    public function destroy(Request $request, Leave $leave)
+    {
+        if (!Auth::user()->hasRole(['admin', 'super_admin'])) {
+            abort(403);
+        }
+
+        $leave->delete();
+
+        if ($request->wantsJson()) {
+            return response()->json([
+                'ok' => true,
+                'message' => 'Leave deleted.',
+            ]);
+        }
+
+        return back()->with('status', 'Leave deleted.');
+    }
+
+    /** 共通バリデーション */
+    private function validateLeave(Request $request): array
+    {
+        $kindValues   = ['paid', 'absense_to_paid', 'special', 'absence', 'adjustment', 'left_early', 'late', 'other'];
+        $excusedValues = ['excused', 'unexcused'];
+        $statusValues = ['approved', 'pending', 'rejected', 'other'];
+
+        return $request->validate([
+            'user_id'      => ['required', 'integer', 'exists:users,id'],
+            'start_date'   => ['required', 'date'],
+            'end_date'     => ['nullable', 'date', 'after_or_equal:start_date'],
+            'reason'       => ['nullable', 'string'],
+            'kind'         => ['required', Rule::in($kindValues)],
+            'excused'      => ['required', Rule::in($excusedValues)],
+            'special_type' => ['nullable', 'string', 'max:100'],
+            'time_start'   => ['nullable', 'date_format:H:i', 'required_with:time_end'],
+            'time_end'     => ['nullable', 'date_format:H:i', 'required_with:time_start'],
+            'handle_type'  => ['nullable', 'string'],
+            'status'       => ['required', Rule::in($statusValues)],
+        ]);
+    }
+
+    /** JSON/HTML 両対応のバリデーションエラー返却 */
+    private function respondValidationError(Request $request, array $errors)
+    {
+        if ($request->wantsJson()) {
+            return response()->json([
+                'ok' => false,
+                'message' => 'Validation error.',
+                'errors' => $errors,
+            ], 422);
+        }
+        return back()->withErrors($errors)->withInput();
+    }
+}

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -17,89 +17,110 @@ class LeaveManageController extends Controller
      * - 月/ユーザーで絞り込み
      * - イベントカード風スタイルで各行を編集UI化
      */
-    public function edit(Request $request)
-    {
-        $viewer = Auth::user();
-        if (!$viewer->hasRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+public function edit(Request $request)
+{
+    // 1) ユーザー候補
+    $userOptions = User::query()
+        ->select('id', 'first_name', 'family_name', 'employee_code')
+        ->orderBy('employee_code')
+        ->limit(500)
+        ->get();
 
-        // クエリ: month（YYYY-MM）, user_id
-        $month = (string)($request->input('month', now()->format('Y-m')));
-        $userId = $request->integer('user_id') ?: null;
+    // 2) パラメータ取得
+    $userId      = $request->input('user_id');
+    $kind        = $request->input('kind');
+    $excused     = $request->input('excused');
+    $status      = $request->input('status');
+    $specialType = $request->input('special_type');
+    $handleType  = $request->input('handle_type');
+    $reason      = $request->input('reason');
 
-        // 月→期間
-        try {
-            [$y, $m] = explode('-', $month);
-            $periodStart = Carbon::createFromDate((int)$y, (int)$m, 1)->startOfMonth();
-        } catch (\Throwable $e) {
-            $periodStart = now()->startOfMonth();
-            $month = $periodStart->format('Y-m');
-        }
-        $periodEnd = (clone $periodStart)->endOfMonth();
+    $startDate   = $request->input('start_date');
+    $endDate     = $request->input('end_date');
 
-        // ユーザー選択用
-        $userOptions = User::query()
-            ->select('id', 'first_name', 'family_name', 'employee_code')
-            ->orderBy('employee_code')
-            ->get();
-
-        // 一覧取得（start_dateが月内にかかるもの中心、end_dateも考慮）
-        $leaves = Leave::query()
-            ->when($userId, fn($q) => $q->where('user_id', $userId))
-            ->where(function ($q) use ($periodStart, $periodEnd) {
-                // 期間重なり（start<=月末 && (end>=月初 || end nullでstartが月内)）
-                $q->whereDate('start_date', '<=', $periodEnd->toDateString())
-                    ->where(function ($qq) use ($periodStart) {
-                        $qq->whereDate('end_date', '>=', $periodStart->toDateString())
-                            ->orWhereNull('end_date');
-                    });
-            })
-            ->with('user:id,first_name,family_name,employee_code')
-            ->orderBy('start_date')
-            ->orderBy('time_start')
-            ->get();
-
-        // セレクト用オプション
-        $kindOptions = [
-            'paid'            => 'ALP',
-            'absense_to_paid' => 'MT → ALP',
-            'special'         => 'Special',
-            'absence'         => 'MT',
-            'adjustment'      => 'Adjustment',
-            'left_early'      => 'Left Early',
-            'late'            => 'Late',
-            'other'           => 'Other',
-        ];
-        $excusedOptions = [
-            'excused'   => 'Excused',
-            'unexcused' => 'Unexcused',
-        ];
-        $statusOptions = [
-            'approved' => 'Approved',
-            'pending'  => 'Pending',
-            'rejected' => 'Rejected',
-            'other'    => 'Other',
-        ];
-
-        // Blade内で使う簡易フォーマッタ
-        $fmtDate = fn($v) => $v ? Carbon::parse($v)->format('Y-m-d') : '';
-        $fmtTime = fn($v) => $v ? Carbon::parse($v)->format('H:i') : '';
-
-        return view('calendar.leaveEdit', [
-            'month'          => $month,
-            'periodStart'    => $periodStart,
-            'periodEnd'      => $periodEnd,
-            'leaves'         => $leaves,
-            'userOptions'    => $userOptions,
-            'kindOptions'    => $kindOptions,
-            'excusedOptions' => $excusedOptions,
-            'statusOptions'  => $statusOptions,
-            'fmtDate'        => $fmtDate,
-            'fmtTime'        => $fmtTime,
-        ]);
+    // 3) 日付ルール
+    // end のみ → エラー
+    if ($endDate && !$startDate) {
+        return back()
+            ->withErrors(['start_date' => '開始日を指定してください。'])
+            ->withInput();
     }
 
+    // start > end → エラー
+    if ($startDate && $endDate && $startDate > $endDate) {
+        return back()
+            ->withErrors(['start_date' => '開始日は終了日より前に設定してください。'])
+            ->withInput();
+    }
+
+    // 日付フォーマット関数
+    $fmtDate = fn($v) => $v ? Carbon::parse($v)->format('Y-m-d') : '';
+    $fmtTime = fn($v) => $v ? Carbon::parse($v)->format('H:i')   : '';
+
+    // 4) クエリ（Event版と同順序・構成）
+    $leaves = Leave::query()
+        ->with(['user:id,first_name,family_name,employee_code'])
+        ->when($userId,      fn($q) => $q->where('user_id', $userId))
+        ->when($kind,        fn($q) => $q->where('kind', $kind))
+        ->when($excused,     fn($q) => $q->where('excused', $excused))
+        ->when($status,      fn($q) => $q->where('status', $status))
+        ->when($specialType, fn($q) => $q->where('special_type', 'like', '%'.$specialType.'%'))
+        ->when($handleType,  fn($q) => $q->where('handle_type',  'like', '%'.$handleType.'%'))
+        ->when($reason,      fn($q) => $q->where('reason',      'like', '%'.$reason.'%'))
+        // ⬇︎ 日付フィルタ（start & end ⇒ 期間, startのみ ⇒ 当日）
+        ->when($startDate && $endDate, function ($q) use ($startDate, $endDate) {
+            $q->whereDate('start_date', '<=', $endDate)
+              ->where(function($qq) use ($startDate) {
+                  $qq->whereDate('end_date', '>=', $startDate)
+                     ->orWhereNull('end_date');
+              });
+        })
+        ->when($startDate && !$endDate, function ($q) use ($startDate) {
+            $q->whereDate('start_date', '<=', $startDate)
+              ->where(function($qq) use ($startDate) {
+                  $qq->whereDate('end_date', '>=', $startDate)
+                     ->orWhereNull('end_date');
+              });
+        })
+        ->orderByDesc('start_date')
+        ->orderBy('time_start')
+        ->orderBy('user_id')
+        ->paginate(24)
+        ->withQueryString();
+
+    // 5) オプション
+    $statusOptions = [
+        'approved' => 'Approved',
+        'pending'  => 'Pending',
+        'rejected' => 'Rejected',
+        'other'    => 'Other',
+    ];
+    $kindOptions = [
+        'paid'            => 'Paid',
+        'absense_to_paid' => 'Absence→Paid',
+        'special'         => 'Special',
+        'absence'         => 'Absence',
+        'adjustment'      => 'Adjustment',
+        'left_early'      => 'Left Early',
+        'late'            => 'Late',
+        'other'           => 'Other',
+    ];
+    $excusedOptions = [
+        'excused'   => 'Excused',
+        'unexcused' => 'Unexcused',
+    ];
+
+    // 6) 表示
+    return view('calendar.leaveEdit', compact(
+        'leaves',
+        'userOptions',
+        'statusOptions',
+        'kindOptions',
+        'excusedOptions',
+        'fmtDate',
+        'fmtTime'
+    ));
+}
     /** 保存（更新） */
     public function update(Request $request, Leave $leave)
     {

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -125,14 +125,6 @@ class LeaveManageController extends Controller
         $leave->fill($data);
         $leave->save();
 
-        if ($request->wantsJson()) {
-            return response()->json([
-                'ok' => true,
-                'message' => 'Leave updated.',
-                'leave' => $leave->fresh(),
-            ]);
-        }
-
         return back()->with('status', 'Leave updated.');
     }
 
@@ -144,13 +136,6 @@ class LeaveManageController extends Controller
         }
 
         $leave->delete();
-
-        if ($request->wantsJson()) {
-            return response()->json([
-                'ok' => true,
-                'message' => 'Leave deleted.',
-            ]);
-        }
 
         return back()->with('status', 'Leave deleted.');
     }

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -220,7 +220,7 @@ public function edit(Request $request)
             'time_start'   => null,
             'time_end'     => null,
             'handle_type'  => null,
-            'status'       => 'pending',
+            'status'       => 'approved',
         ]);
 
         return back()->with('status', "空白Leaveを {$leave->start_date->format('Y-m-d')} に追加しました。");

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -211,17 +211,16 @@ public function edit(Request $request)
 
         // デフォルト値（必要ならここを調整）
         $leave = Leave::create([
-            'user_id'     => $data['user_id'],
-            'start_date'  => $data['start_date'],
-            'end_date'    => null,
-            'reason'      => null,
-            'kind'        => 'other',        // 既定で other
-            'excused'     => 'unexcused',    // 既定で非公認
-            'special_type' => null,
-            'time_start'  => null,
-            'time_end'    => null,
-            'handle_type' => null,
-            'status'      => 'pending',      // 既定で pending（承認フローに載せるなら）
+            'user_id'      => null,
+            'start_date'   => $data['start_date'],
+            'end_date'     => null,
+            'reason'       => null,
+            'kind'         => 'special',
+            'excused'      => 'excused',
+            'time_start'   => null,
+            'time_end'     => null,
+            'handle_type'  => null,
+            'status'       => 'pending',
         ]);
 
         return back()->with('status', "空白Leaveを {$leave->start_date->format('Y-m-d')} に追加しました。");

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -174,4 +174,115 @@ class LeaveManageController extends Controller
         }
         return back()->withErrors($errors)->withInput();
     }
+
+    /** 空白Leave 追加 */
+    public function storeBlank(Request $request)
+    {
+        if (!auth()->user()->hasRole(['admin', 'super_admin'])) {
+            abort(403);
+        }
+
+        // 必須: user_id, start_date
+        $data = $request->validate([
+            'user_id'    => ['required', 'integer', 'exists:users,id'],
+            'start_date' => ['required', 'date'],
+        ]);
+
+        // デフォルト値（必要ならここを調整）
+        $leave = Leave::create([
+            'user_id'     => $data['user_id'],
+            'start_date'  => $data['start_date'],
+            'end_date'    => null,
+            'reason'      => null,
+            'kind'        => 'other',        // 既定で other
+            'excused'     => 'unexcused',    // 既定で非公認
+            'special_type' => null,
+            'time_start'  => null,
+            'time_end'    => null,
+            'handle_type' => null,
+            'status'      => 'pending',      // 既定で pending（承認フローに載せるなら）
+        ]);
+
+        return back()->with('status', "空白Leaveを {$leave->start_date->format('Y-m-d')} に追加しました。");
+    }
+
+    /** 一括更新 */
+    public function bulkUpdate(Request $request)
+    {
+        if (!auth()->user()->hasRole(['admin', 'super_admin'])) {
+            abort(403);
+        }
+
+        $items = $request->input('items', []);
+        if (!is_array($items) || empty($items)) {
+            return response()->json(['ok' => false, 'message' => '対象がありません'], 422);
+        }
+
+        // 許容値
+        $kindValues    = ['paid', 'absense_to_paid', 'special', 'absence', 'adjustment', 'left_early', 'late', 'other'];
+        $excusedValues = ['excused', 'unexcused'];
+        $statusValues  = ['approved', 'pending', 'rejected', 'other'];
+
+        // items.* で配列バリデーション
+        $validated = $request->validate([
+            'items'                          => ['required', 'array', 'min:1'],
+            'items.*.id'                     => ['required', 'integer', 'exists:leaves,id'],
+            'items.*.user_id'                => ['required', 'integer', 'exists:users,id'],
+            'items.*.start_date'             => ['required', 'date'],
+            'items.*.end_date'               => ['nullable', 'date', 'after_or_equal:items.*.start_date'],
+            'items.*.reason'                 => ['nullable', 'string'],
+            'items.*.kind'                   => ['required', Rule::in($kindValues)],
+            'items.*.excused'                => ['required', Rule::in($excusedValues)],
+            'items.*.special_type'           => ['nullable', 'string', 'max:100'],
+            'items.*.time_start'             => ['nullable', 'date_format:H:i', 'required_with:items.*.time_end'],
+            'items.*.time_end'               => ['nullable', 'date_format:H:i', 'required_with:items.*.time_start'],
+            'items.*.handle_type'            => ['nullable', 'string'],
+            'items.*.status'                 => ['required', Rule::in($statusValues)],
+        ]);
+
+        // 追加の論理チェック（start < end）
+        foreach ($validated['items'] as $it) {
+            if (!empty($it['time_start']) && !empty($it['time_end'])) {
+                $ts = Carbon::createFromFormat('H:i', $it['time_start']);
+                $te = Carbon::createFromFormat('H:i', $it['time_end']);
+                if ($te->lessThanOrEqualTo($ts)) {
+                    return response()->json([
+                        'ok' => false,
+                        'message' => "ID {$it['id']}: End time must be after Start time."
+                    ], 422);
+                }
+            }
+        }
+
+        // 一括反映
+        foreach ($validated['items'] as $it) {
+            $leave = Leave::find($it['id']);
+            $leave->fill([
+                'user_id'     => $it['user_id'],
+                'start_date'  => $it['start_date'],
+                'end_date'    => $it['end_date'] ?? null,
+                'reason'      => $it['reason'] ?? null,
+                'kind'        => $it['kind'],
+                'excused'     => $it['excused'],
+                'special_type' => $it['special_type'] ?? null,
+                'time_start'  => $it['time_start'] ?? null,
+                'time_end'    => $it['time_end'] ?? null,
+                'handle_type' => $it['handle_type'] ?? null,
+                'status'      => $it['status'],
+            ]);
+            $leave->save();
+        }
+
+        $updated = count($validated['items']);
+
+        // ✅ JSON返却でもフラッシュを仕込む
+        session()->flash('status', "一括保存しました（{$updated} 件）");
+
+        return response()->json([
+            'ok'      => true,
+            'updated' => $updated,
+            'failed'  => 0,
+            'message' => '一括保存しました。',
+        ]);
+    }
 }

--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -26,6 +26,7 @@ class Leave extends Model
         'time_end',
         'status',
         'approved_by',
+        'handle_type'
     ];
 
     protected $casts = [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,10 +11,12 @@ use App\Models\Event;
 use App\Observers\LeaveObserver;
 use App\Observers\EventObserver;
 use App\Services\Calendar\ForecastResolver;
+use App\Services\Calendar\LeaveResolver;
 use App\Services\Calendar\Providers\HolidayProvider;
 use App\Services\Calendar\Providers\ClosureProvider;
 use App\Services\Calendar\Providers\SubCountProvider;
 use App\Services\Calendar\Providers\AllEventProvider;
+use App\Services\Calendar\Providers\AllLeaveProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -49,6 +51,16 @@ class AppServiceProvider extends ServiceProvider
                 $app->make(AllEventProvider::class),
             ];
             return new ForecastResolver($providers);
+        });
+
+        $this->app->singleton(LeaveResolver::class, function ($app) {
+            // ここで「祝日」と「会社長期休み」だけに限定
+            $providers = [
+                $app->make(HolidayProvider::class),
+                $app->make(ClosureProvider::class), 
+                $app->make(AllLeaveProvider::class),
+            ];
+            return new LeaveResolver($providers);
         });
     }
 

--- a/app/Services/Calendar/LeaveResolver.php
+++ b/app/Services/Calendar/LeaveResolver.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Services\Calendar;
+
+use App\Models\User;
+use App\Services\Calendar\Contracts\CalendarEventProvider;
+use Carbon\Carbon;
+
+class LeaveResolver
+{
+    /** @var CalendarEventProvider[] */
+    private array $providers = [];
+    private array $meta;
+    private array $rules;
+
+    public function __construct(iterable $providers)
+    {
+        $this->providers = is_array($providers) ? $providers : iterator_to_array($providers);
+        $this->meta  = config('calendar_leave.providers', []);
+        $this->rules = config('calendar_leave.rules', []);
+    }
+
+    /**
+     * 背景(BACKGROUND)は日割り→日別最小levelのみ採用（祝日優先）
+     * ON(Event/Leave)は圧縮せず全件返す（背景に「足す」）
+     */
+    public function build(?User $user, Carbon $start, Carbon $end): array
+    {
+        $backgroundDaily = []; // 'YYYY-MM-DD' => ['by_level' => [level => [event,array...]]]
+        $onEvents = [];
+
+        foreach ($this->providers as $p) {
+            $cls = get_class($p);
+            $defaults = $this->meta[$cls] ?? [];
+
+            foreach ($p->provide($user, $start, $end) as $ev) {
+                if (is_array($ev)) $ev = (object)$ev;
+
+                // config を最優先に level/type/plan を決定
+                $level     = $defaults['level'] ?? ($ev->level ?? 9);
+                $type      = $defaults['type']  ?? ($ev->type ?? EventType::BACKGROUND);
+                $planGroup = $defaults['plan']  ?? ($ev->planGroup ?? PlanGroup::REGULAR_PLAN);
+
+                // FC配列化
+                $arr = method_exists($ev, 'toArray') ? $ev->toArray() : get_object_vars($ev);
+                $arr['extendedProps'] = $arr['extendedProps'] ?? [];
+                $arr['extendedProps']['level'] = $level;
+
+                // 決定値を直に埋めて後段の判定で使う
+                $arr['type']      = $type;
+                $arr['planGroup'] = $planGroup;
+
+                if ($type === EventType::BACKGROUND) {
+                    // 背景表示の補完
+                    if (!isset($arr['display'])) $arr['display'] = 'background';
+
+                    // 日割り展開（クエリ範囲にクランプ）
+                    [$S, $E] = $this->eventRange($arr, $start, $end); // endExclusive
+                    $cur = $S->copy();
+                    while ($cur < $E) {
+                        $d = $cur->toDateString();
+
+                        $dayEvent = $arr;
+                        $dayEvent['start'] = $d; // 背景は日付のみでOK
+                        unset($dayEvent['end']);
+
+                        $backgroundDaily[$d]['by_level'][$level][] = $dayEvent;
+                        $cur->addDay();
+                    }
+                    continue;
+                }
+
+                // === ON はそのまま素通し（圧縮しない）===
+                [$S, $E] = $this->eventRange($arr, $start, $end);
+                if ($E > $S) {
+                    $onEvents[] = $arr;
+                }
+            }
+        }
+
+        // --- 背景は「その日の最小 level」を採用（祝日 untouchable） ---
+        $compressedBackground = [];
+        foreach ($backgroundDaily as $d => $bucket) {
+            if (empty($bucket['by_level'])) continue;
+
+            $levels = array_keys($bucket['by_level']);
+            sort($levels);
+
+            $minLevel = ($this->rules['holiday_untouchable'] ?? true) && in_array(1, $levels, true)
+                ? 1
+                : $levels[0];
+
+            foreach ($bucket['by_level'][$minLevel] as $ev) {
+                $compressedBackground[] = $ev;
+            }
+        }
+
+        // === 最終出力 ===
+        // on_adds_to_background = true の前提で単純結合
+        $out = array_merge($onEvents, $compressedBackground);
+
+        // 並び：sort_order → start → title
+        usort($out, function ($a, $b) {
+            $ao = (int)($a['extendedProps']['sort_order'] ?? 999);
+            $bo = (int)($b['extendedProps']['sort_order'] ?? 999);
+            if ($ao !== $bo) return $ao <=> $bo;
+
+            $as = substr((string)($a['start'] ?? ''), 0, 19);
+            $bs = substr((string)($b['start'] ?? ''), 0, 19);
+            if ($as !== $bs) return strcmp($as, $bs);
+
+            return strcmp((string)($a['title'] ?? ''), (string)($b['title'] ?? ''));
+        });
+
+        return $out;
+    }
+
+    /**
+     * @return array{0:Carbon,1:Carbon} [start, endExclusive]
+     * FullCalendarの allDay 仕様や 'YYYY-MM-DD' / ISO 文字列を考慮しつつ
+     * リクエスト範囲にクランプ
+     */
+    private function eventRange(array $ev, Carbon $reqStart, Carbon $reqEnd): array
+    {
+        $s = Carbon::parse(substr((string)($ev['start'] ?? ''), 0, 10) ?: $reqStart->toDateString())->startOfDay();
+        $e = !empty($ev['end'])
+            ? Carbon::parse(substr((string)$ev['end'], 0, 10))->startOfDay()
+            : $s->copy()->addDay();
+
+        $S = $s->lessThan($reqStart) ? $reqStart->copy()->startOfDay() : $s;
+        $E = $e->greaterThan($reqEnd) ? $reqEnd->copy()->startOfDay() : $e;
+
+        if ($E <= $S) $E = $S->copy()->addDay();
+
+        return [$S, $E];
+    }
+}

--- a/app/Services/Calendar/Providers/AllLeaveProvider.php
+++ b/app/Services/Calendar/Providers/AllLeaveProvider.php
@@ -69,6 +69,28 @@ class AllLeaveProvider
                     $classes[] = "status-{$leave->status}";
                 }
 
+                /**
+                 * ★ absence だけ例外処理（枠線色を handle_type + excused で決定）
+                 *  1) handle_type = null/'' → yellow
+                 *  2) handle_type != null → excused=excused → green
+                 *  3) handle_type != null → excused=unexcused → red
+                 */
+                if ($leave->kind === 'absence') {
+                    $handled = !empty($leave->handle_type);
+
+                    if (!$handled) {
+                        // 1) 未ハンドル
+                        $classes[] = 'absence-unhandled';
+                    } else {
+                        // 2) / 3) ハンドル済み（excused / unexcused）
+                        if ($leave->excused === 'excused') {
+                            $classes[] = 'absence-handled-excused';
+                        } else { // 'unexcused' 想定
+                            $classes[] = 'absence-handled-unexcused';
+                        }
+                    }
+                }
+
 
                 $events->push([
                     'title'      => $title,

--- a/app/Services/Calendar/Providers/AllLeaveProvider.php
+++ b/app/Services/Calendar/Providers/AllLeaveProvider.php
@@ -20,7 +20,7 @@ class AllLeaveProvider
     ) {}
 
     /**
-     * 指定期間内の「全ユーザー分の承認済みLeave」を FullCalendar event[] 形式で返す
+     * 指定期間内の「全ユーザー分の Leave（全ステータス）」を FullCalendar event[] 形式で返す
      *
      * @return \Illuminate\Support\Collection<int, array>
      */
@@ -28,7 +28,7 @@ class AllLeaveProvider
     {
         // 全ユーザー分を対象にするため user_id フィルタは掛けない
         $leaves = Leave::query()
-            ->approved()
+            // ->approved()  // ← 承認済み限定を撤去（全件取得）
             ->between($start, $end)
             ->with(['user:id,name,first_name,family_name,employee_code']) // 表示用
             ->get();
@@ -91,7 +91,8 @@ class AllLeaveProvider
                             'end_date'     => $leave->end_date?->toDateString(),
                             'time_start'   => $leave->time_start,
                             'time_end'     => $leave->time_end,
-                            'status'       => $leave->status,
+                            'status'       => $leave->status, // ← 後段の検索用に保持
+                            'handle_type'  => $leave->handle_type, // 共有された新カラムも保持
                         ],
                     ],
                 ]);

--- a/app/Services/Calendar/Providers/AllLeaveProvider.php
+++ b/app/Services/Calendar/Providers/AllLeaveProvider.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services\Calendar\Providers;
+
+use App\Models\Leave;
+use App\Models\User;
+use App\Services\Calendar\EventType;
+use App\Services\Calendar\PlanGroup;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class AllLeaveProvider
+{
+    public function __construct(
+        private readonly array $meta = [
+            'level' => 1, // ベース250831FC
+            'type'  => EventType::OFF,
+            'plan'  => PlanGroup::EVENT,
+        ]
+    ) {}
+
+    /**
+     * 指定期間内の「全ユーザー分の承認済みLeave」を FullCalendar event[] 形式で返す
+     *
+     * @return \Illuminate\Support\Collection<int, array>
+     */
+    public function provide(User $viewer, Carbon $start, Carbon $end): Collection
+    {
+        // 全ユーザー分を対象にするため user_id フィルタは掛けない
+        $leaves = Leave::query()
+            ->approved()
+            ->between($start, $end)
+            ->with(['user:id,name,first_name,family_name,employee_code']) // 表示用
+            ->get();
+
+        $events = collect();
+
+        foreach ($leaves as $leave) {
+            // Leave モデル側のユーティリティを流用（LeaveProvider と同一）
+            foreach ($leave->eachDate() as $date) {
+                $isAllDay = $leave->isAllDay();
+
+                $startAt = $isAllDay
+                    ? $date->toDateString()
+                    : Carbon::parse($date->toDateString() . ' ' . $leave->time_start)->toIso8601String();
+
+                // FullCalendar の仕様：allDay の end は翌日
+                $endAt = $isAllDay
+                    ? $date->copy()->addDay()->toDateString()
+                    : Carbon::parse($date->toDateString() . ' ' . $leave->time_end)->toIso8601String();
+
+                // 表示名（ユーザー名を先頭に付ける）
+                $u = $leave->user;
+                $userName = $u?->name
+                    ?? trim(($u?->family_name ?? '') . ' ' . ($u?->first_name ?? ''))
+                    ?: 'User';
+                $emp = $u?->employee_code ? "[{$u->employee_code}]" : '';
+                $title = "{$userName}{$emp} - " . $leave->displayTitle();
+
+                // CSS クラス（既存 LeaveProvider と揃える）
+                $classes = ['fc-leave', "fc-leave-{$leave->kind}"];
+                if ($leave->excused !== 'unknown') {
+                    $classes[] = "fc-leave-{$leave->excused}";
+                }
+
+                $events->push([
+                    'title'      => $title,
+                    'start'      => $startAt,
+                    'end'        => $endAt,
+                    'allDay'     => $isAllDay,
+                    'display'    => 'auto',
+                    'classNames' => $classes,
+                    'extendedProps' => [
+                        'category'   => 'leave',
+                        'plan'       => $this->meta['plan'],
+                        'type'       => $this->meta['type'],
+                        'level'      => $this->meta['level'],
+                        'sort_order' => 0, // eventOrder用
+                        'user' => [
+                            'id'             => $u?->id,
+                            'name'           => $userName,
+                            'employee_code'  => $u?->employee_code,
+                        ],
+                        'leave' => [
+                            'id'           => $leave->id,
+                            'kind'         => $leave->kind,
+                            'excused'      => $leave->excused,
+                            'special_type' => $leave->special_type,
+                            'reason'       => $leave->reason,
+                            'start_date'   => $leave->start_date?->toDateString(),
+                            'end_date'     => $leave->end_date?->toDateString(),
+                            'time_start'   => $leave->time_start,
+                            'time_end'     => $leave->time_end,
+                            'status'       => $leave->status,
+                        ],
+                    ],
+                ]);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/app/Services/Calendar/Providers/AllLeaveProvider.php
+++ b/app/Services/Calendar/Providers/AllLeaveProvider.php
@@ -59,9 +59,16 @@ class AllLeaveProvider
 
                 // CSS クラス（既存 LeaveProvider と揃える）
                 $classes = ['fc-leave', "fc-leave-{$leave->kind}"];
+
                 if ($leave->excused !== 'unknown') {
                     $classes[] = "fc-leave-{$leave->excused}";
                 }
+
+                // ✅ statusクラスを追加（例: status-approved / status-pending / status-rejected）
+                if (!empty($leave->status)) {
+                    $classes[] = "status-{$leave->status}";
+                }
+
 
                 $events->push([
                     'title'      => $title,

--- a/config/calendar_leave.php
+++ b/config/calendar_leave.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Services\Calendar\EventType;
+use App\Services\Calendar\PlanGroup;
+
+return [
+    'providers' => [
+        // REGULAR PLAN
+        App\Services\Calendar\Providers\HolidayProvider::class    => ['level' => 1, 'type' => EventType::BACKGROUND, 'plan' => PlanGroup::REGULAR_PLAN],
+        App\Services\Calendar\Providers\ClosureProvider::class    => ['level' => 4, 'type' => EventType::BACKGROUND, 'plan' => PlanGroup::REGULAR_PLAN],
+        App\Services\Calendar\Providers\AllLeaveProvider::class   => ['level' => 1, 'type' => EventType::ON,         'plan' => PlanGroup::EVENT       ],
+    ],
+
+    'rules' => [
+        'on_adds_to_background'         => true,
+        'holiday_untouchable'           => true,
+    ],
+];

--- a/database/migrations/2025_09_02_102158_create_leaves_table.php
+++ b/database/migrations/2025_09_02_102158_create_leaves_table.php
@@ -13,10 +13,10 @@ return new class extends Migration
     {
         Schema::create('leaves', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
 
             // 期間（単日OK・連休OK）
-            $table->date('start_date');
+            $table->date('start_date')->nullable();
             $table->date('end_date')->nullable(); // nullなら単日扱い
 
            // 発生理由/メモ（遅刻の詳細理由、有給の任意理由など）

--- a/database/migrations/2025_09_02_102158_create_leaves_table.php
+++ b/database/migrations/2025_09_02_102158_create_leaves_table.php
@@ -19,30 +19,33 @@ return new class extends Migration
             $table->date('start_date');
             $table->date('end_date')->nullable(); // nullなら単日扱い
 
-            // 休暇の種別（前3項目はPaid,その他はUnpaid扱い）
-            // paid=有給, absense_to_paid=欠席から有給へ, special=特別休暇(結婚/忌引など), absence=欠席, adjustment=調整, other=その他
-            $table->enum('kind', ['paid', 'absense_to_paid', 'special', 'absence', 'adjustment', 'other' ])->index();
-
-            // 会社としての扱い
-            $table->enum('excused', ['excused', 'unexcused'])->default('unexcused')->index();
-
-            // 特別休暇の種類（例: wedding, bereavement 等）
-            $table->string('special_type', 100)->nullable();
-
-            // 申請理由/メモ（遅刻の詳細理由、有給の任意理由など）
+           // 発生理由/メモ（遅刻の詳細理由、有給の任意理由など）
             $table->text('reason')->nullable();
 
+            // 休暇の種別
+            // paid=有給, absense_to_paid=欠席から有給へ, special=特別休暇(結婚/忌引など), absence=欠席, adjustment=調整, left_early=早退, late=遅刻, other=その他 
+            $table->enum('kind', ['paid', 'absense_to_paid', 'special', 'absence', 'adjustment', 'left_early', 'late', 'other'])->index();
+
+            // 会社としての扱い（免除/非免除/不明）
+            $table->enum('excused', ['excused', 'unexcused'])->default('unexcused')->index();
+
+            // Special、Otherの種類（例: wedding, bereavement, sick child leave 等）
+            $table->string('special_type', 100)->nullable();
+
             // 時間帯（partial対応：遅刻・早退など。終日ならnull）
-            // 多分使わないが残しておく。上記はeventのtime_start等と合わせる。給与計算はOBIC7等で対応している。
             $table->time('time_start')->nullable();
             $table->time('time_end')->nullable();
 
+            // 処理方法メモ（管理者用。給与計算などでの特記事項など）
+            $table->text('handle_type')->nullable();
+
             // 承認ステータス（最低限）
-            $table->enum('status', ['approved', 'pending', 'rejected'])->default('approved')->index();
+            $table->enum('status', ['approved', 'pending', 'rejected', 'other'])->default('approved')->index();
             $table->foreignId('approved_by')->nullable()->constrained('users')->nullOnDelete();
 
             $table->timestamps();
-            $table->index(['user_id', 'start_date', 'end_date']);
+            $table->index(['user_id', 'start_date', 'end_date', 'excused', 'kind']);
+
         });
     }
 

--- a/database/seeders/LeaveSeeder.php
+++ b/database/seeders/LeaveSeeder.php
@@ -21,31 +21,23 @@ class LeaveSeeder extends Seeder
         Leave::create([
             'user_id'     => 7,
             'start_date'  => '2025-10-15',
+            'end_date'    => '2025-10-16',
             'kind'        => 'paid',        // 有給
-            'excused'     => 'excused',
-            'reason'      => null,
-            'status'      => 'approved',
-        ]);
-        Leave::create([
-            'user_id'     => 7,
-            'start_date'  => '2025-10-16',
-            'kind'        => 'paid',
             'excused'     => 'excused',
             'reason'      => null,
             'status'      => 'approved',
         ]);
 
         // user_id=4 （結婚式：5日連続）
-        foreach (['2025-10-15','2025-10-16','2025-10-17','2025-10-18','2025-10-19'] as $d) {
-            Leave::create([
-                'user_id'     => 4,
-                'start_date'  => $d,
-                'kind'        => 'special',
-                'special_type'=> '結婚式',
-                'excused'     => 'excused',
-                'reason'      => null,
-                'status'      => 'approved',
-            ]);
-        }
+        Leave::create([
+            'user_id'     => 4,
+            'start_date'  => '2025-10-15',
+            'end_date'    => '2025-10-19',
+            'kind'        => 'special',
+            'special_type' => '結婚式',
+            'excused'     => 'excused',
+            'reason'      => null,
+            'status'      => 'approved',
+        ]);
     }
 }

--- a/public/css/leave-custom.css
+++ b/public/css/leave-custom.css
@@ -29,62 +29,6 @@
   font-weight: 600;
 }
 
-/* =======================================================
-   ▼▼ カレンダー全体のグレー化（背景・セル・ヘッダー）▼▼
-   ======================================================= */
-
-/* カレンダー背景全体 */
-#calendar {
-  background-color: #f3f4f6 !important; /* gray-100 */
-  border-radius: 8px;
-  padding: 8px;
-}
-
-/* 曜日ヘッダー部 */
-.fc .fc-col-header-cell {
-  background-color: #e5e7eb !important; /* gray-200 */
-  color: #333 !important;
-  border: 1px solid #d1d5db !important;
-}
-
-/* 日付セルの背景 */
-.fc .fc-daygrid-day {
-  background-color: #f9fafb !important; /* gray-50 */
-  border: 1px solid #d1d5db !important;
-}
-
-/* todayセル（本日）は少し強調） */
-.fc .fc-day-today {
-  background-color: #e5e7eb !important; /* gray-200 */
-  box-shadow: inset 0 0 6px 2px rgba(0,0,0,0.1);
-}
-
-/* 月・週・リストなど共通のヘッダータイトル部 */
-.fc-toolbar {
-  background-color: #e5e7eb !important; /* gray-200 */
-  border-radius: 5px;
-  padding: 6px 10px;
-}
-
-/* ボタン */
-.fc .fc-button {
-  background-color: #d1d5db !important; /* gray-300 */
-  border: 1px solid #9ca3af !important;
-  color: #111 !important;
-}
-.fc .fc-button:hover {
-  background-color: #9ca3af !important;
-  color: #fff !important;
-}
-
-/* リストビュー用の背景 */
-.fc .fc-list-table {
-  background-color: #f3f4f6 !important;
-}
-/* =======================================================
-   ▲▲　カレンダー全体の基本スタイル設定 ▲▲
-   ======================================================= */
-
 /* イベント角丸（基本） */
 .fc .fc-event {
   border-radius: 6px !important;

--- a/public/css/leave-custom.css
+++ b/public/css/leave-custom.css
@@ -1,0 +1,54 @@
+/* 今日の背景（控えめ・基本のみ） */
+.fc-day-today {
+  outline-offset: -2px;
+  box-shadow: inset 0 0 6px 2px rgba(255, 200, 0, 0.35);
+}
+
+/* 会社休業日（背景用・基本） */
+.fc-company-break {
+  background-color: rgba(173, 173, 173, 0.5) !important;
+  border: 1px solid #fff !important;
+  font-weight: 600;
+}
+
+/* イベント角丸（基本） */
+.fc .fc-event {
+  border-radius: 6px !important;
+}
+
+/* カレンダー外観 */
+#calendar {
+  max-width: 1300px;  /* autoは無効なので具体値を */
+  margin: 20px auto;
+}
+
+/* セル内余白（最小） */
+.fc .fc-daygrid-day-frame { padding: 0; }
+
+/* ヘッダー（最小） */
+.fc-col-header-cell-cushion {
+  text-decoration: none !important;
+  color: #222 !important;
+  font-size: 0.95em !important;
+}
+
+/* 日付数字（最小） */
+.fc-daygrid-day-number {
+  margin-top: -2px !important;
+  color: #222 !important;
+  font-size: 0.90em !important;
+  text-decoration: none !important;
+}
+
+/* イベント枠（最小） */
+.fc-daygrid-event {
+  margin-top: -2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.90em;
+  padding: 0;
+  border-radius: 6px;
+  max-width: 95%;
+  box-sizing: border-box;
+}

--- a/public/css/leave-custom.css
+++ b/public/css/leave-custom.css
@@ -1,7 +1,25 @@
-/* 今日の背景（控えめ・基本のみ） */
+/* 今日の日付背景 */
 .fc-day-today {
   outline-offset: -2px;
-  box-shadow: inset 0 0 6px 2px rgba(255, 200, 0, 0.35);
+  animation: today-glow-inset 2s infinite;
+}
+@keyframes today-glow-inset {
+  20% { box-shadow: inset 0 0 3px 2px rgba(255, 128, 128, 0.5); }
+  50% { box-shadow: inset 0 0 15px 6px rgba(255, 180, 180, 0.53); }
+  100% { box-shadow: inset 0 0 3px 2px rgba(254, 255, 180, 0.53); }
+}
+
+/* 祝日背景（アニメにしたい場合はこちらだけ残す） */
+.fc-holiday {
+  animation: rainbow-bg 3s linear infinite;
+}
+@keyframes rainbow-bg {
+  0%   { background-color: #ffaaaa; }
+  20%  { background-color: #ffd700; }
+  40%  { background-color: #aaffaa; }
+  60%  { background-color: #aaaaff; }
+  80%  { background-color: #ffaaff; }
+  100% { background-color: #ffaaaa; }
 }
 
 /* 会社休業日（背景用・基本） */
@@ -10,6 +28,62 @@
   border: 1px solid #fff !important;
   font-weight: 600;
 }
+
+/* =======================================================
+   ▼▼ カレンダー全体のグレー化（背景・セル・ヘッダー）▼▼
+   ======================================================= */
+
+/* カレンダー背景全体 */
+#calendar {
+  background-color: #f3f4f6 !important; /* gray-100 */
+  border-radius: 8px;
+  padding: 8px;
+}
+
+/* 曜日ヘッダー部 */
+.fc .fc-col-header-cell {
+  background-color: #e5e7eb !important; /* gray-200 */
+  color: #333 !important;
+  border: 1px solid #d1d5db !important;
+}
+
+/* 日付セルの背景 */
+.fc .fc-daygrid-day {
+  background-color: #f9fafb !important; /* gray-50 */
+  border: 1px solid #d1d5db !important;
+}
+
+/* todayセル（本日）は少し強調） */
+.fc .fc-day-today {
+  background-color: #e5e7eb !important; /* gray-200 */
+  box-shadow: inset 0 0 6px 2px rgba(0,0,0,0.1);
+}
+
+/* 月・週・リストなど共通のヘッダータイトル部 */
+.fc-toolbar {
+  background-color: #e5e7eb !important; /* gray-200 */
+  border-radius: 5px;
+  padding: 6px 10px;
+}
+
+/* ボタン */
+.fc .fc-button {
+  background-color: #d1d5db !important; /* gray-300 */
+  border: 1px solid #9ca3af !important;
+  color: #111 !important;
+}
+.fc .fc-button:hover {
+  background-color: #9ca3af !important;
+  color: #fff !important;
+}
+
+/* リストビュー用の背景 */
+.fc .fc-list-table {
+  background-color: #f3f4f6 !important;
+}
+/* =======================================================
+   ▲▲　カレンダー全体の基本スタイル設定 ▲▲
+   ======================================================= */
 
 /* イベント角丸（基本） */
 .fc .fc-event {
@@ -52,3 +126,82 @@
   max-width: 95%;
   box-sizing: border-box;
 }
+
+/* =======================================================
+   Leave カラーリング設定
+   status + excused（優先） → kind（補助）
+   ======================================================= */
+
+/* --- Status / Excused 組み合わせ ---------------------------------- */
+
+/* Leave の枠線は常に 3px */
+.fc .fc-event.fc-leave {
+  border-width: 3px !important;
+  border-style: solid !important;
+}
+
+/* pending: yellow */
+.fc .fc-event.fc-leave.status-pending {
+  border-color: #facc15;
+}
+
+/* approved + excused: green */
+.fc .fc-event.fc-leave.status-approved.fc-leave-excused {
+  border-color: #22c55e;
+}
+
+/* approved + unexcused: red */
+.fc .fc-event.fc-leave.status-approved.fc-leave-unexcused {
+  border-color: #ef4444;
+}
+/* rejected: gray */
+.fc .fc-event.fc-leave.status-rejected {
+  border-color: #6b7280;
+}
+
+/* その他の status: kind 色で処理するため特別指定なし */
+
+/* --- Kind（休暇種別） --------------------------------------------- */
+/* .fc-event-main 付けると枠線は適応外となる */
+/* kind に応じた基本カラー。status による上書きを許容する。 */
+
+.fc .fc-event.fc-leave-paid {
+  background-color: #93c5fd !important; /* light blue */
+  border-color: #93c5fd !important;
+  color: #000 !important;
+}
+
+.fc .fc-event.fc-leave-absense_to_paid {
+  background-color: #3b82f6 !important; /* blue */
+  border-color: #3b82f6 !important;
+  color: #fff !important;
+}
+
+.fc .fc-event.fc-leave-special {
+  background-color: #f472b6 !important; /* pink */
+  border-color: #f472b6 !important;
+  color: #fff !important;
+}
+
+.fc .fc-event.fc-leave-adjustment {
+  background-color: #9ca3af !important; /* gray */
+  border-color: #9ca3af !important;
+  color: #000 !important;
+}
+
+/* absence / left_early / late: yellow */
+.fc .fc-event.fc-leave-absence .fc-event-main,
+.fc .fc-event.fc-leave-left_early .fc-event-main,
+.fc .fc-event.fc-leave-late .fc-event-main {
+  background-color: #4b4b4b96 !important; /* yellow */
+  border-color: #fde047; /* !importantつけないことによりstatus + excused枠線が適応される */
+  color: #ffffff !important;
+}
+
+/* other: purple */
+.fc .fc-event.fc-leave-other {
+  background-color: #a855f7 !important; /* purple */
+  border-color: #a855f7 !important;
+  color: #fff !important;
+}
+

--- a/public/css/leave-custom.css
+++ b/public/css/leave-custom.css
@@ -111,41 +111,59 @@
 
 .fc .fc-event.fc-leave-paid {
   background-color: #93c5fd !important; /* light blue */
-  border-color: #93c5fd !important;
+  border-color: #93c5fd;
   color: #000 !important;
 }
 
 .fc .fc-event.fc-leave-absense_to_paid {
   background-color: #3b82f6 !important; /* blue */
-  border-color: #3b82f6 !important;
+  border-color: #3b82f6;
   color: #fff !important;
 }
 
 .fc .fc-event.fc-leave-special {
   background-color: #f472b6 !important; /* pink */
-  border-color: #f472b6 !important;
+  border-color: #f472b6;
   color: #fff !important;
 }
 
 .fc .fc-event.fc-leave-adjustment {
   background-color: #9ca3af !important; /* gray */
-  border-color: #9ca3af !important;
+  border-color: #9ca3af;
   color: #000 !important;
-}
-
-/* absence / left_early / late: yellow */
-.fc .fc-event.fc-leave-absence .fc-event-main,
-.fc .fc-event.fc-leave-left_early .fc-event-main,
-.fc .fc-event.fc-leave-late .fc-event-main {
-  background-color: #4b4b4b96 !important; /* yellow */
-  border-color: #fde047; /* !importantつけないことによりstatus + excused枠線が適応される */
-  color: #ffffff !important;
 }
 
 /* other: purple */
 .fc .fc-event.fc-leave-other {
   background-color: #a855f7 !important; /* purple */
-  border-color: #a855f7 !important;
+  border-color: #a855f7;
+  color: #fff !important;
+}
+
+/* =======================================================
+   Absence だけ：枠線色を handle_type + excused で上書き
+   （status の色付けより後に書く／!important で確実に上書き）
+   ======================================================= */
+
+/* 1) handle_type = null/空 → yellow */
+.fc .fc-event.fc-leave.fc-leave-absence.absence-unhandled {
+  border-color: #facc15 !important; /* yellow */
+}
+
+/* 2) handle_type あり && excused → green */
+.fc .fc-event.fc-leave.fc-leave-absence.absence-handled-excused {
+  border-color: #22c55e !important; /* green */
+}
+
+/* 3) handle_type あり && unexcused → red */
+.fc .fc-event.fc-leave.fc-leave-absence.absence-handled-unexcused {
+  border-color: #ef4444 !important; /* red */
+}
+
+/* other: purple */
+.fc .fc-event.fc-leave-other {
+  background-color: #a855f7 !important; /* purple */
+  border-color: #a855f7;
   color: #fff !important;
 }
 

--- a/public/js/leave.js
+++ b/public/js/leave.js
@@ -1,0 +1,69 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const calendarEl = document.getElementById('calendar');
+    console.log('[] loaded - leave.js:3');
+
+    // ▼▼ FullCalendar 初期化（基本のみ）▼▼
+    const calendar = new FullCalendar.Calendar(calendarEl, {
+        locale: 'en',
+        initialView: 'dayGridMonth',
+        initialDate: window.initialDate,
+        height: 'auto',
+        firstDay: 0,
+        slotDuration: '00:10:00',
+        slotLabelFormat: { hour: '2-digit', minute: '2-digit', hour12: false },
+        slotMinTime: '09:00:00',
+        slotMaxTime: '23:00:00',
+        eventOrder: "extendedProps.category,title,start",
+        headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,listWeek' },
+        dayMaxEventRows: true,
+        navLinks: true,
+        nowIndicator: true,
+        validRange: { start: '2025-04-01', end: '' },
+        editable: false,
+
+        views: {
+            listWeek: {
+                listDayFormat: { weekday: 'long' },
+                listDaySideFormat: { month: 'short', day: 'numeric' }
+            }
+        },
+
+        events: {
+            url: window.calendarEventsUrl,
+            failure: () => alert('イベント取得に失敗しました'),
+            error: (xhr) => console.error('FC error - leave.js:28', xhr?.xhr?.responseText || xhr)
+        },
+
+        dayCellContent(info) {
+            if (info.view.type === 'dayGridMonth') return info.date.getDate();
+            return { html: '' };
+        },
+
+        // ▼▼ Event枠内の表示（タイトルのみ）▼▼
+        eventContent(arg) {
+            return { html: `${arg.event.title ?? ''}` };
+        },
+
+        // ▼▼ クリックで簡易モーダル（基本情報のみ）▼▼
+        eventClick(info) {
+            const e = info.event;
+            const p = e.extendedProps || {};
+
+            const title = e.title || 'Leave';
+            const fmt = (d) => d ? d.toLocaleDateString('ja-JP') : '';
+
+            let html = `<div class="mb-2"><strong>${title}</strong></div>`;
+            if (e.start || e.end) {
+                html += `<div>Date: ${fmt(e.start)}${e.end ? ' 〜 ' + fmt(e.end) : ''}</div>`;
+            }
+            if (p.kind)   html += `<div>Kind: ${p.kind}</div>`;
+            if (p.status) html += `<div>Status: ${p.status}</div>`;
+            if (p.user_name) html += `<div>User: ${p.user_name}</div>`;
+
+            document.getElementById('eventModalBody').innerHTML = html;
+            new bootstrap.Modal(document.getElementById('eventModal')).show();
+        }
+    });
+
+    calendar.render();
+});

--- a/resources/views/calendar/absenceReport.blade.php
+++ b/resources/views/calendar/absenceReport.blade.php
@@ -1,0 +1,257 @@
+{{-- resources/views/calendar/absenceReport.blade.php --}}
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <div>
+    <h2 class="mb-0">Absence Report</h2>
+    <div class="text-muted small mt-1">
+      User: <span class="fw-semibold">{{ $user->name ?? trim(($user->family_name ?? '').' '.($user->first_name ?? '')) }}</span>
+    </div>
+  </div>
+  @role('admin|super_admin')
+    <span class="badge text-bg-primary">Admin View</span>
+  @else
+    <span class="badge text-bg-secondary">My Absences</span>
+  @endrole
+</div>
+
+@if(session('success'))  <div class="alert alert-success py-2 mb-2">{{ session('success') }}</div> @endif
+@if(session('error'))    <div class="alert alert-danger  py-2 mb-2">{{ session('error') }}</div>   @endif
+@if ($errors->any())
+  <div class="alert alert-danger py-2 mb-2">
+    <ul class="mb-0">@foreach ($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>
+  </div>
+@endif
+
+@php
+  $kindLabels = $kindLabels ?? [
+    'absence'         => 'Unpaid Leave',
+    'absense_to_paid' => 'ALP',
+    'other'           => 'Others',
+  ];
+  $handleTypeOptions = $handleTypeOptions ?? [
+    'self_cover' => 'Self Cover',
+    'makeup'     => 'Make-up Lesson',
+    'refund'     => 'Refund',
+    'other'      => 'Other',
+  ];
+@endphp
+
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0 absence-table">
+        {{-- ★ 列幅を安定させる --}}
+        <colgroup>
+          <col style="width:12rem">
+          <col style="width:10rem">
+          <col style="width:auto">
+          <col style="width:16rem">
+          <col style="width:8rem">
+          <col style="width:9rem">
+        </colgroup>
+
+        <thead class="table-light">
+          <tr>
+            <th>Date</th>
+            <th>Kind</th>
+            <th>Reason</th>
+            <th>Handle Type</th>
+            <th>Status</th>
+            <th class="text-end">Action</th>
+          </tr>
+        </thead>
+
+        <tbody>
+        @forelse($leaves as $leave)
+          @php
+            $kindLabel = $leave->kind === 'other'
+              ? ($leave->special_type ?: 'Others')
+              : ($kindLabels[$leave->kind] ?? ucfirst($leave->kind));
+
+            $needsReport = ($leave->kind === 'absence') && is_null($leave->reason) && is_null($leave->handle_type);
+            $statusText  = ($leave->reason && $leave->handle_type) ? 'Submitted' : ($needsReport ? 'Required' : '—');
+
+            $dateMain = optional($leave->start_date)->toDateString();
+            $dateSub  = (!empty($leave->end_date) && $leave->end_date?->ne($leave->start_date)) ? $leave->end_date->toDateString() : null;
+
+            $formId = 'report-form-'.$leave->id;
+          @endphp
+
+          <tr class="{{ $needsReport ? 'row-required' : '' }}">
+            {{-- Date --}}
+            <td>
+              <div class="d-flex flex-column">
+                <span class="fw-semibold">{{ $dateMain }}</span>
+                @if($dateSub)<span class="small text-muted">〜 {{ $dateSub }}</span>@endif
+              </div>
+            </td>
+
+            {{-- Kind --}}
+            <td>
+              <span class="badge rounded-pill
+                @switch($kindLabel)
+                  @case('Unpaid Leave') text-bg-primary text-white @break
+                  @case('ALP')          text-bg-info    text-white @break
+                  @default              text-bg-info    text-white
+                @endswitch
+              ">{{ $kindLabel }}</span>
+            </td>
+
+            {{-- Reason --}}
+            <td class="col-reason">
+              @if($needsReport)
+                <textarea name="reason"
+                          form="{{ $formId }}"
+                          class="form-control form-control-sm"
+                          rows="2"
+                          placeholder="Enter reason (required)"
+                          required></textarea>
+              @else
+                <textarea class="form-control form-control-sm bg-body-tertiary"
+                          rows="2"
+                          readonly>{{ $leave->reason }}</textarea>
+              @endif
+            </td>
+
+            {{-- Handle Type --}}
+            <td class="col-handle">
+              @if($needsReport)
+                <select name="handle_type"
+                        form="{{ $formId }}"
+                        class="form-select form-select-sm"
+                        required>
+                  <option value="">— Select —</option>
+                  @foreach($handleTypeOptions as $val => $label)
+                    <option value="{{ $val }}">{{ $label }}</option>
+                  @endforeach
+                </select>
+              @else
+                @php
+                  $handleLabel = $leave->handle_type ? ($handleTypeOptions[$leave->handle_type] ?? $leave->handle_type) : '';
+                @endphp
+                <input type="text"
+                      class="form-control form-control-sm bg-body-tertiary"
+                      value="{{ $handleLabel }}"
+                      readonly>
+              @endif
+            </td>
+
+            {{-- Status --}}
+            <td>
+              @if($statusText === 'Submitted')
+                <span class="badge rounded-pill text-bg-success">Submitted</span>
+              @elseif($statusText === 'Required')
+                <span class="badge rounded-pill text-bg-warning text-dark">Required</span>
+              @else
+                <span class="text-muted">—</span>
+              @endif
+            </td>
+
+            {{-- Action --}}
+            <td class="text-end">
+              @if($needsReport)
+                <form id="{{ $formId }}" method="POST" action="{{ route('report.update', $leave) }}" class="d-inline-block">
+                  @csrf @method('PUT')
+                  <button type="submit" class="btn btn-sm btn-primary">Submit</button>
+                </form>
+              @else
+                <button type="button" class="btn btn-sm btn-outline-secondary" disabled>Submitted</button>
+              @endif
+            </td>
+          </tr>
+        @empty
+          <tr><td colspan="6" class="text-center text-muted py-4">No records.</td></tr>
+        @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('styles')
+<style>
+  /* 必要行のハイライト（疑似要素は使わない） */
+  .absence-table tr.row-required { background: linear-gradient(90deg, rgba(252,211,77,.12), transparent 45%); }
+  .absence-table tr.row-required td:first-child { border-left: 4px solid #f59e0b; }
+
+  /* 読取専用の背景 */
+  .form-control[readonly], .bg-body-tertiary { background-color: var(--bs-tertiary-bg) !important; }
+
+  /* スマホ：theadを非表示にしてカード風に */
+  @media (max-width: 768px) {
+    .absence-table thead { display:none; }
+    .absence-table colgroup { display:none; }
+    .absence-table tbody tr { display:grid; grid-template-columns:1fr; gap:.5rem .75rem; padding:.75rem; border-top:1px solid var(--bs-border-color); }
+    .absence-table tbody td { display:grid; grid-template-columns:9rem 1fr; align-items:center; gap:.5rem; padding:.25rem 0; border:0 !important; }
+    .absence-table tbody td::before { content: attr(data-label); font-size:.8rem; color:var(--bs-secondary-color); }
+  }
+/* 高さ・フォント・角丸を統一 */
+.absence-table .btn-sm,
+.absence-table .badge.rounded-pill {
+  font-size: 0.8rem;
+  font-weight: 400; /* ← 太字を解除 */
+  padding: 0.35rem 0.75rem;
+  border-radius: 1rem !important;
+  line-height: 1.2;
+}
+
+/* ボタンの色統一 */
+.absence-table .btn-primary {
+  background-color: #2563eb; /* Indigo-600 */
+  border-color: #2563eb;
+}
+.absence-table .btn-primary:hover {
+  background-color: #1e40af;
+  border-color: #1e40af;
+}
+
+/* アウトラインボタン（Submitted用） */
+.absence-table .btn-outline-secondary {
+  color: #6b7280;
+  border-color: #cbd5e1;
+  background-color: #f9fafb;
+}
+.absence-table .btn-outline-secondary:disabled {
+  opacity: 1;
+  color: #9ca3af;
+}
+
+/* バッジ配色調整（Bootstrapベース） */
+.badge.text-bg-success {
+  background-color: #22c55e !important;
+  font-weight: 400 !important;
+}
+.badge.text-bg-warning {
+  background-color: #facc15 !important;
+  color: #1e293b !important;
+  font-weight: 400 !important;
+}
+.badge.text-bg-primary {
+  background-color: #3b82f6 !important;
+  font-weight: 400 !important;
+}
+.badge.text-bg-info {
+  background-color: #38bdf8 !important;
+  font-weight: 400 !important;
+}
+/* Reason と Handle Type の列幅をやや短く（Date列を確保） */
+.absence-table .col-reason,
+.absence-table .col-handle {
+  width: 30%;
+  min-width: 5rem;
+}
+
+/* テキストエリアの高さと見た目を自然に */
+.absence-table textarea.form-control-sm {
+  resize: vertical;
+  line-height: 1.3;
+  padding: 0.35rem 0.5rem;
+  height: 2.4rem; /* 少し短め固定（2行相当） */
+  min-height: 2.4rem;
+}
+</style>
+
+@endpush

--- a/resources/views/calendar/edit.blade.php
+++ b/resources/views/calendar/edit.blade.php
@@ -596,21 +596,12 @@ document.addEventListener('input', (e) => {
         },
         body: JSON.stringify({ items }),
       });
-      const json = await res.json();
-
       if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
         alert(json?.message || '保存に失敗しました。');
         return;
       }
-
-      if (json.failed > 0) {
-        console.warn('一部失敗', json.results);
-        alert(`保存：${json.updated} 件 / 失敗：${json.failed} 件\n内容を確認してください。`);
-      } else {
-        alert(`すべて保存しました（${json.updated} 件）`);
-      }
-
-      // 反映を確実にするならリロード
+      // ✅ 成功時はアラートを出さず、フラッシュ表示のために即リロード
       location.reload();
     } catch (err) {
       console.error(err);

--- a/resources/views/calendar/leave.blade.php
+++ b/resources/views/calendar/leave.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Absence Calendar</h2>
+    <span class="badge text-bg-info">Admin View</span>
+</div>
+
+{{-- ▼▼ 月選択フォーム（GET） ▼▼ --}}
+<form method="GET" action="{{ url()->current() }}" class="mb-1">
+  <div class="row g-2 align-items-end">
+    <div class="col-6 col-md-3 col-lg-2">
+      <label class="form-label small mb-1">Month</label>
+      <input type="month"
+             name="month"
+             class="form-control form-control-sm"
+             value="{{ old('month', request('month', now()->format('Y-m'))) }}"
+             required>
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-sm btn-primary">Select</button>
+    </div>
+  </div>
+</form>
+{{-- ▲▲ 月選択フォーム（GET） ▲▲ --}}
+
+<div id="calendar"></div>
+
+<!-- 詳細モーダル（indexと同じ） -->
+<div class="modal fade" id="eventModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body" id="eventModalBody">Reading…</div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('styles')
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.css" rel="stylesheet">
+<link href="{{ asset('css/leave-custom.css') }}" rel="stylesheet">
+@endpush
+
+@push('scripts')
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js"></script>
+  <script>
+    window.calendarEventsUrl = "{{ route('calendar.leave.events') }}";
+    window.initialDate = "{{ request('month', now()->format('Y-m')) }}";
+  </script>
+  <script src="{{ asset('js/leave.js') }}?v={{ filemtime(public_path('js/leave.js')) }}"></script>
+@endpush

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -6,33 +6,91 @@
     <span class="badge text-bg-primary">Admin View</span>
 </div>
 
-{{-- ▼ 検索フォーム（月・ユーザー） --}}
-<form method="GET" action="{{ route('leaves.edit') }}" class="mb-3">
-    <div class="card">
-        <div class="card-body p-2">
-            <div class="row g-2 align-items-end">
-                <div class="col-12 col-md-3">
-                    <label class="form-label small mb-1">Month</label>
-                    <input type="month" name="month" class="form-control form-control-sm"
-                        value="{{ $month }}">
-                </div>
-                <div class="col-12 col-md-4">
-                    <label class="form-label small mb-1">User</label>
-                    <select name="user_id" class="form-select form-select-sm">
-                        <option value="">—</option>
-                        @foreach($userOptions as $u)
-                        <option value="{{ $u->id }}" @selected(request('user_id')==$u->id)>
-                            {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
-                        </option>
-                        @endforeach
-                    </select>
-                </div>
-                <div class="col-12 col-md-2">
-                    <button class="btn btn-sm btn-primary w-100">Search</button>
-                </div>
-            </div>
+{{-- ▼ 検索フォーム --}}
+<form method="GET" action="{{ route('leaves.edit') }}" class="mb-2" id="leave-search-form">
+  <div class="card">
+    <div class="card-body p-2">
+      <div class="row g-2 align-items-end">
+
+        {{-- User --}}
+        <div class="col-12 col-md-3">
+          <label class="form-label small mb-1">User</label>
+          <select name="user_id" class="form-select form-select-sm">
+            <option value="">—</option>
+            @foreach($userOptions as $u)
+              <option value="{{ $u->id }}" @selected(request('user_id')==$u->id)>
+                {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
+              </option>
+            @endforeach
+          </select>
         </div>
+
+        {{-- Kind / Excused / Status --}}
+        <div class="col-6 col-md-2">
+          <label class="form-label small mb-1">Kind</label>
+          <select name="kind" class="form-select form-select-sm">
+            <option value="">—</option>
+            @foreach($kindOptions as $v => $label)
+              <option value="{{ $v }}" @selected(request('kind')===$v)>{{ $label }}</option>
+            @endforeach
+          </select>
+        </div>
+        <div class="col-6 col-md-2">
+          <label class="form-label small mb-1">Excused</label>
+          <select name="excused" class="form-select form-select-sm">
+            <option value="">—</option>
+            @foreach($excusedOptions as $v => $label)
+              <option value="{{ $v }}" @selected(request('excused')===$v)>{{ $label }}</option>
+            @endforeach
+          </select>
+        </div>
+        <div class="col-6 col-md-2">
+          <label class="form-label small mb-1">Status</label>
+          <select name="status" class="form-select form-select-sm">
+            <option value="">—</option>
+            @foreach($statusOptions as $v => $label)
+              <option value="{{ $v }}" @selected(request('status')===$v)>{{ $label }}</option>
+            @endforeach
+          </select>
+        </div>
+
+        {{-- Special / Handle / Reason --}}
+        <div class="col-6 col-md-3">
+          <label class="form-label small mb-1">Special Type</label>
+          <input type="text" name="special_type" value="{{ request('special_type') }}" class="form-control form-control-sm" placeholder="例: 結婚, 忌引">
+        </div>
+        <div class="col-6 col-md-3">
+          <label class="form-label small mb-1">Handle Type</label>
+          <input type="text" name="handle_type" value="{{ request('handle_type') }}" class="form-control form-control-sm" placeholder="例: 後日調整">
+        </div>
+        <div class="col-12 col-md-3">
+          <label class="form-label small mb-1">Reason</label>
+          <input type="text" name="reason" value="{{ request('reason') }}" class="form-control form-control-sm" placeholder="理由を部分一致で検索">
+        </div>
+
+        {{-- Start/End --}}
+        <div class="col-6 col-md-2">
+          <label class="form-label small mb-1">Start Date</label>
+          <input type="date" name="start_date" value="{{ request('start_date') }}" class="form-control form-control-sm" id="filter-start-date">
+        </div>
+        <div class="col-6 col-md-2">
+          <label class="form-label small mb-1">End Date</label>
+          <input type="date" name="end_date" value="{{ request('end_date') }}" class="form-control form-control-sm" id="filter-end-date">
+        </div>
+
+        {{-- Buttons --}}
+        <div class="col-12 col-md-2 d-flex gap-1">
+          <button class="btn btn-sm btn-primary flex-fill">Search</button>
+          <button type="button" id="js-clear-filters" class="btn btn-sm btn-outline-secondary flex-fill">Clear</button>
+        </div>
+
+        <div class="col-12">
+          <div class="invalid-feedback d-block" id="date-error" style="display:none;"></div>
+        </div>
+
+      </div>
     </div>
+  </div>
 </form>
 
 <div class="d-flex align-items-center gap-1 mb-2">
@@ -74,14 +132,14 @@
 
         <div class="col-12 col-sm-6 col-md-4 col-lg-3">
             <div class="card h-100 shadow-sm">
-                {{-- まだ保存先ルート未定のため actionは空。後で PUT/PATCH に差し替え可能 --}}
+                {{-- Leave Manager --}}
                 <form method="POST"
                     action="{{ route('leaves.update', $leave) }}"
                     class="h-100 d-flex flex-column js-leave-form">
                 @csrf
                 @method('PUT')
 
-                {{-- Add Bulk 用ID隠しフィールド --}}
+                {{-- Add Bulk 用ID隠しフィールド (JS用？) --}}
                 <input type="hidden" name="id" value="{{ $leave->id }}">
 
                     <div class="card-body p-2 light-blue">
@@ -98,13 +156,32 @@
                                 </select>
                             </div>
 
-                            {{-- 1: Kind / Status --}}
+                            {{-- 1: Kind / Special Type --}}
                             <div class="row g-1 mb-0">
                                 <div class="col-6">
                                     <label class="form-label small mb-0">Kind</label>
                                     <select name="kind" class="form-select form-select-sm">
                                         @foreach($kindOptions as $v => $label)
                                         <option value="{{ $v }}" @selected($leave->kind===$v)>{{ $label }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Special Type</label>
+                                    <input type="text" name="special_type" class="form-control form-control-sm"
+                                        value="{{ old('special_type', $leave->special_type) }}"
+                                        placeholder="Details for special leave">
+                                </div>
+
+                            </div>
+
+                            {{-- 2: Excused / Status --}}
+                            <div class="row g-1 mb-0">
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Excused</label>
+                                    <select name="excused" class="form-select form-select-sm">
+                                        @foreach($excusedOptions as $v => $label)
+                                        <option value="{{ $v }}" @selected($leave->excused===$v)>{{ $label }}</option>
                                         @endforeach
                                     </select>
                                 </div>
@@ -118,24 +195,6 @@
                                 </div>
                             </div>
 
-                            {{-- 2: Excused / Special Type --}}
-                            <div class="row g-1 mb-0">
-                                <div class="col-6">
-                                    <label class="form-label small mb-0">Excused</label>
-                                    <select name="excused" class="form-select form-select-sm">
-                                        @foreach($excusedOptions as $v => $label)
-                                        <option value="{{ $v }}" @selected($leave->excused===$v)>{{ $label }}</option>
-                                        @endforeach
-                                    </select>
-                                </div>
-                                <div class="col-6">
-                                    <label class="form-label small mb-0">Special Type</label>
-                                    <input type="text" name="special_type" class="form-control form-control-sm"
-                                        value="{{ old('special_type', $leave->special_type) }}"
-                                        placeholder="Details for special leave">
-                                </div>
-                            </div>
-
                             {{-- 3: Dates --}}
                             <div class="row g-1 mb-0">
                                 <div class="col-6">
@@ -144,7 +203,7 @@
                                         value="{{ old('start_date', $fmtDate($leave->start_date)) }}">
                                 </div>
                                 <div class="col-6">
-                                    <label class="form-label small mb-0">End Date (Optional)</label>
+                                    <label class="form-label small mb-0">End Date</label>
                                     <input type="date" name="end_date" class="form-control form-control-sm"
                                         value="{{ old('end_date', $fmtDate($leave->end_date)) }}">
                                 </div>
@@ -153,13 +212,13 @@
                             {{-- 4: Times --}}
                             <div class="row g-1 mb-0">
                                 <div class="col-6">
-                                    <label class="form-label small mb-0">Time Start (Optional)</label>
+                                    <label class="form-label small mb-0">Time Start</label>
                                     <input type="time" name="time_start" class="form-control form-control-sm"
                                         value="{{ old('time_start', $fmtTime($leave->time_start)) }}"
                                         inputmode="numeric" step="60">
                                 </div>
                                 <div class="col-6">
-                                    <label class="form-label small mb-0">Time End (Optional)</label>
+                                    <label class="form-label small mb-0">Time End</label>
                                     <input type="time" name="time_end" class="form-control form-control-sm"
                                         value="{{ old('time_end', $fmtTime($leave->time_end)) }}"
                                         inputmode="numeric" step="60">
@@ -170,7 +229,7 @@
                             <div class="mb-0">
                                 <label class="form-label small mb-0">Reason</label>
                                 <textarea name="reason" class="form-control form-control-sm" rows="2"
-                                    placeholder="理由">{{ old('reason', $leave->reason) }}</textarea>
+                                    placeholder="Reason">{{ old('reason', $leave->reason) }}</textarea>
                             </div>
 
                             {{-- 6: Handle Type --}}
@@ -178,11 +237,11 @@
                                 <label class="form-label small mb-0">Handle Type</label>
                                 <input type="text" name="handle_type" class="form-control form-control-sm"
                                     value="{{ old('handle_type', $leave->handle_type) }}"
-                                    placeholder="後日調整、給与控除等の備考">
+                                    placeholder="Absence handling type">
                             </div>
                         </div>
 
-                        {{-- フッタ操作（後でルート紐付け可） --}}
+                        {{-- フッタ操作 --}}
                         <div class="card-footer bg-white d-flex justify-content-between align-items-center py-2 px-2 gap-1 mt-2">
                             {{-- 削除ボタン：クラスとdata属性をJSに合わせる --}}
                             <button type="button"
@@ -212,7 +271,7 @@
 </div>
 @else
 <div class="alert alert-light border">
-    対象月（{{ $periodStart->format('Y-m-d') }}〜{{ $periodEnd->format('Y-m-d') }}）に該当する休暇はありません。
+    データがありません。
 </div>
 @endif
 
@@ -282,6 +341,48 @@ document.getElementById('js-bulk-save')?.addEventListener('click', async (e) => 
     alert('通信エラーが発生しました。');
   }
 });
+</script>
+
+<script>
+(() => {
+  const form = document.getElementById('leave-search-form');
+  const startEl = document.getElementById('filter-start-date');
+  const endEl = document.getElementById('filter-end-date');
+  const errEl = document.getElementById('date-error');
+  const clearBtn = document.getElementById('js-clear-filters');
+
+  function showError(msg){
+    errEl.textContent = msg;
+    errEl.style.display = 'block';
+  }
+  function clearError(){
+    errEl.textContent = '';
+    errEl.style.display = 'none';
+  }
+
+  // ✅ 検索フォーム送信前の軽いチェック
+  form?.addEventListener('submit', (e) => {
+    clearError();
+    const s = startEl?.value?.trim() || '';
+    const d = endEl?.value?.trim() || '';
+
+    if (!s && d) {
+      e.preventDefault();
+      showError('Start Date を指定してください。');
+      return;
+    }
+    if (s && d && d < s) {
+      e.preventDefault();
+      showError('End Date は Start Date 以降で指定してください。');
+    }
+  });
+
+  // ✅ 条件クリア（URLリロード）
+  clearBtn?.addEventListener('click', () => {
+    const baseUrl = "{{ route('leaves.edit') }}";
+    window.location.href = baseUrl; // クエリ無しで再読み込み
+  });
+})();
 </script>
 @endpush
 

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -216,6 +216,17 @@
 </div>
 @endif
 
+@push('styles')
+<style>
+/* Leaveカード全体の背景を薄灰色に */
+.row .card {
+  background-color: #ecececc4 !important; /* Bootstrapのlightより少し淡いグレー */
+  border: 1px solid #c1c5caff;           /* 薄い枠線 */
+  border-radius: 6px;
+}
+</style>
+@endpush
+
 @push('scripts')
 <script>
   // 削除確認ダイアログ（日付表示）

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -54,10 +54,11 @@
         <div class="col-12 col-sm-6 col-md-4 col-lg-3">
             <div class="card h-100 shadow-sm">
                 {{-- まだ保存先ルート未定のため actionは空。後で PUT/PATCH に差し替え可能 --}}
-                <form class="h-100 d-flex flex-column js-leave-form"
-                    data-leave-id="{{ $leave->id }}">
-                    @csrf
-                    {{-- @method('PUT') ← 更新ルート作成後に有効化 --}}
+                <form method="POST"
+                    action="{{ route('leaves.update', $leave) }}"
+                    class="h-100 d-flex flex-column js-leave-form">
+                @csrf
+                @method('PUT')
 
                     <div class="card-body p-2 light-blue">
                         <div class="mb-0 d-grid gap-0">
@@ -159,26 +160,28 @@
 
                         {{-- フッタ操作（後でルート紐付け可） --}}
                         <div class="card-footer bg-white d-flex justify-content-between align-items-center py-2 px-2 gap-1 mt-2">
-                            {{-- 削除ボタン --}}
+                            {{-- 削除ボタン：クラスとdata属性をJSに合わせる --}}
                             <button type="button"
-                                class="btn btn-sm btn-outline-danger js-delete-leave"
-                                data-url="{{ route('leaves.destroy', $leave) }}">
-                                削除
+                                    class="btn btn-sm btn-outline-danger js-delete"
+                                    data-url="{{ route('leaves.destroy', $leave) }}"
+                                    data-date="{{ $leave->start_date?->format('Y-m-d') ?? 'この休暇' }}">
+                            削除
                             </button>
 
-                            {{-- 保存ボタン --}}
-                            <button type="button"
-                                class="btn btn-sm btn-primary js-save-leave"
-                                data-url="{{ route('leaves.update', $leave) }}">
-                                保存
-                            </button>
+                            {{-- 保存は通常送信 --}}
+                            <button type="submit" class="btn btn-sm btn-primary">保存</button>
                         </div>
-
                         <small class="{{ $cls }} text-left d-block mt-1">
                             {{ $action }}: {{ $time }}
                         </small>
                     </div>
                 </form>
+
+                <form id="js-delete-form" method="POST" class="d-none">
+                    @csrf
+                    @method('DELETE')
+                </form>
+
             </div>
         </div>
         @endforeach
@@ -189,77 +192,20 @@
 </div>
 @endif
 
-{{-- Ajax保存/削除 --}}
 @push('scripts')
 <script>
-document.addEventListener('click', async (e) => {
-  const saveBtn = e.target.closest('.js-save-leave');
-  const deleteBtn = e.target.closest('.js-delete-leave');
+  // 削除確認ダイアログ（日付表示）
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.js-delete');
+    if (!btn) return;
 
-  // 保存処理
-  if (saveBtn) {
-    const url = saveBtn.dataset.url;
-    const card = saveBtn.closest('.card');
-    const form = card.querySelector('form.js-leave-form');
-    const data = Object.fromEntries(new FormData(form));
+    const date = btn.dataset.date || 'この休暇';
+    if (!confirm(`${date} を削除します。よろしいですか？`)) return;
 
-    if (!url) return alert('URLが設定されていません。');
-    if (!confirm('この内容で保存しますか？')) return;
-
-    try {
-      const res = await fetch(url, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-          'Accept': 'application/json'
-        },
-        body: JSON.stringify(data)
-      });
-      const json = await res.json();
-
-      if (res.ok && json.ok) {
-        alert('保存しました。');
-        location.reload();
-      } else {
-        alert('保存に失敗しました。\n' + (json.message || 'Validation error'));
-        console.error(json);
-      }
-    } catch (err) {
-      console.error(err);
-      alert('通信エラーが発生しました。');
-    }
-  }
-
-  // 削除処理
-  if (deleteBtn) {
-    const url = deleteBtn.dataset.url;
-    if (!url) return alert('URLが設定されていません。');
-    if (!confirm('この休暇データを削除しますか？')) return;
-
-    try {
-      const res = await fetch(url, {
-        method: 'DELETE',
-        headers: {
-          'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-          'Accept': 'application/json'
-        }
-      });
-      const json = await res.json();
-
-      if (res.ok && json.ok) {
-        alert('削除しました。');
-        location.reload();
-      } else {
-        alert('削除に失敗しました。\n' + (json.message || 'Error'));
-        console.error(json);
-      }
-    } catch (err) {
-      console.error(err);
-      alert('通信エラーが発生しました。');
-    }
-  }
-});
+    const form = document.getElementById('js-delete-form');
+    form.action = btn.dataset.url;
+    form.submit();
+  });
 </script>
 @endpush
 

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -147,13 +147,15 @@
                             {{-- 0: User --}}
                             <div class="mb-0">
                                 <label class="form-label small mb-0">User</label>
-                                <select name="user_id" class="form-select form-select-sm">
-                                    @foreach($userOptions as $u)
-                                    <option value="{{ $u->id }}" @selected($leave->user_id===$u->id)>
+                            <select name="user_id" class="form-select form-select-sm">
+                                {{-- 空白オプション --}}
+                                <option value="">—</option>
+                                @foreach($userOptions as $u)
+                                    <option value="{{ $u->id }}" @selected($leave->user_id === $u->id)>
                                         {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
                                     </option>
-                                    @endforeach
-                                </select>
+                                @endforeach
+                            </select>
                             </div>
 
                             {{-- 1: Kind / Special Type --}}

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -35,6 +35,27 @@
     </div>
 </form>
 
+<div class="d-flex align-items-center gap-1 mb-2">
+  {{-- 空白Leave追加 --}}
+  <form method="POST" action="{{ route('leaves.store.blank') }}" class="m-0 p-0">
+    @csrf
+    {{-- 現在のフィルタを保持（なければ今日/ログインユーザーにフォールバック） --}}
+    <input type="hidden" name="start_date" value="{{ request('start_date', request('month', now()->toDateString())) }}">
+    <input type="hidden" name="user_id" value="{{ request('user_id', auth()->id()) }}">
+    <button type="submit" class="btn btn-sm btn-success">
+      ＋ Add Blank
+    </button>
+  </form>
+
+  {{-- 一括保存 --}}
+  <button type="button"
+    class="btn btn-sm btn-primary"
+    id="js-bulk-save"
+    data-url="{{ route('leaves.bulk_update') }}">
+    Bulk Save
+  </button>
+</div>
+
 @if($leaves->count())
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
     @foreach($leaves as $leave)
@@ -59,6 +80,9 @@
                     class="h-100 d-flex flex-column js-leave-form">
                 @csrf
                 @method('PUT')
+
+                {{-- Add Bulk 用ID隠しフィールド --}}
+                <input type="hidden" name="id" value="{{ $leave->id }}">
 
                     <div class="card-body p-2 light-blue">
                         <div class="mb-0 d-grid gap-0">
@@ -206,6 +230,47 @@
     form.action = btn.dataset.url;
     form.submit();
   });
+</script>
+<script>
+document.getElementById('js-bulk-save')?.addEventListener('click', async (e) => {
+  const url = e.currentTarget.dataset.url;
+  const forms = Array.from(document.querySelectorAll('form.js-leave-form'));
+  if (!url || forms.length === 0) return;
+
+  const items = forms.map(f => {
+    const fd = new FormData(f);
+    // FormData → 普通のオブジェクトへ
+    const obj = Object.fromEntries(fd.entries());
+    // time/date の空文字は null に正規化（サーババリデーション対策）
+    ['end_date','time_start','time_end','special_type','handle_type','reason'].forEach(k => {
+      if (obj[k] === '') obj[k] = null;
+    });
+    return obj;
+  });
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type':'application/json',
+        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+        'Accept': 'application/json'
+      },
+      body: JSON.stringify({ items })
+    });
+    const json = await res.json();
+    if (res.ok && json.ok) {
+      // PRG + flash を使うためにリロード
+      location.reload();
+    } else {
+      console.error(json);
+      alert(json.message || '一括保存に失敗しました。');
+    }
+  } catch (err) {
+    console.error(err);
+    alert('通信エラーが発生しました。');
+  }
+});
 </script>
 @endpush
 

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -189,7 +189,8 @@
                                 </div>
                                 <div class="col-6">
                                     <label class="form-label small mb-0">Status</label>
-                                    <select name="status" class="form-select form-select-sm">
+                                    <input type="hidden" name="status" value="approved">
+                                    <select name="status" class="form-select form-select-sm" disabled>
                                         @foreach($statusOptions as $v => $label)
                                         <option value="{{ $v }}" @selected($leave->status===$v)>{{ $label }}</option>
                                         @endforeach
@@ -197,29 +198,29 @@
                                 </div>
                             </div>
 
-                            {{-- 3: Dates --}}
+                            {{-- 3: Start --}}
                             <div class="row g-1 mb-0">
-                                <div class="col-6">
+                                <div class="col-7">
                                     <label class="form-label small mb-0">Start Date</label>
                                     <input type="date" name="start_date" class="form-control form-control-sm"
                                         value="{{ old('start_date', $fmtDate($leave->start_date)) }}">
                                 </div>
-                                <div class="col-6">
-                                    <label class="form-label small mb-0">End Date</label>
-                                    <input type="date" name="end_date" class="form-control form-control-sm"
-                                        value="{{ old('end_date', $fmtDate($leave->end_date)) }}">
-                                </div>
-                            </div>
-
-                            {{-- 4: Times --}}
-                            <div class="row g-1 mb-0">
-                                <div class="col-6">
+                                <div class="col-5">
                                     <label class="form-label small mb-0">Time Start</label>
                                     <input type="time" name="time_start" class="form-control form-control-sm"
                                         value="{{ old('time_start', $fmtTime($leave->time_start)) }}"
                                         inputmode="numeric" step="60">
                                 </div>
-                                <div class="col-6">
+                            </div>
+
+                            {{-- 4: End --}}
+                            <div class="row g-1 mb-0">
+                                <div class="col-7">
+                                    <label class="form-label small mb-0">End Date</label>
+                                    <input type="date" name="end_date" class="form-control form-control-sm"
+                                        value="{{ old('end_date', $fmtDate($leave->end_date)) }}">
+                                </div>
+                                <div class="col-5">
                                     <label class="form-label small mb-0">Time End</label>
                                     <input type="time" name="time_end" class="form-control form-control-sm"
                                         value="{{ old('time_end', $fmtTime($leave->time_end)) }}"

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -1,0 +1,266 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Leave Manager</h2>
+    <span class="badge text-bg-primary">Admin View</span>
+</div>
+
+{{-- ▼ 検索フォーム（月・ユーザー） --}}
+<form method="GET" action="{{ route('leaves.edit') }}" class="mb-3">
+    <div class="card">
+        <div class="card-body p-2">
+            <div class="row g-2 align-items-end">
+                <div class="col-12 col-md-3">
+                    <label class="form-label small mb-1">Month</label>
+                    <input type="month" name="month" class="form-control form-control-sm"
+                        value="{{ $month }}">
+                </div>
+                <div class="col-12 col-md-4">
+                    <label class="form-label small mb-1">User</label>
+                    <select name="user_id" class="form-select form-select-sm">
+                        <option value="">—</option>
+                        @foreach($userOptions as $u)
+                        <option value="{{ $u->id }}" @selected(request('user_id')==$u->id)>
+                            {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
+                        </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-12 col-md-2">
+                    <button class="btn btn-sm btn-primary w-100">Search</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>
+
+@if($leaves->count())
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+    @foreach($leaves as $leave)
+    @php
+    $now = now();
+    $diffUpdated = $leave->updated_at?->diffInMinutes($now);
+    $isNew = $leave->created_at && $leave->created_at->equalTo($leave->updated_at);
+    $cls =
+    $isNew ? 'text-success'
+    : (($diffUpdated ?? 10_000) <= 10 ? 'text-danger'
+        : (($diffUpdated ?? 10_000) <=30 ? 'text-warning'
+        : (($diffUpdated ?? 10_000) <=60 ? 'text-dark' : 'text-muted' )));
+        $action=$isNew ? 'Created' : 'Updated' ;
+        $time=optional($leave->updated_at)->format('Y-m-d H:i');
+        @endphp
+
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <div class="card h-100 shadow-sm">
+                {{-- まだ保存先ルート未定のため actionは空。後で PUT/PATCH に差し替え可能 --}}
+                <form class="h-100 d-flex flex-column js-leave-form"
+                    data-leave-id="{{ $leave->id }}">
+                    @csrf
+                    {{-- @method('PUT') ← 更新ルート作成後に有効化 --}}
+
+                    <div class="card-body p-2 light-blue">
+                        <div class="mb-0 d-grid gap-0">
+                            {{-- 0: User --}}
+                            <div class="mb-0">
+                                <label class="form-label small mb-0">User</label>
+                                <select name="user_id" class="form-select form-select-sm">
+                                    @foreach($userOptions as $u)
+                                    <option value="{{ $u->id }}" @selected($leave->user_id===$u->id)>
+                                        {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
+                                    </option>
+                                    @endforeach
+                                </select>
+                            </div>
+
+                            {{-- 1: Kind / Status --}}
+                            <div class="row g-1 mb-0">
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Kind</label>
+                                    <select name="kind" class="form-select form-select-sm">
+                                        @foreach($kindOptions as $v => $label)
+                                        <option value="{{ $v }}" @selected($leave->kind===$v)>{{ $label }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Status</label>
+                                    <select name="status" class="form-select form-select-sm">
+                                        @foreach($statusOptions as $v => $label)
+                                        <option value="{{ $v }}" @selected($leave->status===$v)>{{ $label }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+
+                            {{-- 2: Excused / Special Type --}}
+                            <div class="row g-1 mb-0">
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Excused</label>
+                                    <select name="excused" class="form-select form-select-sm">
+                                        @foreach($excusedOptions as $v => $label)
+                                        <option value="{{ $v }}" @selected($leave->excused===$v)>{{ $label }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Special Type</label>
+                                    <input type="text" name="special_type" class="form-control form-control-sm"
+                                        value="{{ old('special_type', $leave->special_type) }}"
+                                        placeholder="Details for special leave">
+                                </div>
+                            </div>
+
+                            {{-- 3: Dates --}}
+                            <div class="row g-1 mb-0">
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Start Date</label>
+                                    <input type="date" name="start_date" class="form-control form-control-sm"
+                                        value="{{ old('start_date', $fmtDate($leave->start_date)) }}">
+                                </div>
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">End Date (Optional)</label>
+                                    <input type="date" name="end_date" class="form-control form-control-sm"
+                                        value="{{ old('end_date', $fmtDate($leave->end_date)) }}">
+                                </div>
+                            </div>
+
+                            {{-- 4: Times --}}
+                            <div class="row g-1 mb-0">
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Time Start (Optional)</label>
+                                    <input type="time" name="time_start" class="form-control form-control-sm"
+                                        value="{{ old('time_start', $fmtTime($leave->time_start)) }}"
+                                        inputmode="numeric" step="60">
+                                </div>
+                                <div class="col-6">
+                                    <label class="form-label small mb-0">Time End (Optional)</label>
+                                    <input type="time" name="time_end" class="form-control form-control-sm"
+                                        value="{{ old('time_end', $fmtTime($leave->time_end)) }}"
+                                        inputmode="numeric" step="60">
+                                </div>
+                            </div>
+
+                            {{-- 5: Reason --}}
+                            <div class="mb-0">
+                                <label class="form-label small mb-0">Reason</label>
+                                <textarea name="reason" class="form-control form-control-sm" rows="2"
+                                    placeholder="理由">{{ old('reason', $leave->reason) }}</textarea>
+                            </div>
+
+                            {{-- 6: Handle Type --}}
+                            <div class="mb-0">
+                                <label class="form-label small mb-0">Handle Type</label>
+                                <input type="text" name="handle_type" class="form-control form-control-sm"
+                                    value="{{ old('handle_type', $leave->handle_type) }}"
+                                    placeholder="後日調整、給与控除等の備考">
+                            </div>
+                        </div>
+
+                        {{-- フッタ操作（後でルート紐付け可） --}}
+                        <div class="card-footer bg-white d-flex justify-content-between align-items-center py-2 px-2 gap-1 mt-2">
+                            {{-- 削除ボタン --}}
+                            <button type="button"
+                                class="btn btn-sm btn-outline-danger js-delete-leave"
+                                data-url="{{ route('leaves.destroy', $leave) }}">
+                                削除
+                            </button>
+
+                            {{-- 保存ボタン --}}
+                            <button type="button"
+                                class="btn btn-sm btn-primary js-save-leave"
+                                data-url="{{ route('leaves.update', $leave) }}">
+                                保存
+                            </button>
+                        </div>
+
+                        <small class="{{ $cls }} text-left d-block mt-1">
+                            {{ $action }}: {{ $time }}
+                        </small>
+                    </div>
+                </form>
+            </div>
+        </div>
+        @endforeach
+</div>
+@else
+<div class="alert alert-light border">
+    対象月（{{ $periodStart->format('Y-m-d') }}〜{{ $periodEnd->format('Y-m-d') }}）に該当する休暇はありません。
+</div>
+@endif
+
+{{-- Ajax保存/削除 --}}
+@push('scripts')
+<script>
+document.addEventListener('click', async (e) => {
+  const saveBtn = e.target.closest('.js-save-leave');
+  const deleteBtn = e.target.closest('.js-delete-leave');
+
+  // 保存処理
+  if (saveBtn) {
+    const url = saveBtn.dataset.url;
+    const card = saveBtn.closest('.card');
+    const form = card.querySelector('form.js-leave-form');
+    const data = Object.fromEntries(new FormData(form));
+
+    if (!url) return alert('URLが設定されていません。');
+    if (!confirm('この内容で保存しますか？')) return;
+
+    try {
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify(data)
+      });
+      const json = await res.json();
+
+      if (res.ok && json.ok) {
+        alert('保存しました。');
+        location.reload();
+      } else {
+        alert('保存に失敗しました。\n' + (json.message || 'Validation error'));
+        console.error(json);
+      }
+    } catch (err) {
+      console.error(err);
+      alert('通信エラーが発生しました。');
+    }
+  }
+
+  // 削除処理
+  if (deleteBtn) {
+    const url = deleteBtn.dataset.url;
+    if (!url) return alert('URLが設定されていません。');
+    if (!confirm('この休暇データを削除しますか？')) return;
+
+    try {
+      const res = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+          'Accept': 'application/json'
+        }
+      });
+      const json = await res.json();
+
+      if (res.ok && json.ok) {
+        alert('削除しました。');
+        location.reload();
+      } else {
+        alert('削除に失敗しました。\n' + (json.message || 'Error'));
+        console.error(json);
+      }
+    } catch (err) {
+      console.error(err);
+      alert('通信エラーが発生しました。');
+    }
+  }
+});
+</script>
+@endpush
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -174,10 +174,22 @@ Route::middleware(['auth','role:admin|super_admin'])->group(function () {
     Route::post('/events',        [EventAssignController::class, 'store'])->name('events.store');
     Route::post('/events/blank', [EventAssignController::class, 'storeBlank'])->name('events.store.blank');
     Route::put('/events/{event}', [EventAssignController::class, 'update'])->name('events.update');
-    // ★ 追加：一括更新（このページに表示されている分だけ送る）
+    // ★ 一括更新（このページに表示されている分だけ送る）
     Route::post('/events/bulk-update', [EventAssignController::class, 'bulkUpdate'])->name('events.bulk_update');
     Route::delete('/events/{event}', [EventAssignController::class, 'destroy'])->name('events.destroy');
     Route::post('/leaves',        [LeaveController::class, 'store'])->name('leaves.store');
+});
+
+use App\Http\Controllers\LeaveManageController;
+
+Route::middleware(['auth','role:admin|super_admin'])->group(function () {
+    Route::get('/leave_manager', [LeaveManageController::class, 'edit'])->name('leaves.edit');
+    Route::post('/leaves/blank', [LeaveManageController::class, 'storeBlank'])->name('leaves.store.blank');
+    Route::put('/leaves/{leave}', [LeaveManageController::class, 'update'])->name('leaves.update');
+    // ★ 一括更新（このページに表示されている分だけ送る）
+    Route::post('/leaves/bulk-update', [LeaveManageController::class, 'bulkUpdate'])->name('leaves.bulk_update');
+    Route::delete('/leaves/{leave}', [LeaveManageController::class, 'destroy'])->name('leaves.destroy');
+    Route::post('/detailLeaves',        [LeaveController::class, 'detailStore'])->name('leaves.store');
 });
 
 use App\Http\Controllers\SchoolProfileController;

--- a/routes/web.php
+++ b/routes/web.php
@@ -191,6 +191,12 @@ Route::middleware(['auth','role:admin|super_admin'])->group(function () {
     Route::delete('/leaves/{leave}', [LeaveManageController::class, 'destroy'])->name('leaves.destroy');
 });
 
+// Absence Report
+Route::middleware(['auth'])->group(function () {
+    Route::get('/absence_report/{user}', [LeaveController::class, 'absence'])->name('absence.edit');
+    Route::put('/handle_type/{leave}', [LeaveController::class, 'report'])->name('report.update');
+});
+
 use App\Http\Controllers\SchoolProfileController;
 
 Route::get('/schools/search', [SchoolProfileController::class, 'search'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,15 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
         ->name('calendar.forecast.events');
 });
 
+// LeaveCalender関連
+Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
+    Route::get('/leave', [CalendarController::class, 'Leave'])
+        ->name('calendar.leaves');
+
+    Route::get('/leave/events', [CalendarController::class, 'LeaveEvents']) //KSON
+        ->name('calendar.leave.events');
+});
+
 Route::middleware(['auth'])->group(function () {
     // 申請画面（本人用）
     Route::get('/leaveApply', [LeaveApplyController::class, 'create'])->name('leave.apply.create');

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,7 +189,6 @@ Route::middleware(['auth','role:admin|super_admin'])->group(function () {
     // ★ 一括更新（このページに表示されている分だけ送る）
     Route::post('/leaves/bulk-update', [LeaveManageController::class, 'bulkUpdate'])->name('leaves.bulk_update');
     Route::delete('/leaves/{leave}', [LeaveManageController::class, 'destroy'])->name('leaves.destroy');
-    Route::post('/detailLeaves',        [LeaveController::class, 'detailStore'])->name('leaves.store');
 });
 
 use App\Http\Controllers\SchoolProfileController;


### PR DESCRIPTION
## [statusをapprovedに制限する](https://github.com/Jin6hara/LaravelSprout/commit/46ee3f6ee729d28772b44e419becd5e32dc98ba2)
- 元々ユーザーカレンダーの欠席表示、snapshotの発火はstatusがapprovedの場合のみの設定。
- Absenseに関しては後処理が必要の為例外に取り扱おうと思ったが、status選択の事故率高い気がするのでstatusを凍結。例えば欠席作ったのに、誤ってpending (後処理必要の為) にしたためイベント作成されてない→**サブ送ってない**（事故）。
- ユーザーの後処理にapproved感を与えるの大事なため、判定はイベント枠とreasonとhandle type両方!nullかどうかにしようと思う。
- 現状statusはhiddenで常にapprovedすることにした。