### PR TITLE
⭐️ログイン試行制限・添付ファイルの認可チェック

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Http\Request;
 
 class LoginController extends Controller
@@ -20,32 +21,56 @@ class LoginController extends Controller
 
     public function login(Request $request)
     {
-        //ログアウトしてから再認証
-        //Auth::logout();
-        //$request->session()->invalidate();
-        //$request->session()->regenerateToken();
-
         $credentials = $request->validate([
             'email'    => ['required', 'email'],
             'password' => ['required'],
         ]);
 
+        $key          = $this->throttleKey($request);
+        $maxAttempts  = 5;
+        $decaySeconds = 120;
+
+        // ① すでにロックアウト中（6回目以降）は認証処理の前にブロック
+        if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            $seconds = RateLimiter::availableIn($key);
+            return back()->withErrors([
+                'email' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
+            ])->onlyInput('email');
+        }
+
+        // ② 認証試行
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
+            RateLimiter::clear($key);
 
             $user = Auth::user();
             // ここは権限認証とまったく関係ない。本認証はRoute+Policyに行っている。
             // ここでは、ユーザーロールを取得してredirect先を決めているだけ。
-            if ($user->hasRole(['admin', 'super_admin'])) { 
-                return redirect()->route('admin.dashboard');//role check required
+            if ($user->hasRole(['admin', 'super_admin'])) {
+                return redirect()->route('admin.dashboard');
             } else {
-                return redirect()->route('welcome');//role check none required
+                return redirect()->route('welcome');
             }
+        }
+
+        // ③ 失敗: カウンタをインクリメントしてから超過判定
+        RateLimiter::hit($key, $decaySeconds);
+
+        if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            $seconds = RateLimiter::availableIn($key);
+            return back()->withErrors([
+                'email' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
+            ])->onlyInput('email');
         }
 
         return back()->withErrors([
             'email' => 'メールアドレスまたはパスワードが正しくありません。',
         ])->onlyInput('email');
+    }
+
+    private function throttleKey(Request $request): string
+    {
+        return hash('sha256', strtolower($request->input('email', '')) . '|' . $request->ip());
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/LeaveAttachmentController.php
+++ b/app/Http/Controllers/LeaveAttachmentController.php
@@ -18,11 +18,11 @@ class LeaveAttachmentController extends Controller
             abort(404);
         }
 
-        // ② 認可（必要なら）
-        // $this->authorize('view', $leave);
+        // ② 認可
+        $this->authorize('view', $leave);
 
-        // ③ ファイルパス取得（public ディスク前提）
-        $disk = Storage::disk('public');
+        // ③ ファイルパス取得（local ディスク）
+        $disk = Storage::disk('local');
 
         if (! $disk->exists($attachment->path)) {
             abort(404);

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -190,12 +190,12 @@ class LeaveController extends Controller
 
             // 既存の添付があれば削除したい場合（任意）
             if ($leave->attachment) {
-                Storage::disk('public')->delete($leave->attachment->path); // ★ ここだけ変更
+                Storage::disk('local')->delete($leave->attachment->path);
                 $leave->attachment->delete();
             }
 
-            // storage/app/public/attachments/YYYY/MM/... に保存
-            $path = $file->store('attachments/' . now()->format('Y/m'), 'public'); // ★ 第2引数 'public' 追加
+            // storage/app/attachments/YYYY/MM/... に保存（非公開）
+            $path = $file->store('attachments/' . now()->format('Y/m'), 'local');
 
             $leave->attachment()->create([
                 'path'          => $path,
@@ -338,7 +338,6 @@ class LeaveController extends Controller
 
         $downloadName = $attachment->original_name ?: 'attachment';
 
-        // ★ public ディスクからダウンロード
-        return Storage::disk('public')->download($attachment->path, $downloadName);
+        return Storage::disk('local')->download($attachment->path, $downloadName);
     }
 }

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -176,7 +176,13 @@ class LeaveController extends Controller
         $validated = $request->validate([
             'reason'      => ['required', 'string', 'max:1000'],
             'handle_type' => ['required', 'in:apply_alp,no_alp,clinic,sick_child,special_leave,menstrual_leave'],
-            'attachment'  => ['nullable', 'file', 'max:10240'], // ★attachment（10MBなど）
+            'attachment'  => [
+                'nullable',
+                'file',
+                'max:10240',
+                'mimes:pdf,jpg,jpeg,png',
+                'mimetypes:application/pdf,image/jpeg,image/png',
+            ],
         ]);
 
         $leave->update([

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -54,8 +54,7 @@ class PostController extends Controller
                 $folder = 'attachments/' . now()->format('Y/m');
 
                 foreach ($req->file('attachments') as $file) {
-                    // ★ disk を 'public' に固定
-                    $path = $file->store($folder, 'public');
+                    $path = $file->store($folder, 'local');
 
                     $post->attachments()->create([
                         'path'          => $path,

--- a/app/Http/Controllers/ReceivedPostController.php
+++ b/app/Http/Controllers/ReceivedPostController.php
@@ -190,11 +190,11 @@ class ReceivedPostController extends Controller
             abort(404);
         }
 
-        // ② 認可（必要なら）
-        // $this->authorize('view', $post);
+        // ② 認可
+        $this->authorize('view', $post);
 
-        // ③ ファイルパス取得（public ディスク前提）
-        $disk = Storage::disk('public');
+        // ③ ファイルパス取得（local ディスク）
+        $disk = Storage::disk('local');
 
         if (! $disk->exists($attachment->path)) {
             abort(404);

--- a/app/Http/Requests/PostSendRequest.php
+++ b/app/Http/Requests/PostSendRequest.php
@@ -22,8 +22,9 @@ class PostSendRequest extends FormRequest
             'attachments'  => ['sometimes', 'array', 'max:10'],            // 最大10ファイル
             'attachments.*'=> [
                 'file',
-                'max:10240', // 10MB/ファイル
-                'mimes:pdf,jpg,jpeg,png,webp,doc,docx,xls,xlsx,csv,txt,zip'
+                'max:10240',
+                'mimes:pdf,jpg,jpeg,png,docx,xlsx',
+                'mimetypes:application/pdf,image/jpeg,image/png,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             ],
             'expires_at'    => ['nullable', 'date', 'after:now'],          // 期限（任意）
             'allow_replies' => ['required', 'boolean'],                    // 返信可否

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,9 @@ use Spatie\Permission\Traits\HasRoles;
 use App\Models\Pivots\PostViewer;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @mixin \Spatie\Permission\Traits\HasRoles
+ */
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable, SoftDeletes, HasRoles;

--- a/app/Policies/LeavePolicy.php
+++ b/app/Policies/LeavePolicy.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Leave;
+use App\Models\User;
+
+class LeavePolicy
+{
+    public function view(User $user, Leave $leave): bool
+    {
+        return $user->id === $leave->user_id
+            || $user->isAdmin();
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -21,7 +21,9 @@ class PostPolicy
      */
     public function view(User $user, Post $post): bool
     {
-        //
+        return $user->id === $post->user_id
+            || $post->viewers()->where('users.id', $user->id)->exists()
+            || $user->isAdmin();
     }
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,9 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        \App\Models\User::class => \App\Policies\UserPolicy::class,
+        \App\Models\User::class  => \App\Policies\UserPolicy::class,
+        \App\Models\Leave::class => \App\Policies\LeavePolicy::class,
+        \App\Models\Post::class  => \App\Policies\PostPolicy::class,
     ];
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -388,37 +388,37 @@ use App\Http\Controllers\LessonCsvController;
 use App\Http\Controllers\ScheduleCsvController;
 use App\Http\Controllers\UserCsvController;
 
-Route::get('/csv', [CsvController::class, 'index'])
-    ->name('csv.index');
+Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
+    Route::get('/csv', [CsvController::class, 'index'])
+        ->name('csv.index');
 
-Route::get('/csv/users', [UserCsvController::class, 'show'])
-    ->name('csv.users.show');
+    Route::get('/csv/users', [UserCsvController::class, 'show'])
+        ->name('csv.users.show');
 
-Route::get('/csv/users/export', [UserCsvController::class, 'export'])
-    ->name('csv.users.export');
+    Route::get('/csv/users/export', [UserCsvController::class, 'export'])
+        ->name('csv.users.export');
 
-Route::post('/csv/users/import', [UserCsvController::class, 'import'])
-    ->name('csv.users.import');
+    Route::post('/csv/users/import', [UserCsvController::class, 'import'])
+        ->name('csv.users.import');
 
-Route::get('/csv/lessons', [LessonCsvController::class, 'show'])
-    ->name('csv.lessons.show');
+    Route::get('/csv/lessons', [LessonCsvController::class, 'show'])
+        ->name('csv.lessons.show');
 
-Route::get('/csv/lessons/export', [LessonCsvController::class, 'export'])
-    ->name('csv.lessons.export');
+    Route::get('/csv/lessons/export', [LessonCsvController::class, 'export'])
+        ->name('csv.lessons.export');
 
-Route::post('/csv/lessons/import', [LessonCsvController::class, 'import'])
-    ->name('csv.lessons.import');
+    Route::post('/csv/lessons/import', [LessonCsvController::class, 'import'])
+        ->name('csv.lessons.import');
 
+    Route::get('/csv/schedules', [ScheduleCsvController::class, 'show'])
+        ->name('csv.schedules.show');
 
-Route::get('/csv/schedules', [ScheduleCsvController::class, 'show'])
-    ->name('csv.schedules.show');
+    Route::get('/csv/schedules/export', [ScheduleCsvController::class, 'export'])
+        ->name('csv.schedules.export');
 
-Route::get('/csv/schedules/export', [ScheduleCsvController::class, 'export'])
-    ->name('csv.schedules.export');
-
-Route::post('/csv/schedules/import', [ScheduleCsvController::class, 'import'])
-    ->name('csv.schedules.import');
-
+    Route::post('/csv/schedules/import', [ScheduleCsvController::class, 'import'])
+        ->name('csv.schedules.import');
+});
 
 // ---------------------------------------------------------------------------------------------------------▲ CSV関連ルート
 


### PR DESCRIPTION
[添付ファイルの認可チェック復活と非公開ディスクへの移行](https://github.com/Jin6hara/LaravelSprout/commit/d58bd4aa657f9b89a39bea1102f8cd15df720c7e)

## 変更前後の整理

### 以前の仕様とリスク

#### 1. 添付ファイルの保存場所

以前は、添付ファイルを以下の公開ディレクトリに保存していました。

```text
storage/app/public/attachments/
```

また、`php artisan storage:link` により、以下の公開URL配下からアクセスできる状態でした。

```text
public/storage/
```

そのため、例えば以下のようなURLを知っていれば、ログイン不要・権限不要でブラウザから直接ファイルを取得できるリスクがありました。

```text
/public/storage/attachments/2025/06/xxxx.pdf
```

対象となるファイルには、休暇申請の診断書や投稿の機密書類などが含まれるため、公開ディレクトリへの保存はセキュリティ上リスクがありました。

---

#### 2. 添付ファイル配信時の認可チェック

`LeaveAttachmentController::show()` と `ReceivedPostController::download()` には `$this->authorize()` の記述がありましたが、コメントアウトされており、実際には認可チェックが無効でした。

また、以下の状態でした。

- `LeavePolicy` が存在していなかった
- `PostPolicy::view()` の中身が空のままだった
- `AuthServiceProvider` に Policy が登録されていなかった

そのため、コントローラ経由でアクセスした場合でも、認可チェックが機能していませんでした。

対象ルートは `auth` ミドルウェアのみで保護されていたため、ログイン済みであれば、他人の添付ファイルにもアクセスできるリスクがありました。

例：

```text
/leaves/{leave}/attachments/{attachment}
/posts/{post}/attachments/{attachment}
```

---

## 変更内容

| 対象 | 変更内容 |
|---|---|
| `LeavePolicy` | 新規作成し、`view()` を実装。本人または `admin` / `super_admin` のみ許可 |
| `PostPolicy::view()` | 投稿者・宛先ユーザー・`admin` / `super_admin` のみ許可するロジックを実装 |
| `AuthServiceProvider` | `Leave => LeavePolicy`、`Post => PostPolicy` を登録 |
| `LeaveAttachmentController::show()` | `authorize('view', $leave)` のコメントアウトを解除 |
| `ReceivedPostController::download()` | `authorize('view', $post)` のコメントアウトを解除 |
| `LeaveController::report()` | 保存ディスクを `public` から `local` に変更 |
| `LeaveController::download()` | 配信ディスクを `public` から `local` に変更 |
| `LeaveAttachmentController::show()` | 配信ディスクを `public` から `local` に変更 |
| `ReceivedPostController::download()` | 配信ディスクを `public` から `local` に変更 |
| `PostController::send()` | 保存ディスクを `public` から `local` に変更 |

---

## 変更後の仕様

### 添付ファイルの保存先

添付ファイルは、以下の非公開領域に保存されます。

```text
storage/app/attachments/YYYY/MM/
```

`local` ディスクを使用するため、`public/storage/` 配下には保存されません。

そのため、ファイルURLを直接ブラウザで叩いても、添付ファイルは取得できません。

---

### 添付ファイルの配信フロー

変更後は、添付ファイルを直接公開URLから取得するのではなく、必ずLaravelのコントローラを経由して配信します。

```text
リクエスト
  ↓
auth ミドルウェア
  - 未ログインの場合はログイン画面へ
  ↓
コントローラ
  ↓
authorize() による Policy 判定
  - 権限がない場合は 403
  ↓
local ディスクからファイルを読み込み
  ↓
response()->file() でレスポンス返却
```

---

## アクセス可能な条件

| ファイル種別 | アクセス可能なユーザー |
|---|---|
| 休暇添付（診断書等） | 本人 / `admin` / `super_admin` |
| 投稿添付 | 投稿者 / 宛先に含まれるユーザー / `admin` / `super_admin` |

---

## セキュリティ上の改善点

今回の変更により、以下のリスクを解消しました。

- 公開URLを知っていれば誰でも添付ファイルを取得できるリスクを解消
- ログイン済みユーザーが他人の添付ファイルへアクセスできるリスクを解消
- 休暇添付・投稿添付に対して、Policy による認可チェックを有効化
- 添付ファイルを `public` ディスクではなく `local` ディスクへ保存し、Web公開領域から分離
- 添付ファイル配信をLaravelコントローラ経由に統一し、認証・認可を必ず通す構成に変更

---

## まとめ

以前は、添付ファイルが `public` ディスクに保存されていたため、URLを知っていればログイン不要で取得できる可能性がありました。

また、コントローラ側の `authorize()` もコメントアウトされており、ログイン済みユーザーであれば他人の添付ファイルへアクセスできるリスクがありました。

今回の修正では、添付ファイルの保存先を `local` ディスクへ変更し、Webから直接アクセスできない構成にしました。

さらに、`LeavePolicy` と `PostPolicy` を実装・登録し、添付ファイル配信時に必ず `authorize()` を通すことで、本人・関係者・管理者のみがアクセスできるようにしました。