### PR TITLE
Schedule Lines 一覧のパフォーマンス改善（ページネーション + DOM軽量化）

### DIFF
--- a/app/Http/Controllers/ScheduleLineController.php
+++ b/app/Http/Controllers/ScheduleLineController.php
@@ -117,7 +117,7 @@ class ScheduleLineController extends Controller
             }
         }
 
-        $lines = $linesQuery->get();
+        $lines = $linesQuery->paginate(50);
 
         // ユーザー選択肢（スコープ内のユーザー一覧）
         $userOptions = $this->scopeService->targetUserQuery()

--- a/resources/views/schedule/lineEdit.blade.php
+++ b/resources/views/schedule/lineEdit.blade.php
@@ -258,13 +258,9 @@
         <div class="schedule-line-grid">
             <div>
                 <label>User (Owner)</label>
-                <select name="user_id" class="form-select form-select-sm" form="line-form-{{ $line->id }}">
-                    <option value="">— None —</option>
-                    @foreach($userOptions as $opt)
-                    <option value="{{ $opt['id'] }}" @selected($line->user_id == $opt['id'])>
-                        {{ $opt['label'] }}
-                    </option>
-                    @endforeach
+                <select name="user_id" class="form-select form-select-sm js-user-select"
+                    form="line-form-{{ $line->id }}"
+                    data-selected="{{ $line->user_id ?? '' }}">
                 </select>
             </div>
             <div>
@@ -353,6 +349,10 @@
 </div>
 @endforeach
 
+<div class="d-flex justify-content-center mt-3">
+    {{ $lines->appends(request()->query())->links() }}
+</div>
+
 @endif
 
 {{-- 複写入力モーダル --}}
@@ -401,6 +401,21 @@
 </div>
 
 @push('scripts')
+<script type="application/json" id="user-options-data">{!! json_encode($userOptions) !!}</script>
+<script>
+    (function() {
+        const opts = JSON.parse(document.getElementById('user-options-data').textContent);
+        document.querySelectorAll('select.js-user-select').forEach(function(sel) {
+            const selectedId = String(sel.dataset.selected ?? '');
+            sel.appendChild(new Option('— None —', ''));
+            opts.forEach(function(opt) {
+                const o = new Option(opt.label, opt.id);
+                if (String(opt.id) === selectedId) o.selected = true;
+                sel.appendChild(o);
+            });
+        });
+    })();
+</script>
 <script>
     (function() {
         const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||


### PR DESCRIPTION
## `schedules/edit` パフォーマンス改善

### 以前の仕様

- `schedules/edit`（Schedule Lines 一覧）は、日付フィルタに合致する全件を一度に取得・レンダリングしていた
- 最大約 5,000 件が対象となり、ページ読み込みに **約 7.8 秒 / 1,341 kB** を要していた
- 各行の `<select name="user_id">` にユーザー選択肢を HTML として直接出力していた
- そのため、ユーザー数 × 行数分の `<option>` 要素が DOM に存在していた  
  - 例：30ユーザー × 5,000行 = 150,000要素

---

### 今の仕様

- 1ページ **50件** 単位のページネーションで表示
- 検索フィルタの条件はページ遷移時も維持
- ユーザー選択肢は JavaScript で一括初期化
- HTML への重複出力を排除

---

### 変更ポイント

| # | 変更箇所 | 内容 |
|---|---|---|
| 1 | `ScheduleLineController::edit()` | `->get()` から `->paginate(50)` に変更 |
| 2 | `lineEdit.blade.php` | 各行の `<select>` から `@foreach($userOptions)` を削除し、`data-selected` 属性で選択状態を保持 |
| 3 | `lineEdit.blade.php` | `<script type="application/json">` でユーザー選択肢を1回だけ出力し、JS で全 select を初期化 |
| 4 | `lineEdit.blade.php` | ページネーションリンクを追加し、検索クエリを `appends()` で引き継ぎ |

---

### 実装要点

#### ページネーション

`LengthAwarePaginator` は `isEmpty()` や `foreach` がそのまま使えるため、Blade 側の変更は最小限。

また、以下のようにすることで、`Active On`・`User`・`DOW` などの検索条件をページ間で引き継ぐ。

```php
{{ $scheduleLines->appends(request()->query())->links() }}