### PR TITLE
School timetable/disrict only

### DIFF
--- a/app/Http/Controllers/ScheduleDetailController.php
+++ b/app/Http/Controllers/ScheduleDetailController.php
@@ -38,7 +38,7 @@ class ScheduleDetailController extends Controller
         // レッスン一覧（選択肢用）
         $lessonOptions = Lesson::query()
             ->orderBy('lesson_code')
-            ->get(['id', 'lesson_code', 'lesson_name']);
+            ->get(['id', 'lesson_code', 'lesson_name', 'ps_unique_lesson_code']);
 
         // ヘッダー表示用の値を用意
 
@@ -113,10 +113,15 @@ class ScheduleDetailController extends Controller
                 }
                 $data = $v->validated();
 
-                // 1) レッスンを lesson_code で取得（無ければエラー）
-                $lesson = Lesson::query()->where('lesson_code', $data['lesson_code'])->first();
+                // 1) lesson_code または ps_unique_lesson_code で取得（無ければエラー）
+                $lesson = Lesson::query()
+                    ->where(function ($q) use ($data) {
+                        $q->where('lesson_code', $data['lesson_code'])
+                          ->orWhere('ps_unique_lesson_code', $data['lesson_code']);
+                    })
+                    ->first();
                 if (!$lesson) {
-                    $errors[] = ['id' => $detailId, 'messages' => ['指定の lesson_code が見つかりません']];
+                    $errors[] = ['id' => $detailId, 'messages' => ['指定の lesson_code / ps_unique_lesson_code が見つかりません']];
                     continue;
                 }
 
@@ -165,16 +170,19 @@ class ScheduleDetailController extends Controller
         }
     }
 
-    // lesson_code → レッスン情報取得（AJAX）
+    // lesson_code または ps_unique_lesson_code → レッスン情報取得（AJAX）
     public function findLessonByCode(string $code)
     {
         $lesson = Lesson::query()
-            ->select(['id', 'lesson_name', 'lesson_code', 'note', 'lesson_minute'])
-            ->where('lesson_code', $code)
+            ->select(['id', 'lesson_name', 'lesson_code', 'ps_unique_lesson_code', 'note', 'lesson_minute'])
+            ->where(function ($q) use ($code) {
+                $q->where('lesson_code', $code)
+                  ->orWhere('ps_unique_lesson_code', $code);
+            })
             ->first();
 
         if (!$lesson) {
-            return response()->json(['ok' => false, 'message' => 'lesson_code が見つかりません'], 404);
+            return response()->json(['ok' => false, 'message' => 'lesson が見つかりません'], 404);
         }
         return response()->json([
             'ok' => true,

--- a/app/Http/Controllers/SchoolTimetableController.php
+++ b/app/Http/Controllers/SchoolTimetableController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Department;
 use App\Models\ScheduleLine;
 use App\Models\School;
 use App\Services\CurrentScopeService;
@@ -36,11 +37,23 @@ class SchoolTimetableController extends Controller
             0 => '日', 1 => '月', 2 => '火', 3 => '水', 4 => '木', 5 => '金', 6 => '土',
         ];
 
+        $districtId = $this->scopeService->currentDistrictId();
+        $usedDeptIds = ScheduleLine::where('district_id', $districtId)
+            ->distinct()
+            ->pluck('department_id')
+            ->filter()
+            ->values();
+        $departmentOptions = Department::whereIn('id', $usedDeptIds)
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->values();
+
         $props = [
             'initialSchool'      => $schoolName,
             'initialDow'         => $dow,
             'userOptions'        => $userOptions,
             'dowOptions'         => $dowOptions,
+            'departmentOptions'  => $departmentOptions,
             'csrfToken'          => csrf_token(),
             'apiLinesUrl'        => route('school_timetable.lines'),
             'schoolsUrl'         => route('school_timetable.schools'),
@@ -81,7 +94,6 @@ class SchoolTimetableController extends Controller
                 },
             ])
             ->where('district_id', $this->scopeService->currentDistrictId())
-            ->where('department_id', $this->scopeService->currentDepartmentId())
             ->whereLikeInsensitive('school_name', $schoolName)
             ->orderBy('dow')
             ->orderBy('start_time');
@@ -108,6 +120,7 @@ class SchoolTimetableController extends Controller
             return [
                 'id'              => $line->id,
                 'school_name'     => $line->school_name,
+                'department_id'   => $line->department_id,
                 'user_id'         => $line->user_id,
                 'user_name'       => $userName,
                 'dow'             => $line->dow,

--- a/app/Http/Controllers/SchoolTimetableController.php
+++ b/app/Http/Controllers/SchoolTimetableController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Department;
+use App\Models\Lesson;
 use App\Models\ScheduleLine;
 use App\Models\School;
 use App\Services\CurrentScopeService;
@@ -57,6 +58,7 @@ class SchoolTimetableController extends Controller
             'csrfToken'          => csrf_token(),
             'apiLinesUrl'        => route('school_timetable.lines'),
             'schoolsUrl'         => route('school_timetable.schools'),
+            'lessonsUrl'         => route('school_timetable.lessons'),
             'storeLinesUrl'      => route('schedule_lines.store'),
             'bulkUpdateLinesUrl' => route('schedule_lines.bulk_update'),
             'lessonByCodeUrl'    => url('/lessons/by-code'),
@@ -160,5 +162,15 @@ class SchoolTimetableController extends Controller
             ->get(['school_code', 'school_name']);
 
         return response()->json(['ok' => true, 'schools' => $schools]);
+    }
+
+    // API: lesson 一覧（datalist 用）
+    public function lessonList()
+    {
+        $lessons = Lesson::query()
+            ->orderBy('lesson_code')
+            ->get(['id', 'lesson_code', 'ps_unique_lesson_code']);
+
+        return response()->json(['ok' => true, 'lessons' => $lessons]);
     }
 }

--- a/database/seeders/DistrictDepartmentSeeder.php
+++ b/database/seeders/DistrictDepartmentSeeder.php
@@ -14,13 +14,13 @@ class DistrictDepartmentSeeder extends Seeder
     public function run(): void
     {
         // Districts
-        $districts = ['関東', '近畿CK', '中部'];
+        $districts = ['東日本', '西日本(阪)', '西日本(名)'];
         foreach ($districts as $name) {
             District::firstOrCreate(['name' => $name]);
         }
 
         // Departments
-        $departments = ['Native HR', 'Bilingual HR'];
+        $departments = ['Native', 'Bilingual'];
         foreach ($departments as $name) {
             Department::firstOrCreate(['name' => $name]);
         }

--- a/database/seeders/LeaveSeeder.php
+++ b/database/seeders/LeaveSeeder.php
@@ -9,8 +9,8 @@ class LeaveSeeder extends Seeder
 {
     public function run(): void
     {
-        $kinki  = \App\Models\District::where('name', '近畿CK')->first();
-        $native = \App\Models\Department::where('name', 'Native HR')->first();
+        $kinki  = \App\Models\District::where('name', '西日本(阪)')->first();
+        $native = \App\Models\Department::where('name', 'Native')->first();
 
         // user_id=7 （Absence）
         Leave::create([

--- a/database/seeders/ManagementScopeSeeder.php
+++ b/database/seeders/ManagementScopeSeeder.php
@@ -19,16 +19,16 @@ class ManagementScopeSeeder extends Seeder
      * 処理:
      * 1. Users 1〜19 に district_id / department_id を割り当てる
      * 2. super_admin (id=6) に全 district × department の user_management_scopes を付与
-     * 3. admin (id=5) に 近畿CK の 2 件を付与
-     * 4. 全 School を 近畿CK に割り当てる（既存 SchoolSeeder データはすべて大阪・京都・神戸エリア）
+     * 3. admin (id=5) に 西日本(阪) の 2 件を付与
+     * 4. 全 School を 西日本(阪) に割り当てる（既存 SchoolSeeder データはすべて大阪・京都・神戸エリア）
      */
     public function run(): void
     {
-        $kanto     = District::where('name', '関東')->first();
-        $kinki     = District::where('name', '近畿CK')->first();
-        $chubu     = District::where('name', '中部')->first();
-        $native    = Department::where('name', 'Native HR')->first();
-        $bilingual = Department::where('name', 'Bilingual HR')->first();
+        $kanto     = District::where('name', '東日本')->first();
+        $kinki     = District::where('name', '西日本(阪)')->first();
+        $chubu     = District::where('name', '西日本(名)')->first();
+        $native    = Department::where('name', 'Native')->first();
+        $bilingual = Department::where('name', 'Bilingual')->first();
 
         // 1) ユーザーへの district / department 割り当て
         // id => [district, department]
@@ -76,7 +76,7 @@ class ManagementScopeSeeder extends Seeder
             }
         }
 
-        // 3) admin (id=5): 近畿CK の 2 件のみ
+        // 3) admin (id=5): 西日本(阪) の 2 件のみ
         $admin = User::find(5);
 
         foreach ($allDepartments as $dep) {
@@ -87,8 +87,8 @@ class ManagementScopeSeeder extends Seeder
             ]);
         }
 
-        // 4) 全 School を 近畿CK に割り当て
-        // SchoolSeeder のデータはすべて大阪・京都・神戸エリア（近畿CK）
+        // 4) 全 School を 西日本(阪) に割り当て
+        // SchoolSeeder のデータはすべて大阪・京都・神戸エリア（西日本(阪)）
         School::query()->update(['district_id' => $kinki->id]);
     }
 }

--- a/database/seeders/ScheduleSeeder.php
+++ b/database/seeders/ScheduleSeeder.php
@@ -9,8 +9,8 @@ class ScheduleSeeder extends Seeder
 {
     public function run(): void
     {
-        $kinki  = \App\Models\District::where('name', '近畿CK')->first();
-        $native = \App\Models\Department::where('name', 'Native HR')->first();
+        $kinki  = \App\Models\District::where('name', '西日本(阪)')->first();
+        $native = \App\Models\Department::where('name', 'Native')->first();
 
         $s = '2026-04-01';
         $e = '2027-03-31';

--- a/resources/js/components/SchoolTimetable.vue
+++ b/resources/js/components/SchoolTimetable.vue
@@ -36,6 +36,34 @@
       <button class="btn btn-success btn-sm" @click="addLine" :disabled="!searched">+ 新規 Line</button>
     </div>
 
+    <!-- ===== Department チェックボックスフィルター ===== -->
+    <div v-if="departmentOptions.length" class="st-dept-filter">
+      <span class="st-label">部署：</span>
+      <label
+        v-for="dept in departmentOptions"
+        :key="dept.id"
+        class="st-dept-check-label"
+      >
+        <input
+          type="checkbox"
+          :value="dept.id"
+          v-model="deptFilter"
+          class="st-dept-checkbox"
+        />
+        {{ dept.name }}
+      </label>
+      <button
+        v-if="deptFilter.length < departmentOptions.length"
+        class="btn btn-outline-secondary btn-sm st-dept-all-btn"
+        @click="deptFilter = departmentOptions.map(d => d.id)"
+      >全選択</button>
+      <button
+        v-if="deptFilter.length > 0"
+        class="btn btn-outline-secondary btn-sm st-dept-all-btn"
+        @click="deptFilter = []"
+      >全解除</button>
+    </div>
+
     <!-- ===== メッセージ ===== -->
     <div v-if="message" :class="['alert', 'alert-sm', 'py-1', 'px-2', 'mt-1', msgOk ? 'alert-success' : 'alert-danger']">
       {{ message }}
@@ -67,7 +95,7 @@
           </div>
         </div>
         <!-- 各 line 行 -->
-        <div v-for="line in lines" :key="line.id" class="st-grid-row">
+        <div v-for="line in filteredLines" :key="line.id" class="st-grid-row">
           <div class="st-row-label">
             <div class="st-label-dow">{{ dowLabel(line.dow) }}</div>
             <div class="st-label-user">{{ line.user_name || 'No User' }}</div>
@@ -111,7 +139,7 @@
       <!-- ===== 下ペイン: Lines Editor ===== -->
       <div class="st-pane-lines" :style="{ height: linesPaneHeight + 'px' }">
         <div class="st-section-title st-section-title--pane">Schedule Lines</div>
-      <div v-for="line in lines" :key="'ed-' + line.id" class="st-line-block">
+      <div v-for="line in filteredLines" :key="'ed-' + line.id" class="st-line-block">
 
         <!-- Line header -->
         <div class="st-line-header">
@@ -251,6 +279,9 @@
     <div v-if="searched && !lines.length && !loading" class="text-muted mt-3">
       該当する Schedule Line が見つかりませんでした。
     </div>
+    <div v-if="searched && lines.length && !filteredLines.length && !loading" class="text-muted mt-3">
+      選択中の部署に該当する Schedule Line がありません。
+    </div>
   </div>
 </template>
 
@@ -284,6 +315,7 @@ export default {
     initialDow:          { default: null },
     userOptions:         { type: Array,  default: () => [] },
     dowOptions:          { type: Object, default: () => ({}) },
+    departmentOptions:   { type: Array,  default: () => [] },
     csrfToken:           { type: String, default: '' },
     apiLinesUrl:         { type: String, default: '' },
     schoolsUrl:          { type: String, default: '' },
@@ -304,6 +336,8 @@ export default {
       searched:    !!this.initialSchool,
       message:       '',
       msgOk:         true,
+      // department チェックボックスフィルター（全選択が初期値）
+      deptFilter:  this.departmentOptions.map(d => d.id),
       // 各ペインの高さ（px）。リサイズハンドルで変更
       gridPaneHeight:  280,
       linesPaneHeight: 400,
@@ -327,8 +361,14 @@ export default {
       return marks;
     },
 
+    filteredLines() {
+      if (!this.departmentOptions.length) return this.lines;
+      if (!this.deptFilter.length) return [];
+      return this.lines.filter(l => this.deptFilter.includes(l.department_id));
+    },
+
     hasOutOfRange() {
-      return this.lines.some(l => l.details.some(d => this.isOutOfRange(d)));
+      return this.filteredLines.some(l => l.details.some(d => this.isOutOfRange(d)));
     },
   },
 
@@ -622,6 +662,35 @@ export default {
 .st-dow-select   { width: 100px; }
 .st-date-input   { width: 150px; }
 .st-label        { font-size: 0.78rem; white-space: nowrap; margin: 0; }
+
+/* ===== Department filter ===== */
+.st-dept-filter {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  padding: 0.3rem 0.5rem;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  margin-bottom: 0.4rem;
+}
+.st-dept-check-label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  margin: 0;
+}
+.st-dept-checkbox {
+  cursor: pointer;
+}
+.st-dept-all-btn {
+  font-size: 0.72rem;
+  padding: 1px 6px;
+}
 
 /* ===== Section title ===== */
 .st-section-title {

--- a/resources/js/components/SchoolTimetable.vue
+++ b/resources/js/components/SchoolTimetable.vue
@@ -220,10 +220,13 @@
             <div class="st-detail-field st-detail-field--code">
               <label class="st-label">lesson_code</label>
               <input
-                v-model="d.lesson_code"
+                :value="d.lesson_code"
+                list="st-lesson-code-datalist"
                 class="form-control form-control-sm"
-                @blur="fetchLesson(d)"
-                @keyup.enter="fetchLesson(d)"
+                autocomplete="off"
+                @input="onLessonInput(d, $event)"
+                @change="fetchLessonFromEvent(d, $event)"
+                @keyup.enter="fetchLessonFromEvent(d, $event)"
               />
             </div>
             <div class="st-detail-field st-detail-field--name">
@@ -276,6 +279,15 @@
       </div>
     </div>
 
+    <!-- lesson 補完用 datalist（全 detail 行で共有） -->
+    <datalist id="st-lesson-code-datalist">
+      <option
+        v-for="opt in lessonList"
+        :key="opt.id"
+        :value="opt.lesson_code"
+      >[{{ opt.lesson_code }}] {{ opt.ps_unique_lesson_code }}</option>
+    </datalist>
+
     <div v-if="searched && !lines.length && !loading" class="text-muted mt-3">
       該当する Schedule Line が見つかりませんでした。
     </div>
@@ -319,6 +331,7 @@ export default {
     csrfToken:           { type: String, default: '' },
     apiLinesUrl:         { type: String, default: '' },
     schoolsUrl:          { type: String, default: '' },
+    lessonsUrl:          { type: String, default: '' },
     storeLinesUrl:       { type: String, default: '' },
     bulkUpdateLinesUrl:  { type: String, default: '' },
     lessonByCodeUrl:     { type: String, default: '' },
@@ -332,6 +345,7 @@ export default {
       activeOn:    new Date().toISOString().slice(0, 10),
       lines:       [],
       schoolList:  [],
+      lessonList:  [],
       loading:     false,
       searched:    !!this.initialSchool,
       message:       '',
@@ -374,6 +388,7 @@ export default {
 
   mounted() {
     this.fetchSchools();
+    this.fetchLessons();
     if (this.schoolQuery) {
       this.searched = true;
       this.search();
@@ -418,6 +433,19 @@ export default {
         });
         const data = await res.json();
         if (data.ok) this.schoolList = data.schools;
+      } catch (e) {
+        // silent: datalist は補助機能なので失敗しても問題なし
+      }
+    },
+
+    async fetchLessons() {
+      if (!this.lessonsUrl) return;
+      try {
+        const res  = await fetch(this.lessonsUrl, {
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        if (data.ok) this.lessonList = data.lessons;
       } catch (e) {
         // silent: datalist は補助機能なので失敗しても問題なし
       }
@@ -624,6 +652,33 @@ export default {
 
     async fetchLesson(d) {
       const code = (d.lesson_code || '').trim();
+      if (!code) return;
+      try {
+        const res  = await fetch(`${this.lessonByCodeUrl}/${encodeURIComponent(code)}`, {
+          headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+        });
+        const data = await res.json();
+        if (data.ok && data.lesson) {
+          d.lesson_name   = data.lesson.lesson_name;
+          d.lesson_minute = data.lesson.lesson_minute;
+          d.note          = data.lesson.note || '';
+        }
+      } catch (e) {
+        // silent
+      }
+    },
+
+    onLessonInput(d, event) {
+      const code = event.target.value;
+      d.lesson_code = code;
+      // datalist 選択時は options と完全一致する → 即時フェッチ
+      const matched = this.lessonList.some(opt => opt.lesson_code === code);
+      if (matched) this.fetchLessonFromEvent(d, event);
+    },
+
+    async fetchLessonFromEvent(d, event) {
+      const code = (event.target.value || '').trim();
+      d.lesson_code = code;
       if (!code) return;
       try {
         const res  = await fetch(`${this.lessonByCodeUrl}/${encodeURIComponent(code)}`, {

--- a/resources/views/schedule/detailsEdit.blade.php
+++ b/resources/views/schedule/detailsEdit.blade.php
@@ -132,15 +132,15 @@
                     <input type="time" class="form-control form-control-sm js-end-time" value="{{ $endCalc }}" readonly>
                 </td>
                 <td>
-                    <select class="form-select form-select-sm js-lesson-code" style="min-width: 12rem;">
-                        <option value="">— Select —</option>
-                        @foreach($lessonOptions as $opt)
-                        <option value="{{ $opt->lesson_code }}"
-                            @selected(($d->lesson->lesson_code ?? '') === $opt->lesson_code)>
-                            {{ $opt->lesson_code }} — {{ $opt->lesson_name }}
-                        </option>
-                        @endforeach
-                    </select>
+                    <input
+                        type="text"
+                        list="lesson-datalist"
+                        class="form-control form-control-sm js-lesson-code"
+                        style="min-width: 12rem;"
+                        value="{{ $d->lesson->lesson_code ?? '' }}"
+                        placeholder="lesson code"
+                        autocomplete="off"
+                    >
                 </td>
                 <td>
                     <input type="text" class="form-control form-control-sm js-lesson-note"
@@ -177,6 +177,13 @@
         </tbody>
     </table>
 </div>
+
+{{-- lesson 補完用 datalist（全行で共有） --}}
+<datalist id="lesson-datalist">
+    @foreach($lessonOptions as $opt)
+    <option value="{{ $opt->lesson_code }}">[{{ $opt->lesson_code }}] {{ $opt->ps_unique_lesson_code }}</option>
+    @endforeach
+</datalist>
 @endif
 @endsection
 
@@ -209,7 +216,10 @@
             if (!code) return;
 
             try {
-                const res = await fetch(`{{ route('lessons.by_code', ['code' => '___CODE___']) }}`.replace('___CODE___', encodeURIComponent(code)));
+                const res = await fetch(
+                    `{{ route('lessons.by_code', ['code' => '___CODE___']) }}`.replace('___CODE___', encodeURIComponent(code)),
+                    { headers: { 'Accept': 'application/json' } }
+                );
                 const data = await res.json();
                 if (!res.ok || !data.ok) throw new Error(data?.message || 'レッスン取得に失敗');
 

--- a/resources/views/schedule/lineEdit.blade.php
+++ b/resources/views/schedule/lineEdit.blade.php
@@ -144,6 +144,11 @@
     <div>
         <h2 class="mb-0">Schedule Lines</h2>
     </div>
+    <div>
+        <a href="{{ route('schedules.school_timetable') }}" class="btn btn-sm btn-outline-secondary">
+            School Timetable
+        </a>
+    </div>
 </div>
 
 {{-- 検索フォーム --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -273,6 +273,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/schedules/school-timetable', [SchoolTimetableController::class, 'index'])->name('schedules.school_timetable');
     Route::get('/api/school-timetable/lines', [SchoolTimetableController::class, 'lines'])->name('school_timetable.lines');
     Route::get('/api/school-timetable/schools', [SchoolTimetableController::class, 'schools'])->name('school_timetable.schools');
+    Route::get('/api/school-timetable/lessons', [SchoolTimetableController::class, 'lessonList'])->name('school_timetable.lessons');
 });
 
 use App\Http\Controllers\CommuterPassAdvisorController;


### PR DESCRIPTION
[School Timetableの部署フィルターを画面側に移す](https://github.com/Jin6hara/LaravelSprout/commit/6221202b718c56e66d9cc7e42ae0acfcb0c49b42)
## 概要

SchoolTimetable（`/schedules/school-timetable`）の表示仕様を変更しました。

これまで Schedule Line はログインユーザーの `district_id` と `department_id` の両方でバックエンド絞り込みをしていたため、部署をまたいだ同校の時間割は表示されませんでした。

今回の変更により、バックエンドでは `district_id` のみで絞り込み、部署単位の絞り込みは画面側のチェックボックスで行う仕様に変更しました。

## 元々の仕様

- Schedule Line の取得時に、ログインユーザーの `district_id` と `department_id` の両方でバックエンド絞り込みをしていた
- 部署をまたいだ同校の時間割は一切表示されなかった

## 現在の仕様

- バックエンドの絞り込みは `district_id` のみ
- 部署フィルタリングは画面（Vue）側のチェックボックスで行う
- 複数部署を同時選択可能
- 「全選択」「全解除」ボタンあり
- 同一 district 内の全部署のタイムラインを横断的に閲覧・比較できる

## 変更内容

### SchoolTimetableController.php

- `lines()` から `->where('department_id', ...)` を削除
- Schedule Line の取得条件を district 絞りのみに変更
- `lines()` のレスポンスに `department_id` を追加
  - Vue 側で部署フィルタリングを行うため
- `index()` で現 district の ScheduleLine から `department_id` を `distinct` 取得
- 取得した department_id を Department 名と合わせて `departmentOptions` として Vue props に渡す

### SchoolTimetable.vue

- `departmentOptions` prop を追加
- `deptFilter` を data に追加
  - 選択済み部署 ID の配列
  - 初期値は全部署選択
- `filteredLines` computed を追加
  - `deptFilter` に含まれる `department_id` の line のみ返す
- 検索バー下部に部署チェックボックス行を追加
  - `departmentOptions` が空のときは非表示
- グリッド・エディター両方の `v-for` を `lines` から `filteredLines` に変更
- フィルター結果が 0 件のときの案内メッセージを追加

## 影響範囲

- `/schedules/school-timetable` の表示・フィルタリング仕様に影響
- `/schedule_manager` 側は無変更
  - `ScheduleManagerController` は無変更
  - `ScheduleManager.vue` は無変更

## ポイント

- district 単位で Schedule Line を取得することで、同一 district 内の部署横断表示が可能になった
- department 単位の表示切り替えは Vue 側で行うため、複数部署の比較がしやすくなった
- 既存の `/schedule_manager` 側には影響しないよう、変更範囲を SchoolTimetable 側に限定した

[School TimetableのLesson選択をdatalist補完方式に変更・部署フィルターを画面側へ移動](https://github.com/Jin6hara/LaravelSprout/commit/93767a0e8b5fee0a79ad3340217724bee6212f6f)
## 変更の背景

lesson 選択を `<select>` から datalist 付き `<input>` に変更し、`lesson_code` / `ps_unique_lesson_code` の両方で補完・検索できるようにしました。

また、bulk 保存時に `lesson_code` のみで lesson 検索していたため、`ps_unique_lesson_code` 指定時にレッスンが見つからず保存に失敗する不具合を修正しました。

あわせて、`lineEdit` 画面から School Timetable へ移動できる導線を追加しました。

## 変更内容

### `ScheduleDetailController.php`

- `edit()`
  - `lessonOptions` クエリに `ps_unique_lesson_code` を追加
- `bulkUpdate()`
  - lesson 検索を `lesson_code` または `ps_unique_lesson_code` の OR 条件に変更
  - bulk 保存時の lesson 検索失敗バグを修正
- `findLessonByCode()`
  - `lesson_code` または `ps_unique_lesson_code` の OR 検索に変更
  - レスポンスに `ps_unique_lesson_code` を追加
- fetch 呼び出しに `Accept: application/json` ヘッダーを追加
  - エラー時に HTML ではなく JSON が返るよう修正

### `SchoolTimetableController.php`

- `lessonList()`
  - datalist 用の lesson 一覧 API を新規追加
  - 追加API：`/api/school-timetable/lessons`
- `index()`
  - `lessonsUrl` prop を追加

### `SchoolTimetable.vue`

- `lesson_code` 入力欄を datalist 付き `<input>` に変更
  - 候補表示形式：`[lesson_code] ps_unique_lesson_code`
- マウント時に `/api/school-timetable/lessons` から lesson 一覧を AJAX 取得
  - `fetchLessons()` を追加
- `onLessonInput()` を追加
  - datalist 候補と完全一致した場合は即時 fetch
  - 手入力の場合は `@change` で fetch

### `detailsEdit.blade.php`

- lesson 選択を `<select>` から datalist 付き `<input>` に変更
- 全行で共有する `<datalist id="lesson-datalist">` を配置
- option 表示形式を `[lesson_code] ps_unique_lesson_code` に統一

### `lineEdit.blade.php`

- ページ右上に School Timetable へのリンクボタンを追加

### `routes/web.php`

- `/api/school-timetable/lessons` ルートを追加

## 修正ポイント

- lesson 選択を datalist 化し、入力補完と手入力の両方に対応
- `lesson_code` / `ps_unique_lesson_code` のどちらでも lesson 検索できるよう修正
- bulk 保存時に `ps_unique_lesson_code` 指定でも正しく保存できるよう修正
- School Timetable 側でも lesson 一覧を API 経由で取得できるよう対応
- `lineEdit` 画面から School Timetable へ移動しやすくなるよう導線を追加