### PR TITLE
School Timetable ページの追加と schedule_details.note カラムの追加

### DIFF
--- a/app/Http/Controllers/ScheduleDetailController.php
+++ b/app/Http/Controllers/ScheduleDetailController.php
@@ -102,6 +102,7 @@ class ScheduleDetailController extends Controller
                 $v = Validator::make($raw, [
                     'lesson_code'     => ['required', 'string', 'max:255'],
                     'note'            => ['nullable', 'string', 'max:2000'],
+                    'detail_note'     => ['nullable', 'string', 'max:2000'],
                     'start_time'      => ['required', 'date_format:H:i'],
                     'effective_start' => ['required', 'date'],
                     'effective_end'   => ['nullable', 'date', 'after_or_equal:effective_start'],
@@ -126,6 +127,10 @@ class ScheduleDetailController extends Controller
                 $detail->effective_end   = isset($data['effective_end']) && $data['effective_end'] !== ''
                     ? Carbon::parse($data['effective_end'])->toDateString()
                     : null;
+                // schedule_details 固有のメモ（detail_note がリクエストに含まれる場合のみ更新）
+                if (array_key_exists('detail_note', $data)) {
+                    $detail->note = $data['detail_note'] ?? null;
+                }
                 $detail->save();
 
                 // 3) lesson の note を更新（画面の「note」は lessons.note を指す）

--- a/app/Http/Controllers/ScheduleLineController.php
+++ b/app/Http/Controllers/ScheduleLineController.php
@@ -262,14 +262,16 @@ class ScheduleLineController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'user_id' => ['nullable', 'exists:users,id'],
+            'user_id'     => ['nullable', 'exists:users,id'],
+            'school_name' => ['nullable', 'string', 'max:255'],
+            'dow'         => ['nullable', 'integer', 'between:0,6'],
         ]);
 
         $line = new ScheduleLine();
         $line->user_id         = $data['user_id'] ?? null;
         $line->total_minutes   = 0;
-        $line->dow             = 0;
-        $line->school_name     = '';
+        $line->dow             = $data['dow'] ?? 0;
+        $line->school_name     = $data['school_name'] ?? '';
         $line->start_time      = '00:00:00';
         $line->end_time        = '00:00:00';
         $line->effective_start = now()->toDateString();

--- a/app/Http/Controllers/SchoolTimetableController.php
+++ b/app/Http/Controllers/SchoolTimetableController.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ScheduleLine;
+use App\Models\School;
+use App\Services\CurrentScopeService;
+use Illuminate\Http\Request;
+use Carbon\Carbon;
+
+class SchoolTimetableController extends Controller
+{
+    public function __construct(private CurrentScopeService $scopeService) {}
+
+    public function index(Request $request)
+    {
+        $schoolName = trim((string)$request->input('school', ''));
+        $dow = $request->has('dow') && $request->input('dow') !== ''
+            ? (int)$request->input('dow')
+            : null;
+
+        $userOptions = $this->scopeService->targetUserQuery()
+            ->orderBy('family_name')
+            ->orderBy('first_name')
+            ->get(['id', 'first_name', 'family_name', 'employee_code'])
+            ->map(function ($u) {
+                $label = trim($u->family_name . ' ' . ($u->first_name ?? ''));
+                if (!empty($u->employee_code)) {
+                    $label .= " [{$u->employee_code}]";
+                }
+                return ['id' => $u->id, 'label' => $label];
+            })
+            ->values();
+
+        $dowOptions = [
+            0 => '日', 1 => '月', 2 => '火', 3 => '水', 4 => '木', 5 => '金', 6 => '土',
+        ];
+
+        $props = [
+            'initialSchool'      => $schoolName,
+            'initialDow'         => $dow,
+            'userOptions'        => $userOptions,
+            'dowOptions'         => $dowOptions,
+            'csrfToken'          => csrf_token(),
+            'apiLinesUrl'        => route('school_timetable.lines'),
+            'schoolsUrl'         => route('school_timetable.schools'),
+            'storeLinesUrl'      => route('schedule_lines.store'),
+            'bulkUpdateLinesUrl' => route('schedule_lines.bulk_update'),
+            'lessonByCodeUrl'    => url('/lessons/by-code'),
+        ];
+
+        return view('schedule.schoolTimetable', compact('props'));
+    }
+
+    // API: school_name（+ 任意で dow）で絞った schedule_lines + details を JSON で返す
+    public function lines(Request $request)
+    {
+        $schoolName = trim((string)$request->input('school', ''));
+        $activeOn   = $request->input('active_on', now()->toDateString());
+        $dow = $request->has('dow') && $request->input('dow') !== ''
+            ? (int)$request->input('dow')
+            : null;
+
+        if ($schoolName === '') {
+            return response()->json(['ok' => false, 'message' => 'school は必須です'], 422);
+        }
+
+        $activeDate = Carbon::parse($activeOn)->toDateString();
+
+        $query = ScheduleLine::query()
+            ->with([
+                'user:id,first_name,family_name,employee_code',
+                'details' => function ($q) use ($activeDate) {
+                    $q->with(['lesson:id,lesson_name,lesson_code,note,lesson_minute'])
+                      ->whereDate('effective_start', '<=', $activeDate)
+                      ->where(function ($q2) use ($activeDate) {
+                          $q2->whereDate('effective_end', '>=', $activeDate)
+                             ->orWhereNull('effective_end');
+                      })
+                      ->orderBy('start_time');
+                },
+            ])
+            ->where('district_id', $this->scopeService->currentDistrictId())
+            ->where('department_id', $this->scopeService->currentDepartmentId())
+            ->whereLikeInsensitive('school_name', $schoolName)
+            ->orderBy('dow')
+            ->orderBy('start_time');
+
+        if (!is_null($dow)) {
+            $query->where('dow', $dow);
+        }
+
+        if ($activeOn) {
+            $d = Carbon::parse($activeOn)->toDateString();
+            $query->whereDate('effective_start', '<=', $d)
+                  ->where(function ($q) use ($d) {
+                      $q->whereDate('effective_end', '>=', $d)
+                        ->orWhereNull('effective_end');
+                  });
+        }
+
+        $lines = $query->get()->map(function ($line) {
+            $user     = $line->user;
+            $userName = $user
+                ? trim(($user->family_name ?? '') . ' ' . ($user->first_name ?? ''))
+                : null;
+
+            return [
+                'id'              => $line->id,
+                'school_name'     => $line->school_name,
+                'user_id'         => $line->user_id,
+                'user_name'       => $userName,
+                'dow'             => $line->dow,
+                'start_time'      => substr((string)$line->start_time, 0, 5),
+                'end_time'        => substr((string)$line->end_time, 0, 5),
+                'total_minutes'   => $line->total_minutes,
+                'effective_start' => optional($line->effective_start)->toDateString(),
+                'effective_end'   => optional($line->effective_end)->toDateString(),
+                'handover_memo'   => $line->handover_memo,
+                'details'         => $line->details->map(function ($d) {
+                    $lesson = $d->lesson;
+                    return [
+                        'id'              => $d->id,
+                        'start_time'      => substr((string)$d->start_time, 0, 5),
+                        'lesson_id'       => $d->lesson_id,
+                        'lesson_code'     => $lesson->lesson_code ?? '',
+                        'lesson_name'     => $lesson->lesson_name ?? '',
+                        'lesson_minute'   => $lesson->lesson_minute ?? 0,
+                        'note'            => $lesson->note ?? '',
+                        'detail_note'     => $d->note ?? '',
+                        'effective_start' => optional($d->effective_start)->toDateString(),
+                        'effective_end'   => optional($d->effective_end)->toDateString(),
+                    ];
+                })->values(),
+            ];
+        });
+
+        return response()->json(['ok' => true, 'lines' => $lines]);
+    }
+
+    // API: school_code / school_name 一覧（datalist 用）
+    public function schools()
+    {
+        $schools = School::query()
+            ->where('is_active', true)
+            ->orderBy('school_name')
+            ->get(['school_code', 'school_name']);
+
+        return response()->json(['ok' => true, 'schools' => $schools]);
+    }
+}

--- a/app/Models/ScheduleDetail.php
+++ b/app/Models/ScheduleDetail.php
@@ -19,6 +19,7 @@ class ScheduleDetail extends Model
         'lesson_id',
         'effective_start',
         'effective_end',
+        'note',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_09_04_104506_create_schedule_details_table.php
+++ b/database/migrations/2025_09_04_104506_create_schedule_details_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             // ▼ 有効期間
             $t->date('effective_start');              // 必須
             $t->date('effective_end')->nullable();    // NULL=オープンエンド
+            $t->text('note')->nullable();             // 備考
 
             $t->timestamps();
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -33,3 +33,11 @@ if (inboxEl) {
     const props = inboxEl.dataset.props ? JSON.parse(inboxEl.dataset.props) : {};
     createApp(InboxBadge, props).mount(inboxEl);
 }
+
+import SchoolTimetable from './components/SchoolTimetable.vue';
+
+const stEl = document.getElementById('schoolTimetable');
+if (stEl) {
+    const props = stEl.dataset.props ? JSON.parse(stEl.dataset.props) : {};
+    createApp(SchoolTimetable, props).mount(stEl);
+}

--- a/resources/js/components/SchoolTimetable.vue
+++ b/resources/js/components/SchoolTimetable.vue
@@ -1,0 +1,961 @@
+<template>
+  <div class="st-root">
+    <!-- ===== 検索フォーム ===== -->
+    <div class="st-search-bar">
+      <label class="st-label">学校名</label>
+      <!-- datalist で school_code / school_name の候補を補助表示 -->
+      <input
+        v-model="schoolQuery"
+        list="stSchoolDatalist"
+        class="form-control form-control-sm st-school-input"
+        placeholder="部分一致で検索"
+        @keyup.enter="search"
+      />
+      <datalist id="stSchoolDatalist">
+        <option
+          v-for="s in schoolList"
+          :key="s.school_code"
+          :value="s.school_name"
+        >{{ s.school_code }} / {{ s.school_name }}</option>
+      </datalist>
+
+      <label class="st-label">曜日</label>
+      <!-- 未選択（null）= 全曜日 -->
+      <select v-model="dowFilter" class="form-select form-select-sm st-dow-select">
+        <option :value="null">全曜日</option>
+        <option v-for="(label, val) in dowOptions" :key="val" :value="Number(val)">{{ label }}</option>
+      </select>
+
+      <label class="st-label">基準日</label>
+      <input
+        v-model="activeOn"
+        type="date"
+        class="form-control form-control-sm st-date-input"
+      />
+      <button class="btn btn-primary btn-sm" @click="search">検索</button>
+      <button class="btn btn-success btn-sm" @click="addLine" :disabled="!searched">+ 新規 Line</button>
+    </div>
+
+    <!-- ===== メッセージ ===== -->
+    <div v-if="message" :class="['alert', 'alert-sm', 'py-1', 'px-2', 'mt-1', msgOk ? 'alert-success' : 'alert-danger']">
+      {{ message }}
+    </div>
+
+    <!-- ===== 2ペイン分割レイアウト ===== -->
+    <div v-if="lines.length" class="st-split">
+
+      <!-- ===== 上ペイン: Timetable Grid ===== -->
+      <div class="st-pane-grid" :style="{ height: gridPaneHeight + 'px' }">
+        <div class="st-section-title st-section-title--pane">Time Grid（9:30〜22:30）</div>
+        <!-- st-grid-outer のみ overflow-x: auto。ラベル列は sticky で固定 -->
+        <div class="st-grid-outer">
+        <!-- ヘッダー行 -->
+        <div class="st-grid-header">
+          <div class="st-row-label st-row-label--header"></div>
+          <div class="st-time-header">
+            <div
+              v-for="h in timeHeaderMarks"
+              :key="h.label"
+              class="st-time-mark"
+              :style="{
+                left:      h.leftPx + 'px',
+                transform: h.anchor === 'left'  ? 'translateX(0)'
+                         : h.anchor === 'right' ? 'translateX(-100%)'
+                         : 'translateX(-50%)'
+              }"
+            >{{ h.label }}</div>
+          </div>
+        </div>
+        <!-- 各 line 行 -->
+        <div v-for="line in lines" :key="line.id" class="st-grid-row">
+          <div class="st-row-label">
+            <div class="st-label-dow">{{ dowLabel(line.dow) }}</div>
+            <div class="st-label-user">{{ line.user_name || 'No User' }}</div>
+            <div class="st-label-id">#{{ line.id }}</div>
+            <div class="st-label-time">{{ line.start_time }}–{{ line.end_time }}</div>
+          </div>
+          <div class="st-cells-wrap">
+            <!-- grid 背景（CSS gradient で正確にピクセルを描画） -->
+            <div class="st-cells-bg"></div>
+            <!-- event blocks（範囲内のみ） -->
+            <div class="st-events">
+              <template v-for="d in line.details" :key="d.id">
+                <div
+                  v-if="!isOutOfRange(d)"
+                  class="st-event"
+                  :style="eventStyle(d)"
+                  :title="`${d.lesson_code} ${d.lesson_name} ${d.start_time} (${d.lesson_minute || 5}min)`"
+                  @click="activeDetail = d"
+                >
+                  <span v-if="d.detail_note" class="st-event-note-dot"></span>
+                  <span class="st-event-code">{{ d.lesson_code }}</span>
+                  <span class="st-event-name">{{ d.lesson_name }}</span>
+                  <span class="st-event-time">{{ d.start_time }}</span>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+        <!-- 範囲外 warning -->
+        <div v-if="hasOutOfRange" class="st-oor-warning">
+          ⚠ 9:30〜22:30 の範囲外の Detail が存在します（グリッド外のため省略表示）
+        </div>
+        </div><!-- /st-grid-outer -->
+      </div><!-- /st-pane-grid -->
+
+      <!-- 中央リサイズハンドル（グリッド高さを変更） -->
+      <div class="st-resize-handle" @mousedown="startResizePane($event, 'gridPaneHeight')">
+        <span class="st-resize-grip">&#8942;&#8942;&#8942;</span>
+      </div>
+
+      <!-- ===== 下ペイン: Lines Editor ===== -->
+      <div class="st-pane-lines" :style="{ height: linesPaneHeight + 'px' }">
+        <div class="st-section-title st-section-title--pane">Schedule Lines</div>
+      <div v-for="line in lines" :key="'ed-' + line.id" class="st-line-block">
+
+        <!-- Line header -->
+        <div class="st-line-header">
+          <span class="st-line-id">#{{ line.id }}</span>
+          <span class="st-line-school">{{ line.school_name }}</span>
+          <div class="ms-auto d-flex gap-1">
+            <button class="btn btn-sm btn-primary" @click="saveLine(line)">Line 保存</button>
+            <button class="btn btn-sm btn-outline-danger" @click="deleteLine(line)">削除</button>
+          </div>
+        </div>
+
+        <!-- Line fields -->
+        <div class="st-line-fields">
+          <div class="st-field-group">
+            <label class="st-label">学校名</label>
+            <input v-model="line.school_name" class="form-control form-control-sm" />
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">担当者</label>
+            <select v-model="line.user_id" class="form-select form-select-sm">
+              <option :value="null">（未割当）</option>
+              <option v-for="u in userOptions" :key="u.id" :value="u.id">{{ u.label }}</option>
+            </select>
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">曜日</label>
+            <select v-model="line.dow" class="form-select form-select-sm">
+              <option v-for="(label, val) in dowOptions" :key="val" :value="Number(val)">{{ label }}</option>
+            </select>
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">開始</label>
+            <input v-model="line.start_time" type="time" class="form-control form-control-sm" />
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">終了</label>
+            <input v-model="line.end_time" type="time" class="form-control form-control-sm" />
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">合計分</label>
+            <span class="form-control-sm d-block">{{ line.total_minutes }}</span>
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">有効開始</label>
+            <input v-model="line.effective_start" type="date" class="form-control form-control-sm" />
+          </div>
+          <div class="st-field-group">
+            <label class="st-label">有効終了</label>
+            <input v-model="line.effective_end" type="date" class="form-control form-control-sm" />
+          </div>
+        </div>
+
+        <!-- Details -->
+        <div class="st-details-area">
+          <div class="st-details-header">
+            <span>Details</span>
+            <button class="btn btn-sm btn-outline-secondary" @click="addDetail(line)">+ Add Detail</button>
+            <button class="btn btn-sm btn-primary" @click="saveDetails(line)">Details 一括保存</button>
+          </div>
+
+          <div v-if="!line.details.length" class="text-muted small px-2 py-1">詳細なし</div>
+
+          <!-- detail rows -->
+          <div
+            v-for="d in line.details"
+            :key="'d-' + d.id"
+            class="st-detail-row"
+            :class="{ 'st-detail-oor': isOutOfRange(d) }"
+          >
+            <div class="st-detail-field">
+              <label class="st-label">開始時刻</label>
+              <input v-model="d.start_time" type="time" class="form-control form-control-sm" />
+            </div>
+            <div class="st-detail-field">
+              <label class="st-label">終了(計算)</label>
+              <span class="form-control-sm d-block">{{ calcDetailEnd(d) }}</span>
+            </div>
+            <div class="st-detail-field st-detail-field--code">
+              <label class="st-label">lesson_code</label>
+              <input
+                v-model="d.lesson_code"
+                class="form-control form-control-sm"
+                @blur="fetchLesson(d)"
+                @keyup.enter="fetchLesson(d)"
+              />
+            </div>
+            <div class="st-detail-field st-detail-field--name">
+              <label class="st-label">lesson_name</label>
+              <input v-model="d.lesson_name" class="form-control form-control-sm" readonly />
+            </div>
+            <div class="st-detail-field">
+              <label class="st-label">分数</label>
+              <input v-model.number="d.lesson_minute" type="number" class="form-control form-control-sm" readonly />
+            </div>
+            <div class="st-detail-field">
+              <label class="st-label">有効開始</label>
+              <input v-model="d.effective_start" type="date" class="form-control form-control-sm" />
+            </div>
+            <div class="st-detail-field">
+              <label class="st-label">有効終了</label>
+              <input v-model="d.effective_end" type="date" class="form-control form-control-sm" />
+            </div>
+            <div class="st-detail-field st-detail-field--dnote">
+              <label class="st-label">メモ</label>
+              <input v-model="d.detail_note" class="form-control form-control-sm" />
+            </div>
+            <div class="st-detail-field st-detail-field--actions">
+              <button class="btn btn-sm btn-outline-danger" @click="deleteDetail(line, d)" title="削除">✕</button>
+            </div>
+            <div v-if="isOutOfRange(d)" class="st-oor-tag">範囲外</div>
+          </div><!-- /st-detail-row -->
+        </div><!-- /st-details-area -->
+      </div><!-- /st-line-block (v-for) -->
+      </div><!-- /st-pane-lines -->
+
+      <!-- 下部リサイズハンドル（Lines Editor 高さを変更） -->
+      <div class="st-resize-handle" @mousedown="startResizePane($event, 'linesPaneHeight')">
+        <span class="st-resize-grip">&#8942;&#8942;&#8942;</span>
+      </div>
+    </div><!-- /st-split -->
+
+    <!-- ===== Detail ポップアップ ===== -->
+    <div v-if="activeDetail" class="st-popup-overlay" @click.self="activeDetail = null">
+      <div class="st-popup">
+        <button class="st-popup-close" @click="activeDetail = null">✕</button>
+        <div class="st-popup-title">{{ activeDetail.lesson_code }} — {{ activeDetail.lesson_name }}</div>
+        <div class="st-popup-row"><span>開始:</span> {{ activeDetail.start_time }}</div>
+        <div class="st-popup-row"><span>分数:</span> {{ activeDetail.lesson_minute || 5 }} min</div>
+        <div class="st-popup-row"><span>有効:</span> {{ activeDetail.effective_start }} 〜 {{ activeDetail.effective_end || '—' }}</div>
+        <div class="st-popup-row st-popup-note" v-if="activeDetail.detail_note">
+          <span>メモ:</span> {{ activeDetail.detail_note }}
+        </div>
+        <div v-else class="st-popup-row text-muted"><span>メモ:</span> No note</div>
+      </div>
+    </div>
+
+    <div v-if="searched && !lines.length && !loading" class="text-muted mt-3">
+      該当する Schedule Line が見つかりませんでした。
+    </div>
+  </div>
+</template>
+
+<script>
+// Grid 定数（9:30〜22:30、5分刻み、156 slots）
+const GRID_START_MIN = 9 * 60 + 30;  // 570
+const GRID_END_MIN   = 22 * 60 + 30; // 1350
+const GRID_TOTAL_MIN = GRID_END_MIN - GRID_START_MIN; // 780
+const SLOT_MIN       = 5;
+const SLOT_COUNT     = GRID_TOTAL_MIN / SLOT_MIN; // 156
+const SLOT_PX        = 10; // 1 slot = 10px
+const CELLS_WIDTH_PX = SLOT_COUNT * SLOT_PX; // 1560px
+
+function timeToMin(hhmm) {
+  if (!hhmm) return null;
+  const [h, m] = hhmm.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function minToHhmm(min) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
+}
+
+export default {
+  name: 'SchoolTimetable',
+
+  props: {
+    initialSchool:       { type: String, default: '' },
+    initialDow:          { default: null },
+    userOptions:         { type: Array,  default: () => [] },
+    dowOptions:          { type: Object, default: () => ({}) },
+    csrfToken:           { type: String, default: '' },
+    apiLinesUrl:         { type: String, default: '' },
+    schoolsUrl:          { type: String, default: '' },
+    storeLinesUrl:       { type: String, default: '' },
+    bulkUpdateLinesUrl:  { type: String, default: '' },
+    lessonByCodeUrl:     { type: String, default: '' },
+  },
+
+  data() {
+    return {
+      schoolQuery: this.initialSchool,
+      // initialDow が null でなければ数値化
+      dowFilter:   this.initialDow !== null ? Number(this.initialDow) : null,
+      activeOn:    new Date().toISOString().slice(0, 10),
+      lines:       [],
+      schoolList:  [],
+      loading:     false,
+      searched:    !!this.initialSchool,
+      message:       '',
+      msgOk:         true,
+      // 各ペインの高さ（px）。リサイズハンドルで変更
+      gridPaneHeight:  280,
+      linesPaneHeight: 400,
+      // クリックされた detail（ポップアップ表示用）
+      activeDetail: null,
+    };
+  },
+
+  computed: {
+    // 9:30 〜 22:30 の時刻ラベルマーク（整時 + 9:30/22:30 端点）
+    timeHeaderMarks() {
+      const marks = [];
+      // 左端: translateX(0) で左寄せ
+      marks.push({ label: '9:30', leftPx: 0, anchor: 'left' });
+      for (let h = 10; h <= 22; h++) {
+        const minFromStart = h * 60 - GRID_START_MIN;
+        marks.push({ label: `${h}:00`, leftPx: minFromStart / SLOT_MIN * SLOT_PX, anchor: 'center' });
+      }
+      // 右端: translateX(-100%) で右寄せ
+      marks.push({ label: '22:30', leftPx: CELLS_WIDTH_PX, anchor: 'right' });
+      return marks;
+    },
+
+    hasOutOfRange() {
+      return this.lines.some(l => l.details.some(d => this.isOutOfRange(d)));
+    },
+  },
+
+  mounted() {
+    this.fetchSchools();
+    if (this.schoolQuery) {
+      this.searched = true;
+      this.search();
+    }
+  },
+
+  methods: {
+    // ---- リサイズハンドルのドラッグ処理（prop: 変更するデータキー名） ----
+    startResizePane(e, prop) {
+      e.preventDefault();
+      const startY = e.clientY;
+      const startH = this[prop];
+      const onMove = (ev) => {
+        const newH = Math.max(120, Math.min(startH + ev.clientY - startY, window.innerHeight * 0.85));
+        this[prop] = Math.round(newH);
+      };
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup',   onUp);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup',   onUp);
+    },
+
+    dowLabel(dow) {
+      const map = { 0: '日', 1: '月', 2: '火', 3: '水', 4: '木', 5: '金', 6: '土' };
+      return map[dow] ?? '?';
+    },
+
+    showMsg(ok, text) {
+      this.msgOk   = ok;
+      this.message = text;
+    },
+
+    // ---- School datalist ----
+
+    async fetchSchools() {
+      if (!this.schoolsUrl) return;
+      try {
+        const res  = await fetch(this.schoolsUrl, {
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        if (data.ok) this.schoolList = data.schools;
+      } catch (e) {
+        // silent: datalist は補助機能なので失敗しても問題なし
+      }
+    },
+
+    // ---- 検索（URL クエリパラメータも同期） ----
+
+    async search() {
+      if (!this.schoolQuery.trim()) {
+        this.showMsg(false, '学校名を入力してください。');
+        return;
+      }
+      this.loading  = true;
+      this.message  = '';
+      this.searched = true;
+
+      // refresh 後も検索条件を保持するため URL を更新
+      const params = new URLSearchParams();
+      params.set('school', this.schoolQuery.trim());
+      if (this.dowFilter !== null && this.dowFilter !== '') {
+        params.set('dow', String(this.dowFilter));
+      }
+      window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+
+      try {
+        const dowParam = this.dowFilter !== null && this.dowFilter !== ''
+          ? `&dow=${this.dowFilter}` : '';
+        const url = `${this.apiLinesUrl}?school=${encodeURIComponent(this.schoolQuery)}&active_on=${this.activeOn}${dowParam}`;
+        const res  = await fetch(url, { headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' } });
+        const data = await res.json();
+        if (data.ok) {
+          this.lines = data.lines;
+        } else {
+          this.showMsg(false, data.message || '取得に失敗しました。');
+        }
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    // ---- Time Grid ----
+
+    isOutOfRange(d) {
+      const s = timeToMin(d.start_time);
+      if (s === null) return false;
+      return s < GRID_START_MIN || s >= GRID_END_MIN;
+    },
+
+    // ピクセル基準でイベントを配置（スロット背景と座標系を統一）
+    eventStyle(d) {
+      const startMin     = timeToMin(d.start_time);
+      const duration     = Math.max(SLOT_MIN, d.lesson_minute || SLOT_MIN);
+      // グリッド開始からの 5 分スロット数（0 始まり）
+      const slotOffset   = (startMin - GRID_START_MIN) / SLOT_MIN;
+      const slotDuration = Math.max(1, Math.ceil(duration / SLOT_MIN));
+      return {
+        left:            `${slotOffset * SLOT_PX}px`,
+        width:           `${slotDuration * SLOT_PX}px`,
+        backgroundColor: this.lessonColor(d.lesson_code),
+      };
+    },
+
+    lessonColor(code) {
+      if (!code) return '#adb5bd';
+      let hash = 0;
+      for (let i = 0; i < code.length; i++) {
+        hash = code.charCodeAt(i) + ((hash << 5) - hash);
+      }
+      const hue = Math.abs(hash) % 360;
+      return `hsl(${hue}, 55%, 68%)`;
+    },
+
+    calcDetailEnd(d) {
+      const s = timeToMin(d.start_time);
+      if (s === null) return '—';
+      return minToHhmm(s + Math.max(SLOT_MIN, d.lesson_minute || SLOT_MIN));
+    },
+
+    // ---- Line CRUD ----
+
+    async addLine() {
+      try {
+        const res  = await fetch(this.storeLinesUrl, {
+          method: 'POST',
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            user_id:     null,
+            school_name: this.schoolQuery.trim(),
+            dow:         this.dowFilter !== null ? this.dowFilter : 0,
+          }),
+        });
+        const data = await res.json();
+        if (data.ok) {
+          this.showMsg(true, data.message);
+          await this.search();
+        } else {
+          this.showMsg(false, data.message || '作成に失敗しました。');
+        }
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      }
+    },
+
+    async saveLine(line) {
+      try {
+        const url = `/schedule_lines/bulk-update`;
+        const payload = {
+          items: [{
+            id:              line.id,
+            user_id:         line.user_id,
+            dow:             line.dow,
+            school_name:     line.school_name,
+            start_time:      line.start_time,
+            end_time:        line.end_time,
+            effective_start: line.effective_start,
+            effective_end:   line.effective_end,
+            handover_memo:   line.handover_memo || null,
+          }],
+        };
+        const res  = await fetch(url, {
+          method: 'POST',
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        this.showMsg(data.ok, data.message || (data.ok ? '保存しました。' : '保存に失敗しました。'));
+        if (data.ok) await this.search();
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      }
+    },
+
+    async deleteLine(line) {
+      if (!confirm(`Line #${line.id} を削除しますか？（関連 detail も削除されます）`)) return;
+      try {
+        const res  = await fetch(`/schedule_lines/${line.id}`, {
+          method: 'DELETE',
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        this.showMsg(data.ok, data.message || (data.ok ? '削除しました。' : '削除に失敗しました。'));
+        if (data.ok) this.lines = this.lines.filter(l => l.id !== line.id);
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      }
+    },
+
+    // ---- Detail CRUD ----
+
+    async addDetail(line) {
+      try {
+        const res  = await fetch(`/schedule_lines/${line.id}/details`, {
+          method: 'POST',
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        this.showMsg(data.ok, data.message || (data.ok ? '追加しました。' : '追加に失敗しました。'));
+        if (data.ok) await this.search();
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      }
+    },
+
+    async deleteDetail(line, d) {
+      if (!confirm(`Detail #${d.id}（${d.lesson_code} ${d.start_time}）を削除しますか？`)) return;
+      try {
+        const res  = await fetch(`/schedule_details/${d.id}`, {
+          method: 'DELETE',
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        this.showMsg(data.ok, data.message || (data.ok ? '削除しました。' : '削除に失敗しました。'));
+        if (data.ok) line.details = line.details.filter(x => x.id !== d.id);
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      }
+    },
+
+    async saveDetails(line) {
+      try {
+        const items = line.details.map(d => ({
+          id:              d.id,
+          lesson_code:     d.lesson_code,
+          note:            d.note || null,
+          detail_note:     d.detail_note ?? null,
+          start_time:      d.start_time,
+          effective_start: d.effective_start,
+          effective_end:   d.effective_end || null,
+        }));
+        const res  = await fetch(`/schedule_lines/${line.id}/details/bulk-update`, {
+          method: 'POST',
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items }),
+        });
+        const data = await res.json();
+        this.showMsg(data.ok, data.message || (data.ok ? '保存しました。' : '保存に失敗しました。'));
+        if (data.ok) await this.search();
+      } catch (e) {
+        this.showMsg(false, '通信エラーが発生しました。');
+      }
+    },
+
+    async fetchLesson(d) {
+      const code = (d.lesson_code || '').trim();
+      if (!code) return;
+      try {
+        const res  = await fetch(`${this.lessonByCodeUrl}/${encodeURIComponent(code)}`, {
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        if (data.ok && data.lesson) {
+          d.lesson_name   = data.lesson.lesson_name;
+          d.lesson_minute = data.lesson.lesson_minute;
+          d.note          = data.lesson.note || '';
+        }
+      } catch (e) {
+        // silent
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+/* ===== Root ===== */
+.st-root {
+  padding: 0.5rem;
+  font-size: 0.85rem;
+}
+
+/* ===== Search bar ===== */
+.st-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+.st-school-input { width: 220px; }
+.st-dow-select   { width: 100px; }
+.st-date-input   { width: 150px; }
+.st-label        { font-size: 0.78rem; white-space: nowrap; margin: 0; }
+
+/* ===== Section title ===== */
+.st-section-title {
+  font-weight: 600;
+  border-bottom: 2px solid #555;
+  margin: 0.75rem 0 0.3rem;
+  padding-bottom: 0.15rem;
+  font-size: 0.88rem;
+}
+/* ペイン内のタイトルは上マージンを詰める */
+.st-section-title--pane {
+  margin-top: 0.3rem;
+}
+
+/* ===== 2ペイン分割レイアウト ===== */
+.st-split {
+  display: flex;
+  flex-direction: column;
+}
+
+/* 上ペイン: グリッド（高さは :style でバインド） */
+.st-pane-grid {
+  display: flex;
+  flex-direction: column;
+  min-height: 120px;
+  overflow: hidden;
+}
+/* st-grid-outer がペインの残り高さを満たす */
+.st-pane-grid .st-grid-outer {
+  flex: 1;
+  min-height: 0;
+  border-radius: 4px;
+  overflow-x: auto;
+  overflow-y: auto;
+}
+
+/* リサイズハンドル */
+.st-resize-handle {
+  flex-shrink: 0;
+  height: 10px;
+  background: #dee2e6;
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid #adb5bd;
+  border-bottom: 1px solid #adb5bd;
+  user-select: none;
+}
+.st-resize-grip {
+  font-size: 0.6rem;
+  color: #6c757d;
+  letter-spacing: 1px;
+  line-height: 1;
+}
+
+/* 下ペイン: Lines Editor（height は :style バインドで制御） */
+.st-pane-lines {
+  min-height: 150px;
+  overflow-y: auto;
+  padding: 0 0.1rem 0.5rem;
+}
+
+/* ===== Timetable grid ===== */
+
+/* 外枠: 横スクロール専用コンテナ */
+.st-grid-outer {
+  overflow-x: auto;
+  overflow-y: visible;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.st-grid-header,
+.st-grid-row {
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid #e0e0e0;
+  min-width: max-content; /* background と border-bottom を全幅に伸ばす */
+  /* overflow を設定しない（sticky が効くよう） */
+}
+.st-grid-header { background: #f8f9fa; }
+
+/* 左固定ラベル列: position sticky で横スクロール時に固定 */
+.st-row-label {
+  flex-shrink: 0;
+  width: 120px;
+  padding: 4px 6px;
+  border-right: 2px solid #555;
+  background: #f0f0f0;
+  font-size: 0.72rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  /* sticky 固定 */
+  position: sticky;
+  left: 0;
+  z-index: 2;
+}
+.st-row-label--header {
+  background: #e9ecef;
+  min-height: 22px;
+}
+.st-label-dow  { font-weight: 700; font-size: 0.82rem; }
+.st-label-user { color: #333; }
+.st-label-id   { color: #888; font-size: 0.68rem; }
+.st-label-time { color: #555; }
+
+/* 時刻ヘッダー: セル領域と同じ幅で固定 */
+.st-time-header {
+  flex-shrink: 0;
+  width: 1560px; /* SLOT_COUNT(156) × SLOT_PX(10px) */
+  position: relative;
+  height: 22px;
+}
+.st-time-mark {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 0.68rem;
+  color: #555;
+  top: 3px;
+  white-space: nowrap;
+  /* 左端の 9:30 ラベルが切れないよう最小 left を保証 */
+  min-width: max-content;
+}
+
+/* セル領域: スロット背景 + イベントブロックを内包 */
+.st-cells-wrap {
+  flex-shrink: 0;
+  width: 1560px; /* SLOT_COUNT(156) × SLOT_PX(10px) */
+  height: 52px;
+  position: relative;
+}
+
+/* 背景グリッド（CSS gradient で正確に描画、flex 累積誤差なし）
+   9:30 開始のため:
+   ・5分線 (10px毎): x=9-10, 19-20, 29-30, ...
+   ・30分線 (120px毎, offset=0): x=119-120, 239-240, ...  (10:30, 11:30, ...)
+   ・60分線 (120px毎, offset=60): x=59-60, 179-180, ...   (10:00, 11:00, ...) */
+.st-cells-bg {
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(to right, transparent 0, transparent 119px, #bbb 119px, #bbb 120px),
+    repeating-linear-gradient(to right, transparent 0, transparent 119px, #ddd 119px, #ddd 120px),
+    repeating-linear-gradient(to right, transparent 0, transparent 9px,   #f0f0f0 9px, #f0f0f0 10px);
+  background-position: 60px 0, 0px 0, 0px 0;
+  background-size: 120px 100%, 120px 100%, 10px 100%;
+}
+
+/* event blocks */
+.st-events {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.st-event {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  border-radius: 3px;
+  overflow: hidden;
+  padding: 1px 3px;
+  font-size: 0.65rem;
+  line-height: 1.2;
+  cursor: default;
+  pointer-events: auto;
+  border: 1px solid rgba(0,0,0,0.15);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  white-space: nowrap;
+}
+.st-event-code  { font-weight: 700; }
+.st-event-name  { overflow: hidden; text-overflow: ellipsis; }
+.st-event-time  { font-size: 0.6rem; color: rgba(0,0,0,0.6); }
+
+.st-oor-warning {
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  color: #856404;
+  background: #fff3cd;
+}
+
+/* ===== Lines Editor ===== */
+.st-line-block {
+  border: 1px solid #aaa;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+}
+
+.st-line-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #343a40;
+  color: #fff;
+  padding: 4px 10px;
+  font-size: 0.82rem;
+}
+.st-line-id     { font-weight: 700; }
+.st-line-school { color: #adb5bd; }
+
+.st-line-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #fdf7f8;
+  border-bottom: 1px solid #ddd;
+}
+.st-field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* ===== Details area ===== */
+.st-details-area {
+  padding: 0.4rem 0.75rem 0.5rem;
+}
+
+.st-details-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.3rem;
+  font-weight: 600;
+  font-size: 0.82rem;
+}
+
+.st-detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.35rem;
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid #eee;
+  position: relative;
+}
+.st-detail-row:last-child { border-bottom: none; }
+.st-detail-row:hover      { background: #f9f9f9; }
+
+.st-detail-oor { background: #fff8e1; }
+
+.st-detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.st-detail-field--code { min-width: 110px; }
+.st-detail-field--name { min-width: 150px; }
+.st-detail-field--actions {
+  display: flex;
+  align-items: flex-end;
+}
+
+.st-oor-tag {
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  font-size: 0.65rem;
+  background: #ffc107;
+  color: #333;
+  border-radius: 3px;
+  padding: 0 4px;
+}
+
+/* detail_note 赤点（event block 右上に絶対配置） */
+.st-event-note-dot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #dc3545;
+  flex-shrink: 0;
+}
+
+/* detail メモ入力フィールド */
+.st-detail-field--dnote { min-width: 130px; }
+
+/* Detail ポップアップ */
+.st-popup-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.st-popup {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  min-width: 260px;
+  max-width: 420px;
+  position: relative;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+}
+.st-popup-close {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  cursor: pointer;
+  color: #666;
+  line-height: 1;
+}
+.st-popup-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin-bottom: 0.6rem;
+  padding-right: 1.5rem;
+}
+.st-popup-row {
+  font-size: 0.82rem;
+  margin-bottom: 0.2rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.st-popup-row span {
+  font-weight: 600;
+  margin-right: 4px;
+}
+.st-popup-note {
+  margin-top: 0.4rem;
+  padding-top: 0.4rem;
+  border-top: 1px solid #eee;
+}
+</style>

--- a/resources/views/schedule/detailsEdit.blade.php
+++ b/resources/views/schedule/detailsEdit.blade.php
@@ -104,6 +104,7 @@
                 <th>End</th>
                 <th>Code</th>
                 <th>Note</th>
+                <th>Memo</th>
                 <th>Effective</th>
                 <th>Until</th>
                 <th>Actions</th>
@@ -144,6 +145,10 @@
                 <td>
                     <input type="text" class="form-control form-control-sm js-lesson-note"
                         value="{{ $d->lesson->note ?? '' }}" style="min-width: 8rem;">
+                </td>
+                <td>
+                    <input type="text" class="form-control form-control-sm js-detail-note"
+                        value="{{ $d->note ?? '' }}" style="min-width: 8rem;">
                 </td>
                 <td>
                     <input type="date" class="form-control form-control-sm js-eff-start" value="{{ $effStart }}">
@@ -265,6 +270,7 @@
                 const id = Number(card.dataset.id);
                 const code = card.querySelector('.js-lesson-code')?.value?.trim() || '';
                 const note = card.querySelector('.js-lesson-note')?.value ?? '';
+                const detailNote = card.querySelector('.js-detail-note')?.value ?? null;
                 const st = (card.querySelector('.js-start-time')?.value || '').trim();
                 const es = (card.querySelector('.js-eff-start')?.value || '').trim();
                 const ee = (card.querySelector('.js-eff-end')?.value || '').trim();
@@ -273,6 +279,7 @@
                     id,
                     lesson_code: code,
                     note,
+                    detail_note: detailNote,
                     start_time: st, // 'HH:MM'
                     effective_start: es || null, // 空は null
                     effective_end: ee || null, // 空は null

--- a/resources/views/schedule/schoolTimetable.blade.php
+++ b/resources/views/schedule/schoolTimetable.blade.php
@@ -1,0 +1,6 @@
+{{-- resources/views/schedule/schoolTimetable.blade.php --}}
+@extends('layouts.app')
+
+@section('content')
+<div id="schoolTimetable" data-props='@json($props)'></div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -263,6 +263,14 @@ Route::middleware(['auth'])->group(function () {
 });
 
 
+use App\Http\Controllers\SchoolTimetableController;
+
+Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
+    Route::get('/schedules/school-timetable', [SchoolTimetableController::class, 'index'])->name('schedules.school_timetable');
+    Route::get('/api/school-timetable/lines', [SchoolTimetableController::class, 'lines'])->name('school_timetable.lines');
+    Route::get('/api/school-timetable/schools', [SchoolTimetableController::class, 'schools'])->name('school_timetable.schools');
+});
+
 use App\Http\Controllers\CommuterPassAdvisorController;
 
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {


### PR DESCRIPTION
## 新規追加
### SchoolTimetableController — 学校名・曜日・基準日で絞った ScheduleLine + ScheduleDetail を返す API、学校名一覧 API
### SchoolTimetable.vue — 2ペイン構成（Time Grid / Lines Editor）の SPA コンポーネント

- Time Grid: 9:30〜22:30、CSS gradient による正確なグリッド描画
- Lines Editor: ScheduleLine・ScheduleDetail の CRUD（Ajax）
- 両ペインともドラッグで高さ調整可能
- 学校名 datalist 補完、URL クエリパラメータ永続化
- 新規 Line 作成時に検索条件（学校名・曜日）を引き継ぎ

### schedule_details に note カラム追加（nullable text）

- lessons.note（既存）とは別の、Detail 単位のメモ
- Time Grid イベントブロック右上に赤点表示（メモありの場合）

イベントブロッククリックでポップアップ表示（メモ含む）
## 変更
### ScheduleDetailController::bulkUpdate — detail_note → schedule_details.note に保存追加（既存の note → lessons.note 更新は維持）
### ScheduleLineController::store — school_name・dow を受け取り新規 Line に反映
### detailsEdit.blade.php — Memo 列追加（schedule_details.note の表示・編集）