### PR TITLE
Fix/dd id calendar resolver

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -54,15 +54,6 @@ class CalendarController extends Controller
 
             $user = User::findOrFail($targetUserId);
 
-            // admin: district/department スコープ内ユーザーのみ閲覧可
-            if ($viewer->hasRole(['admin', 'super_admin'])) {
-                $did = $this->scopeService->currentDistrictId();
-                $dep = $this->scopeService->currentDepartmentId();
-                if (($did && $user->district_id !== $did) || ($dep && $user->department_id !== $dep)) {
-                    abort(404);
-                }
-            }
-
             $events = $resolver->build($user, $start, $end);
             return response()->json($events);
         } catch (\Throwable $e) {

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -17,10 +17,18 @@ class CalendarController extends Controller
     public function index(Request $request, ?User $user = null)
     {
         $viewer = Auth::user();
-        $viewUser = $user ?? $viewer; // 自分
-        // general は自分のみ、admin/super_admin は誰でも
-        if (!$viewer->hasRole(['admin', 'super_admin']) && $viewUser->id !== $viewer->id) {
+        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
+        $viewUser = $user ?? ($isAdmin ? null : $viewer);
+        if (!$isAdmin && ($viewUser?->id !== $viewer->id)) {
             abort(403);
+        }
+
+        // スコープが切り替わった後に古いユーザーのURLが残っている場合はリセット
+        if ($isAdmin && $viewUser !== null) {
+            $currentDid = $this->scopeService->currentDistrictId();
+            if ($currentDid !== null && $viewUser->district_id !== $currentDid) {
+                return redirect()->route('calendar.index');
+            }
         }
 
         // 管理者だけにセレクト用リストを渡す（district/department で直接絞り込み）
@@ -48,6 +56,18 @@ class CalendarController extends Controller
             $viewer = Auth::user();
             $start = Carbon::parse($request->query('start', now()->startOfYear()))->startOfDay();
             $end   = Carbon::parse($request->query('end',   now()->endOfYear()))->endOfDay();
+
+            $rawUserId = $request->query('user_id');
+            $noUserSelected = $rawUserId === null || $rawUserId === '' || $rawUserId === 'null' || (int)$rawUserId <= 0;
+
+            if ($noUserSelected && $viewer->hasRole(['admin', 'super_admin'])) {
+                $holidays = app(\App\Services\Calendar\Providers\HolidayProvider::class)->provide($viewer, $start, $end);
+                $closures = app(\App\Services\Calendar\Providers\ClosureProvider::class)->provide($viewer, $start, $end);
+                $holidayDates = array_flip(array_map(fn($e) => $e->dateKey, $holidays));
+                $filteredClosures = array_filter($closures, fn($e) => !isset($holidayDates[$e->dateKey]));
+                $events = array_map(fn($e) => $e->toArray(), array_merge($holidays, array_values($filteredClosures)));
+                return response()->json($events);
+            }
 
             $targetUserId = (int) $request->query('user_id', $viewer->id);
             if (!$viewer->hasRole(['admin', 'super_admin']) && $targetUserId !== $viewer->id) abort(403);

--- a/public/js/fullcalendar.js
+++ b/public/js/fullcalendar.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function () {
         editable: false,
         events: {
             url: window.calendarEventsUrl, // テンプレート埋め込み用
-            extraParams: { user_id: window.calendarUserId }, // テンプレート埋め込み用
+            extraParams: window.calendarUserId != null ? { user_id: window.calendarUserId } : {}, // テンプレート埋め込み用
             failure: () => console.warn('Calendar: イベントの取得に失敗しました'),
             error: (xhr) => console.error('FC error:', xhr?.xhr?.responseText || xhr)
         },

--- a/public/js/fullcalendar.js
+++ b/public/js/fullcalendar.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', function () {
         events: {
             url: window.calendarEventsUrl, // テンプレート埋め込み用
             extraParams: { user_id: window.calendarUserId }, // テンプレート埋め込み用
-            failure: () => alert('イベント取得に失敗しました'),
+            failure: () => console.warn('Calendar: イベントの取得に失敗しました'),
             error: (xhr) => console.error('FC error:', xhr?.xhr?.responseText || xhr)
         },
         // 週の日付表示制御

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -5,7 +5,7 @@
   <h2 class="mb-0">Schedule</h2>
   {{-- 役割ヒント --}}
   @role('admin|super_admin')
-  <span class="badge text-bg-primary">Admin View: {{ $viewUser->name ?? ('ID:'.$viewUser->id) }}</span>
+  <span class="badge text-bg-primary">Admin View: {{ $viewUser ? ($viewUser->name ?? 'ID:'.$viewUser->id) : '（未選択）' }}</span>
   @else
   <span class="badge text-bg-secondary">Schedule</span>
   @endrole
@@ -35,7 +35,7 @@
         <option value="">（選択）</option>
         @foreach($userOptions as $u)
           <option value="{{ $u->employee_code }}"
-            @selected((string)($viewUser->employee_code) === (string)$u->employee_code)>
+            @selected($viewUser && (string)$viewUser->employee_code === (string)$u->employee_code)>
             {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
           </option>
         @endforeach
@@ -75,7 +75,7 @@
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js"></script>
 <script>
   window.calendarEventsUrl = "{{ route('calendar.events') }}";
-  window.calendarUserId    = @json($viewUser->id);
+  window.calendarUserId    = @json($viewUser?->id);
   window.initialDate       = "{{ request('month', now()->format('Y-m')) }}";
 </script>
 <script src="{{ asset('js/fullcalendar.js') }}"></script>


### PR DESCRIPTION
## 変更点の説明

### 問題（修正前の挙動）

近畿の管理者が関東スコープに切り替えてカレンダーを開くと、ユーザー未選択の状態でも管理者自身（近畿）の勤務データが表示されていた。

---

## 修正内容

### CalendarController.php

#### index() メソッド（2箇所）

未選択時の `$viewUser` を `null` に変更。

// 変更前: 未選択でも管理者自身になる
$viewUser = $user ?? $viewer;

// 変更後: 管理者は未選択をnullで表現
$viewUser = $user ?? ($isAdmin ? null : $viewer);

#### スコープ外ユーザーURLの自動リセット

`/calendar/000006` のような URL が残っていても、現在のスコープ（地域）と異なるユーザーであれば `/calendar` へリダイレクトするように修正。

---

### events() メソッド

ユーザーが未選択の場合（`user_id` が未送信・空・`"null"` 文字列・`0`）、管理者に対して祝日と Company Closure だけを返すように修正。

また、同じ日に祝日と Company Closure が重なる場合は祝日を優先する。

---

### fullcalendar.js

`calendarUserId` が `null` の場合は、`user_id` パラメータ自体を送信しないように修正。

// 変更前: calendarUserId=null でも user_id=null を送信していた
extraParams: { user_id: window.calendarUserId }

// 変更後: null のときはパラメータ自体を送らない
extraParams: window.calendarUserId != null ? { user_id: window.calendarUserId } : {}

---

### index.blade.php（3箇所）

`$viewUser` が `null` になり得るため、以下の3箇所を null-safe に修正。

- バッジ表示：未選択時に「（未選択）」と表示
- ドロップダウンの `@selected`：`$viewUser &&` のガードを追加
- JS変数：`$viewUser->id` → `$viewUser?->id`

---

## 結果

管理者が別地域スコープを開いた場合、ユーザー未選択状態では管理者自身の勤務データが表示されず、祝日と Company Closure のみが表示されるようになった。

また、スコープ外ユーザーのURLが残っている場合も自動的に `/calendar` に戻るため、異なる地域のユーザーデータが誤って表示されることを防止できる。