### PR TITLE
Adjustment/calendar js/0510

### DIFF
--- a/public/js/forecast.js
+++ b/public/js/forecast.js
@@ -1,12 +1,10 @@
 document.addEventListener('DOMContentLoaded', function () {
-    const savedView = localStorage.getItem('forecastCalendarView') || 'dayGridMonth';
+    const storedView = localStorage.getItem('forecastCalendarView');
+    const savedView = ['dayGridMonth', 'listWeek'].includes(storedView)
+        ? storedView
+        : 'dayGridMonth';
     const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
     const calendarEl = document.getElementById('calendar');
-    console.log('[] loaded - forecast.js:3');
-    function openSubModal(ev) {
-        console.log('[] openSubModal - forecast.js:5', ev.extendedProps);
-    }
-
     // ▼▼ Total Subs 明細モーダル ▼▼
     function openSubModal(ev) {
         const p = ev.extendedProps || {};
@@ -119,7 +117,7 @@ document.addEventListener('DOMContentLoaded', function () {
         displayEventTime: false, //Listの時間を表示しない
         nowIndicator: true,
         validRange: { start: '2025-04-01', end: '' },
-        editable: true, //eventDrop: (info) => updateEvent(info.event), // ← updateもできるらしい
+        editable: false,
         //その他面白い機能：selectable, selectMirror, dayMaxEvents, weekends, businessHours, etc.
 
         views: {

--- a/public/js/forecast.js
+++ b/public/js/forecast.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
+    const savedView = localStorage.getItem('forecastCalendarView') || 'dayGridMonth';
+    const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
     const calendarEl = document.getElementById('calendar');
     console.log('[] loaded - forecast.js:3');
     function openSubModal(ev) {
@@ -101,8 +103,8 @@ document.addEventListener('DOMContentLoaded', function () {
     // ▼▼ FullCalendar 初期化 ▼▼
     const calendar = new FullCalendar.Calendar(calendarEl, {
         locale: 'en',
-        initialView: 'dayGridMonth',
-        initialDate: window.initialDate,
+        initialView: savedView,
+        initialDate: savedDate,
         height: 'auto',
         firstDay: 0,
         slotDuration: '00:10:00',
@@ -122,9 +124,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
         views: {
             listWeek: {
-                listDayFormat: { weekday: 'long' }, // Monday のように
-                listDaySideFormat: { month: 'short', day: 'numeric' } // Jan 1 のように
+                listDayFormat: {
+                    weekday: 'long',
+                    month: 'short',
+                    day: 'numeric'
+                },
+                listDaySideFormat: false
             }
+        },
+
+        datesSet(info) {
+            localStorage.setItem('forecastCalendarView', info.view.type);
+            localStorage.setItem('forecastCalendarDate', info.startStr);
         },
 
         events: {

--- a/public/js/fullcalendar.js
+++ b/public/js/fullcalendar.js
@@ -1,4 +1,10 @@
 document.addEventListener('DOMContentLoaded', function () {
+    const storedView = localStorage.getItem('forecastCalendarView');
+    const savedView = ['dayGridMonth', 'listWeek'].includes(storedView)
+        ? storedView
+        : 'dayGridMonth';
+    const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
+
     // ▼▼ これによりLessonの終了時間を計算 ▼▼
     // HH:MM 形式の文字列に分数を加算して HH:MM 形式で返す
     function addMinutesToHHMM(hhmm, minutes) {
@@ -17,52 +23,72 @@ document.addEventListener('DOMContentLoaded', function () {
     const calendarEl = document.getElementById('calendar');
     const calendar = new FullCalendar.Calendar(calendarEl, {
         locale: 'en',
-        initialView: 'dayGridMonth',
-        initialDate: window.initialDate,
+        initialView: savedView,
+        initialDate: savedDate,
         height: 'auto',
         firstDay: 0,
+
         // 10分単位でスロットを区切る
         slotDuration: '00:10:00',
+
         // ラベルを 09:00, 09:10, … のように24h表記
         slotLabelFormat: {
             hour: '2-digit',
             minute: '2-digit',
             hour12: false
         },
+
         // 表示範囲を制限
         slotMinTime: '09:00:00',
         slotMaxTime: '23:00:00',
+
         eventOrder: "extendedProps.category,title,start",
+
         headerToolbar: {
             left: 'prev,next today',
             center: 'title',
-            right: 'dayGridMonth,timeGridWeek,listWeek'
+            // right: 'dayGridMonth,timeGridWeek,listWeek',
+            right: 'dayGridMonth,listWeek'
         },
+
         //buttonText: { today: '今日', month: '月', week: '週', day: '日', list: 'リスト' },
+
         dayMaxEventRows: true,
         navLinks: true,
         nowIndicator: true,
         editable: false,
+
         events: {
             url: window.calendarEventsUrl, // テンプレート埋め込み用
             extraParams: window.calendarUserId != null ? { user_id: window.calendarUserId } : {}, // テンプレート埋め込み用
             failure: () => console.warn('Calendar: イベントの取得に失敗しました'),
             error: (xhr) => console.error('FC error:', xhr?.xhr?.responseText || xhr)
         },
+
         // 週の日付表示制御
-        dayCellContent(info) {
-            if (info.view.type === 'dayGridMonth') {
-                return info.date.getDate();      // 月表示だけ日付数字
+        views: {
+            listWeek: {
+                listDayFormat: {
+                    weekday: 'long',
+                    month: 'short',
+                    day: 'numeric'
+                },
+                listDaySideFormat: false
             }
-            return { html: '' };               // timeGrid(週/日)では描画しない
         },
+
+        datesSet(info) {
+            localStorage.setItem('forecastCalendarView', info.view.type);
+            localStorage.setItem('forecastCalendarDate', info.startStr);
+        },
+
         eventContent: function (arg) {
             return { html: arg.event.title };
         },
 
         eventClick(info) {
-
             info.jsEvent.preventDefault();
+
             const e = info.event;
             const p = e.extendedProps || {};
             let html = `<div class="mb-2"><strong>${e.title}</strong></div>`;
@@ -83,7 +109,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 ${min != null ? `${min}分` : (d.lesson_type ?? '—')}
                 </span>`;
 
-                html += `<li class="list-group-item d-flex justify-content-between align-items-center">
+                    html += `<li class="list-group-item d-flex justify-content-between align-items-center">
                     <span>${range} ${name}${code}</span>
                 ${badge}
                 </li>`;
@@ -93,8 +119,11 @@ document.addEventListener('DOMContentLoaded', function () {
             } else {
                 // ▼▼ 詳細がないときは従来の簡易情報 ▼▼
                 //html += `<div>Type: ${p.kind ?? ''}</div>`;
+
                 if (p.closure_code) html += `<div>Category: ${p.closure_code}</div>`;
+
                 const fmt = d => d ? d.toLocaleDateString('ja-JP') : '';
+
                 //if (e.start || e.end) html += `<div>日付：${fmt(e.start)}${e.end ? ' 〜 ' + fmt(e.end) : ''}</div>`; //endは使わないので削除
                 if (e.start || e.end) html += `<div>Date: ${fmt(e.start)}</div>`;
             }   // ▲▲ 詳細がないときは従来の簡易情報 ▲▲
@@ -104,5 +133,6 @@ document.addEventListener('DOMContentLoaded', function () {
             modal.show();
         }
     });
+
     calendar.render();
 });

--- a/public/js/fullcalendar.js
+++ b/public/js/fullcalendar.js
@@ -1,9 +1,9 @@
 document.addEventListener('DOMContentLoaded', function () {
-    const storedView = localStorage.getItem('forecastCalendarView');
+    const storedView = localStorage.getItem('userCalendarView');
     const savedView = ['dayGridMonth', 'listWeek'].includes(storedView)
         ? storedView
         : 'dayGridMonth';
-    const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
+    const savedDate = localStorage.getItem('userCalendarDate') || window.initialDate;
 
     // ▼▼ これによりLessonの終了時間を計算 ▼▼
     // HH:MM 形式の文字列に分数を加算して HH:MM 形式で返す
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', function () {
         events: {
             url: window.calendarEventsUrl, // テンプレート埋め込み用
             extraParams: window.calendarUserId != null ? { user_id: window.calendarUserId } : {}, // テンプレート埋め込み用
-            failure: () => console.warn('Calendar: イベントの取得に失敗しました'),
+            failure: () => alert('イベント取得に失敗しました'),
             error: (xhr) => console.error('FC error:', xhr?.xhr?.responseText || xhr)
         },
 
@@ -78,8 +78,8 @@ document.addEventListener('DOMContentLoaded', function () {
         },
 
         datesSet(info) {
-            localStorage.setItem('forecastCalendarView', info.view.type);
-            localStorage.setItem('forecastCalendarDate', info.startStr);
+            localStorage.setItem('userCalendarView', info.view.type);
+            localStorage.setItem('userCalendarDate', info.startStr);
         },
 
         eventContent: function (arg) {
@@ -129,7 +129,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }   // ▲▲ 詳細がないときは従来の簡易情報 ▲▲
 
             document.getElementById('eventModalBody').innerHTML = html;
-            const modal = new bootstrap.Modal(document.getElementById('eventModal'));
+            const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('eventModal'));
             modal.show();
         }
     });

--- a/public/js/leave.js
+++ b/public/js/leave.js
@@ -1,12 +1,14 @@
 document.addEventListener('DOMContentLoaded', function () {
+    const savedView = localStorage.getItem('forecastCalendarView') || 'dayGridMonth';
+    const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
     const calendarEl = document.getElementById('calendar');
     console.log('[] loaded - leave.js:3');
 
     // ▼▼ FullCalendar 初期化（基本のみ）▼▼
     const calendar = new FullCalendar.Calendar(calendarEl, {
         locale: 'en',
-        initialView: 'dayGridMonth',
-        initialDate: window.initialDate,
+        initialView: savedView,
+        initialDate: savedDate,
         height: 'auto',
         firstDay: 0,
         slotDuration: '00:10:00',
@@ -14,7 +16,7 @@ document.addEventListener('DOMContentLoaded', function () {
         slotMinTime: '09:00:00',
         slotMaxTime: '23:00:00',
         eventOrder: "extendedProps.category,title,start",
-        headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,listWeek' },
+        headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,listMonth' },
         dayMaxEventRows: true,
         navLinks: true,
         displayEventTime: false, //Listの時間を表示しない
@@ -24,9 +26,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
         views: {
             listWeek: {
-                listDayFormat: { weekday: 'long' },
-                listDaySideFormat: { month: 'short', day: 'numeric' }
+                listDayFormat: {
+                    weekday: 'long',
+                    month: 'short',
+                    day: 'numeric'
+                },
+                listDaySideFormat: false
             }
+        },
+
+        datesSet(info) {
+            localStorage.setItem('forecastCalendarView', info.view.type);
+            localStorage.setItem('forecastCalendarDate', info.startStr);
         },
 
         events: {

--- a/public/js/leave.js
+++ b/public/js/leave.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', function () {
-    const savedView = localStorage.getItem('forecastCalendarView') || 'dayGridMonth';
-    const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
+    const storedView = localStorage.getItem('leaveCalendarView');
+    const savedView = ['dayGridMonth', 'listMonth'].includes(storedView)
+        ? storedView
+        : 'dayGridMonth';
+    const savedDate = localStorage.getItem('leaveCalendarDate') || window.initialDate;
     const calendarEl = document.getElementById('calendar');
     console.log('[] loaded - leave.js:3');
 
@@ -25,7 +28,7 @@ document.addEventListener('DOMContentLoaded', function () {
         editable: false,
 
         views: {
-            listWeek: {
+            listMonth: {
                 listDayFormat: {
                     weekday: 'long',
                     month: 'short',
@@ -36,8 +39,8 @@ document.addEventListener('DOMContentLoaded', function () {
         },
 
         datesSet(info) {
-            localStorage.setItem('forecastCalendarView', info.view.type);
-            localStorage.setItem('forecastCalendarDate', info.startStr);
+            localStorage.setItem('leaveCalendarView', info.view.type);
+            localStorage.setItem('leaveCalendarDate', info.startStr);
         },
 
         events: {


### PR DESCRIPTION
## 修正内容サマリー

### 🔴 Critical

#### localStorage キー衝突の解消

各カレンダーページで使用していた `localStorage` のキーを分離しました。

- `fullcalendar.js`
  - `userCalendarView`
  - `userCalendarDate`

- `leave.js`
  - `leaveCalendarView`
  - `leaveCalendarDate`

- `forecast.js`
  - 既存のまま
  - `forecastCalendarView`
  - `forecastCalendarDate`

これにより、3ページ間のビュー切り替え状態が独立します。  
たとえば `leave.js` 側で `listMonth` を選択しても、通常カレンダーや Forecast カレンダーに影響しなくなります。

#### モーダル重複インスタンス問題の修正

`fullcalendar.js` の Bootstrap Modal 生成処理を、毎回 `new bootstrap.Modal(...)` する形から、既存インスタンスを再利用する形に変更しました。

`bootstrap.Modal.getOrCreateInstance(...)`

これにより、モーダルの重複生成や backdrop が残る可能性を抑制します。

---

### 🟡 Important

| ファイル | 修正内容 |
|---|---|
| `forecast.js` | 空の重複 `openSubModal` 定義を削除 |
| `forecast.js` | `editable: true` を `editable: false` に変更 |
| `leave.js` | `views.listWeek` を `views.listMonth` に変更 |

#### forecast.js

空の `openSubModal` 定義が重複していたため削除しました。  
また、保存ハンドラが存在しない状態でイベントをドラッグ移動できてしまうのを防ぐため、`editable` を `false` に変更しました。

#### leave.js

`headerToolbar` 側で使用しているビューと整合するように、`views.listWeek` を `views.listMonth` に修正しました。

---

### 🟢 Minor

| ファイル | 修正内容 |
|---|---|
| `forecast.js` | `savedView` のバリデーションを追加 |
| `leave.js` | `savedView` のバリデーションを追加 |
| `fullcalendar.js` | events fetch failure 時に `alert` を追加 |

#### savedView バリデーション追加

`forecast.js` / `leave.js` に `savedView` のバリデーションを追加し、不正なビュー名が `localStorage` に残っていても安全に初期表示できるようにしました。

- `forecast.js`
  - `dayGridMonth`
  - `listMonth`

- `leave.js`
  - `dayGridMonth`
  - `listMonth`

#### failure 時の alert 追加

`fullcalendar.js` の events fetch failure 時にも `alert` を追加し、他のカレンダー系 JS とエラー表示の挙動を統一しました。

---

## 期待される効果

- 通常カレンダー / Leave カレンダー / Forecast カレンダー間で、表示ビューや表示日付の状態が干渉しなくなる
- Leave 側で `listMonth` を選んでも、他ページの表示が壊れなくなる
- Bootstrap Modal の重複インスタンス生成を防止できる
- Forecast カレンダーで保存処理のないドラッグ移動を防止できる
- 不正な `localStorage` 値による表示崩れを防止できる
