### PR TITLE
PosgreSQL向けの修正

### DIFF
--- a/database/migrations/2025_08_24_202517_create_holidays_table.php
+++ b/database/migrations/2025_08_24_202517_create_holidays_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -23,6 +24,10 @@ return new class extends Migration
             $table->json('meta')->nullable();
             $table->timestamps();
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "holidays" add constraint "holidays_year_non_negative" check ("year" >= 0)');
+        }
     }
 
     /**

--- a/database/migrations/2025_08_29_203249_create_schedules_table.php
+++ b/database/migrations/2025_08_29_203249_create_schedules_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -40,6 +41,10 @@ return new class extends Migration
             $t->index(['schedule_id', 'dow', 'effective_start', 'effective_end'], 'sch_line_idx');
             $t->index(['school_name', 'effective_start', 'effective_end'], 'sch_line_school_period_idx');
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "schedules" add constraint "schedules_total_minutes_non_negative" check ("total_minutes" >= 0)');
+        }
     }
 
     /**
@@ -47,7 +52,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('schedules');
         Schema::dropIfExists('schedule_lines');
+        Schema::dropIfExists('schedules');
     }
 };

--- a/database/migrations/2025_09_04_104502_create_lessons_table.php
+++ b/database/migrations/2025_09_04_104502_create_lessons_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -19,6 +20,10 @@ return new class extends Migration
             $t->enum('lesson_type', ['kids','adults','break','other'])->default('other');
             $t->timestamps();
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "lessons" add constraint "lessons_lesson_minute_non_negative" check ("lesson_minute" >= 0)');
+        }
     }
 
     /**

--- a/database/migrations/2025_09_05_220435_create_leave_credits_table.php
+++ b/database/migrations/2025_09_05_220435_create_leave_credits_table.php
@@ -37,7 +37,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('leave_credits');
         Schema::dropIfExists('leave_credit_transactions');
+        Schema::dropIfExists('leave_credits');
     }
 };

--- a/database/migrations/2025_09_17_144321_create_commuting_expenses_table.php
+++ b/database/migrations/2025_09_17_144321_create_commuting_expenses_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use App\Enums\ExpenseReportStatus;
 use App\Enums\ExpenseCategory;
@@ -93,6 +94,15 @@ return new class extends Migration
             // 同一レポート内で、日付＋並び順の組み合わせは一意
             $t->index(['expense_report_id', 'expense_date', 'seq']);
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "expense_reports" add constraint "expense_reports_year_non_negative" check ("year" >= 0)');
+            DB::statement('alter table "expense_reports" add constraint "expense_reports_month_non_negative" check ("month" >= 0)');
+            DB::statement('alter table "expense_reports" add constraint "expense_reports_total_amount_non_negative" check ("total_amount" >= 0)');
+            DB::statement('alter table "commuter_passes" add constraint "commuter_passes_cost_non_negative" check ("cost" >= 0)');
+            DB::statement('alter table "expenses" add constraint "expenses_seq_non_negative" check ("seq" >= 0)');
+            DB::statement('alter table "expenses" add constraint "expenses_cost_non_negative" check ("cost" >= 0)');
+        }
     }
 
     /**
@@ -100,8 +110,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('expense_reports');
-        Schema::dropIfExists('commuter_passes');
         Schema::dropIfExists('expenses');
+        Schema::dropIfExists('commuter_passes');
+        Schema::dropIfExists('expense_reports');
     }
 };

--- a/database/migrations/2025_10_17_145008_create_schools_table.php
+++ b/database/migrations/2025_10_17_145008_create_schools_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -56,6 +57,11 @@ return new class extends Migration
             $t->index(['school_profile_id', 'sort_order']);
             $t->index('station_name'); // 名前での簡易検索用（任意）
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "school_stations" add constraint "school_stations_walk_minutes_non_negative" check ("walk_minutes" >= 0)');
+            DB::statement('alter table "school_stations" add constraint "school_stations_sort_order_non_negative" check ("sort_order" >= 0)');
+        }
     }
 
     /**
@@ -63,8 +69,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('schools');
-        Schema::dropIfExists('school_profiles');
         Schema::dropIfExists('school_stations');
+        Schema::dropIfExists('school_profiles');
+        Schema::dropIfExists('schools');
     }
 };

--- a/database/migrations/2025_10_31_141221_create_subs_table.php
+++ b/database/migrations/2025_10_31_141221_create_subs_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -33,6 +34,10 @@ return new class extends Migration
             // よく使う検索用に複合インデックス
             $t->index(['user_id', 'sub_date']);
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "subs" add constraint "subs_total_duration_non_negative" check ("total_duration" >= 0)');
+        }
     }
 
     /**

--- a/database/migrations/2025_10_31_230559_create_route_declarations_table.php
+++ b/database/migrations/2025_10_31_230559_create_route_declarations_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
@@ -54,11 +55,15 @@ return new class extends Migration {
             // パフォーマンス系
             $t->index(['route_declaration_id', 'dow']);
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "route_details" add constraint "route_details_amount_non_negative" check ("amount" >= 0)');
+        }
     }
 
     public function down(): void
     {
-        Schema::dropIfExists('route_declarations');
         Schema::dropIfExists('route_details');
+        Schema::dropIfExists('route_declarations');
     }
 };

--- a/database/migrations/2025_11_08_143250_create_post_related_tables.php
+++ b/database/migrations/2025_11_08_143250_create_post_related_tables.php
@@ -54,8 +54,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('posts');
-        Schema::dropIfExists('post_user');
         Schema::dropIfExists('comments');
+        Schema::dropIfExists('post_user');
+        Schema::dropIfExists('posts');
     }
 };

--- a/database/migrations/2025_11_08_143638_create_attachments_table.php
+++ b/database/migrations/2025_11_08_143638_create_attachments_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -18,6 +19,10 @@ return new class extends Migration
             $t->unsignedBigInteger('size')->nullable();
             $t->timestamps();
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "attachments" add constraint "attachments_size_non_negative" check ("size" >= 0)');
+        }
     }
 
     /**


### PR DESCRIPTION
## MySQL→PostgreSQLに対応するための変更
- 変更前migrate:refresh --seedなどで外部キー制約に引っかかっていたが、downの順番を変更することにより解決