### PR TITLE
Renderデプロイ環境でのCSVインポート500/504エラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN npm ci && npm run build
 RUN chown -R www-data:www-data /var/www/html \
     && chmod -R 775 storage bootstrap/cache
 
+# PHP設定
+COPY docker/php/custom.ini /usr/local/etc/php/conf.d/custom.ini
+
 # nginx設定
 COPY docker/nginx/default.conf /etc/nginx/sites-available/default
 

--- a/app/Http/Controllers/UserCsvController.php
+++ b/app/Http/Controllers/UserCsvController.php
@@ -152,6 +152,8 @@ class UserCsvController extends Controller
         $districtMap   = District::pluck('id', 'name')->all();
         $departmentMap = Department::pluck('id', 'name')->all();
         $roleMap       = Role::where('guard_name', 'web')->pluck('name', 'name')->all();
+        $existingEmails = User::pluck('id', 'email')->all();
+        $existingCodes  = User::pluck('id', 'employee_code')->all();
 
         foreach ($rows as ['row' => $rowNum, 'data' => $data]) {
             $v = Validator::make($data, [
@@ -204,20 +206,14 @@ class UserCsvController extends Controller
             }
 
             // email 重複チェック（別ユーザー）
-            $emailDup = User::where('email', $data['email']);
-            if ($id !== null) {
-                $emailDup->where('id', '!=', $id);
-            }
-            if ($emailDup->exists()) {
+            $emailOwner = $existingEmails[$data['email']] ?? null;
+            if ($emailOwner !== null && $emailOwner !== $id) {
                 $validationErrors[] = "{$rowNum}行目: email「{$data['email']}」は既に別のユーザーが使用しています。";
             }
 
             // employee_code 重複チェック（別ユーザー）
-            $codeDup = User::where('employee_code', $data['employee_code']);
-            if ($id !== null) {
-                $codeDup->where('id', '!=', $id);
-            }
-            if ($codeDup->exists()) {
+            $codeOwner = $existingCodes[$data['employee_code']] ?? null;
+            if ($codeOwner !== null && $codeOwner !== $id) {
                 $validationErrors[] = "{$rowNum}行目: employee_code「{$data['employee_code']}」は既に別のユーザーが使用しています。";
             }
         }

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -16,6 +16,8 @@ server {
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_read_timeout 300;
+        fastcgi_send_timeout 300;
     }
 
     location ~ /\.(?!well-known).* {

--- a/docker/php/custom.ini
+++ b/docker/php/custom.ini
@@ -1,0 +1,4 @@
+upload_max_filesize = 50M
+post_max_size = 50M
+max_execution_time = 300
+memory_limit = 256M


### PR DESCRIPTION
## 背景

- ローカル環境では正常動作していたが、Render デプロイ環境で CSV インポート時に Lesson が 500、User が 504 になっていた。

## 原因と対応

- PHP-FPM のデフォルト制限が厳しすぎた（Lesson 500 の原因）
- docker/php/custom.ini を新規作成し、upload_max_filesize=50M、post_max_size=50M、max_execution_time=300、memory_limit=256M を設定。Dockerfile でコンテナビルド時にコピーするよう追加。
- 
- nginx の fastcgi タイムアウト未設定（User 504 の原因）
- docker/nginx/default.conf に fastcgi_read_timeout 300 / fastcgi_send_timeout 300 を追加。
- 
- User インポートの N+1 クエリ問題（User 504 を悪化させていた原因）
- バリデーションループ内で1行ごとにメール・社員コードの重複を DB クエリしていた箇所を、ループ前に全件取得してメモリ内で照合する方式に変更（N+1 → 2クエリ固定）。

## 影響範囲

- Export 機能への影響なし
- Lesson / User / Schedule CSV Import の安定性向上