### PR TITLE
Flash メッセージを既存 Toast 基盤に統一

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -112,7 +112,7 @@ class AdminController extends Controller
             $user->assignRole('general');
         });
 
-        return redirect()->route('admin.dashboard')->with("status", "登録成功");
+        return redirect()->route('admin.dashboard')->with("toast", "登録成功");
     }
 
     /**

--- a/app/Http/Controllers/EmploymentTermController.php
+++ b/app/Http/Controllers/EmploymentTermController.php
@@ -61,6 +61,6 @@ class EmploymentTermController extends Controller
 
         return redirect()
             ->route('employment_terms.details', $employmentTerm->user)
-            ->with('status', '雇用情報を更新しました。');
+            ->with('toast', '雇用情報を更新しました。');
     }
 }

--- a/app/Http/Controllers/ExpenseEditController.php
+++ b/app/Http/Controllers/ExpenseEditController.php
@@ -199,7 +199,7 @@ class ExpenseEditController extends Controller
 
         // ここは「SUBMITTED のときだけ戻せる」などルールを入れてもOK
         if ($report->status !== ExpenseReportStatus::SUBMITTED) {
-            return back()->with('error', 'Only submitted reports can be unsubmitted.');
+            return back()->with('toast_errors', ['Only submitted reports can be unsubmitted.']);
         }
 
         $report->update([

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -68,7 +68,7 @@ class LeaveController extends Controller
             }
         });
 
-        return back()->with('success', '申請を取り消しました。');
+        return back()->with('toast', '申請を取り消しました。');
     }
 
     /**
@@ -167,10 +167,10 @@ class LeaveController extends Controller
         }
 
         if ($leave->kind !== 'absence') {
-            return back()->with('error', 'This leave is not target for absence self-report.');
+            return back()->with('toast_errors', ['This leave is not target for absence self-report.']);
         }
         if (!is_null($leave->handle_type)) {
-            return back()->with('error', 'Already submitted.');
+            return back()->with('toast_errors', ['Already submitted.']);
         }
 
         $validated = $request->validate([
@@ -210,7 +210,7 @@ class LeaveController extends Controller
             ]);
         }
 
-        return back()->with('status', 'Submitted.');
+        return back()->with('toast', 'Submitted.');
     }
 
     public function allReport(Request $request)

--- a/app/Http/Controllers/LessonCsvController.php
+++ b/app/Http/Controllers/LessonCsvController.php
@@ -98,7 +98,7 @@ class LessonCsvController extends Controller
         fclose($fp);
 
         if (!empty($parseErrors)) {
-            return back()->with('import_errors', $parseErrors);
+            return back()->with('toast_errors', $parseErrors);
         }
 
         if (empty($rows)) {
@@ -126,7 +126,7 @@ class LessonCsvController extends Controller
         }
 
         if (!empty($validationErrors)) {
-            return back()->with('import_errors', $validationErrors);
+            return back()->with('toast_errors', $validationErrors);
         }
 
         // DB保存（トランザクション）
@@ -165,7 +165,7 @@ class LessonCsvController extends Controller
             }
         });
 
-        return back()->with('import_success', "インポート完了：作成 {$created} 件、更新 {$updated} 件");
+        return back()->with('toast', "インポート完了：作成 {$created} 件、更新 {$updated} 件");
     }
 
     /**

--- a/app/Http/Controllers/RoleChangeController.php
+++ b/app/Http/Controllers/RoleChangeController.php
@@ -84,7 +84,7 @@ class RoleChangeController extends Controller
             $this->notifyApprovers($data['role'], $rc);
         });
 
-        return back()->with('status', '権限変更の申請を受け付けました。');
+        return back()->with('toast', '権限変更の申請を受け付けました。');
     }
 
     // 表示名に使う簡易マップ（Bladeの getRoleLabelAttribute に合わせる）

--- a/app/Http/Controllers/ScheduleCsvController.php
+++ b/app/Http/Controllers/ScheduleCsvController.php
@@ -32,11 +32,11 @@ class ScheduleCsvController extends Controller
         try {
             $result = $service->import($path);
         } catch (Throwable $e) {
-            return back()->with('import_errors', ['予期しないエラーが発生しました: ' . $e->getMessage()]);
+            return back()->with('toast_errors', ['予期しないエラーが発生しました: ' . $e->getMessage()]);
         }
 
         if (!empty($result['errors'])) {
-            return back()->with('import_errors', $result['errors']);
+            return back()->with('toast_errors', $result['errors']);
         }
 
         $msg = sprintf(
@@ -47,6 +47,6 @@ class ScheduleCsvController extends Controller
             $result['detail_updated'],
         );
 
-        return back()->with('import_success', $msg);
+        return back()->with('toast', $msg);
     }
 }

--- a/app/Http/Controllers/ScheduleLineController.php
+++ b/app/Http/Controllers/ScheduleLineController.php
@@ -176,7 +176,7 @@ class ScheduleLineController extends Controller
 
         $line->fill($data)->save();
 
-        return back()->with('status', "Line #{$line->id} を更新しました。");
+        return back()->with('toast', "Line #{$line->id} を更新しました。");
     }
 
     public function bulkUpdate(Request $request): JsonResponse

--- a/app/Http/Controllers/UserCsvController.php
+++ b/app/Http/Controllers/UserCsvController.php
@@ -138,7 +138,7 @@ class UserCsvController extends Controller
         fclose($fp);
 
         if (!empty($parseErrors)) {
-            return back()->with('import_errors', $parseErrors);
+            return back()->with('toast_errors', $parseErrors);
         }
 
         if (empty($rows)) {
@@ -219,7 +219,7 @@ class UserCsvController extends Controller
         }
 
         if (!empty($validationErrors)) {
-            return back()->with('import_errors', $validationErrors);
+            return back()->with('toast_errors', $validationErrors);
         }
 
         // ====== DB保存（トランザクション）======
@@ -288,7 +288,7 @@ class UserCsvController extends Controller
         });
 
         return back()->with(
-            'import_success',
+            'toast',
             "インポート完了：作成 {$created} 件、更新 {$updated} 件、雇用期間処理 {$employmentProcessed} 件"
         );
     }

--- a/resources/views/calendar/absenceReportAll.blade.php
+++ b/resources/views/calendar/absenceReportAll.blade.php
@@ -10,8 +10,6 @@
     <span class="badge text-bg-primary">Admin View</span>
 </div>
 
-@if(session('success')) <div class="alert alert-success py-2 mb-2">{{ session('success') }}</div> @endif
-@if(session('error')) <div class="alert alert-danger  py-2 mb-2">{{ session('error') }}</div> @endif
 @if ($errors->any())
 <div class="alert alert-danger py-2 mb-2">
     <ul class="mb-0">@foreach ($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>

--- a/resources/views/csv/lesson_csv.blade.php
+++ b/resources/views/csv/lesson_csv.blade.php
@@ -8,14 +8,6 @@
     <h2 class="mb-0">Lesson CSV</h2>
 </div>
 
-{{-- 成功メッセージ --}}
-@if (session('import_success'))
-    <div class="alert alert-success alert-dismissible fade show" role="alert">
-        <i class="fas fa-check-circle me-2"></i>{{ session('import_success') }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    </div>
-@endif
-
 {{-- バリデーション / パースエラー --}}
 @if ($errors->any())
     <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -23,18 +15,6 @@
         <ul class="mb-0 mt-1">
             @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    </div>
-@endif
-
-@if (session('import_errors'))
-    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-        <i class="fas fa-exclamation-triangle me-2"></i><strong>インポートエラー（{{ count(session('import_errors')) }} 件）</strong>
-        <ul class="mb-0 mt-1" style="max-height:300px;overflow-y:auto;">
-            @foreach (session('import_errors') as $err)
-                <li>{{ $err }}</li>
             @endforeach
         </ul>
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>

--- a/resources/views/csv/schedule_csv.blade.php
+++ b/resources/views/csv/schedule_csv.blade.php
@@ -8,14 +8,6 @@
     <h2 class="mb-0">Schedule CSV</h2>
 </div>
 
-{{-- 成功メッセージ --}}
-@if (session('import_success'))
-    <div class="alert alert-success alert-dismissible fade show" role="alert">
-        <i class="fas fa-check-circle me-2"></i>{{ session('import_success') }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    </div>
-@endif
-
 {{-- バリデーション / パースエラー --}}
 @if ($errors->any())
     <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -23,18 +15,6 @@
         <ul class="mb-0 mt-1">
             @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    </div>
-@endif
-
-@if (session('import_errors'))
-    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-        <i class="fas fa-exclamation-triangle me-2"></i><strong>インポートエラー（{{ count(session('import_errors')) }} 件）</strong>
-        <ul class="mb-0 mt-1" style="max-height:300px;overflow-y:auto;">
-            @foreach (session('import_errors') as $err)
-                <li>{{ $err }}</li>
             @endforeach
         </ul>
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>

--- a/resources/views/csv/user_csv.blade.php
+++ b/resources/views/csv/user_csv.blade.php
@@ -8,14 +8,6 @@
     <h2 class="mb-0">User CSV</h2>
 </div>
 
-{{-- 成功メッセージ --}}
-@if (session('import_success'))
-    <div class="alert alert-success alert-dismissible fade show" role="alert">
-        <i class="fas fa-check-circle me-2"></i>{{ session('import_success') }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    </div>
-@endif
-
 {{-- バリデーション / パースエラー --}}
 @if ($errors->any())
     <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -23,18 +15,6 @@
         <ul class="mb-0 mt-1">
             @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    </div>
-@endif
-
-@if (session('import_errors'))
-    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-        <i class="fas fa-exclamation-triangle me-2"></i><strong>インポートエラー（{{ count(session('import_errors')) }} 件）</strong>
-        <ul class="mb-0 mt-1" style="max-height:300px;overflow-y:auto;">
-            @foreach (session('import_errors') as $err)
-                <li>{{ $err }}</li>
             @endforeach
         </ul>
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>

--- a/resources/views/leaves/create.blade.php
+++ b/resources/views/leaves/create.blade.php
@@ -2,8 +2,6 @@
 @extends('layouts.app')
 @section('content')
 <div class="container max-w-xl mx-auto">
-    @if(session('success')) <div class="alert alert-success">{{ session('success') }}</div> @endif
-
     <h1 class="text-lg font-bold mb-4">Leave 新規</h1>
     <form method="post" action="{{ route('leaves.store') }}">
         @csrf

--- a/resources/views/schedule/detailsEdit.blade.php
+++ b/resources/views/schedule/detailsEdit.blade.php
@@ -91,8 +91,6 @@
     </div>
 </div>
 
-<div id="flash-area" class="mb-2"></div>
-
 @if($details->isEmpty())
 <div class="alert alert-secondary">このラインには明細がありません。</div>
 @else
@@ -194,18 +192,6 @@
             document.querySelector('meta[name="csrf-token"]')?.content ||
             document.querySelector('input[name="_token"]')?.value;
 
-        function showFlash(message, type = 'success') {
-            const area = document.getElementById('flash-area');
-            if (!area || !message) return;
-            const wrap = document.createElement('div');
-            wrap.innerHTML = `
-      <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-        ${message}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>`;
-            area.prepend(wrap.firstElementChild);
-        }
-
         // lesson_code 変更 → レッスン取得して name / minute / note を反映し、End再計算
         document.addEventListener('change', async (e) => {
             const codeInput = e.target.closest('.js-lesson-code');
@@ -242,7 +228,7 @@
                 recalcEndTime(card);
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || 'レッスン取得に失敗しました。', 'danger');
+                window.showToast(err.message || 'レッスン取得に失敗しました。', { variant: 'danger' });
             }
         });
 
@@ -274,7 +260,7 @@
         document.getElementById('details-bulk-save')?.addEventListener('click', async () => {
             // カードを対象に収集
             const rows = Array.from(document.querySelectorAll('.js-detail-row[data-id]'));
-            if (!rows.length) return showFlash('保存対象がありません。', 'danger');
+            if (!rows.length) return window.showToast('保存対象がありません。', { variant: 'danger' });
 
             const items = rows.map(card => {
                 const id = Number(card.dataset.id);
@@ -317,7 +303,7 @@
                 if (res.ok && (data.ok || data.updated > 0)) {
                     if (data.errors && data.errors.length) {
                         const list = data.errors.map(e => `#${e.id ?? '-'}: ${e.messages.join(' / ')}`).join('<br>');
-                        showFlash(`${data.message}<br>${list}`, 'warning');
+                        window.showToast(`${data.message} / ${list}`, { variant: 'warning' });
                     } else {
                         sessionStorage.setItem('flash', JSON.stringify({
                             message: data.message || '保存しました。',
@@ -332,7 +318,7 @@
                 }
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '一括保存に失敗しました。', 'danger');
+                window.showToast(err.message || '一括保存に失敗しました。', { variant: 'danger' });
             }
         });
 
@@ -363,7 +349,7 @@
                 window.location.href = u.toString();
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '追加に失敗しました。', 'danger');
+                window.showToast(err.message || '追加に失敗しました。', { variant: 'danger' });
             }
         });
 
@@ -397,7 +383,7 @@
                 window.location.href = u.toString();
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '複写に失敗しました。', 'danger');
+                window.showToast(err.message || '複写に失敗しました。', { variant: 'danger' });
             }
         });
 
@@ -434,23 +420,20 @@
                 window.location.href = u.toString();
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '削除に失敗しました。', 'danger');
+                window.showToast(err.message || '削除に失敗しました。', { variant: 'danger' });
             }
         });
 
         // リロード越しフラッシュ復元
-        (function restoreFlashOnce() {
+        document.addEventListener('DOMContentLoaded', function restoreFlashOnce() {
             try {
                 const raw = sessionStorage.getItem('flash');
                 if (!raw) return;
-                const {
-                    message,
-                    type
-                } = JSON.parse(raw);
-                showFlash(message, type || 'success');
+                const { message, type } = JSON.parse(raw);
+                if (message) window.showToast(message, { variant: type || 'success' });
                 sessionStorage.removeItem('flash');
             } catch (e) {}
-        })();
+        });
     })();
 </script>
 @endpush

--- a/resources/views/schedule/lineEdit.blade.php
+++ b/resources/views/schedule/lineEdit.blade.php
@@ -421,18 +421,6 @@
         const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
             document.querySelector('input[name="_token"]')?.value;
 
-        function showFlash(message, type = 'success') {
-            const area = document.getElementById('flash-area');
-            if (!area) return;
-            const wrapper = document.createElement('div');
-            wrapper.innerHTML = `
-      <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-        ${message}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>`;
-            area.prepend(wrapper.firstElementChild);
-        }
-
         async function handleDelete(btn) {
             const url = btn.getAttribute('data-delete-url');
             const lineId = btn.getAttribute('data-line-id');
@@ -454,10 +442,10 @@
                 // block 対応: 該当 .schedule-line-block と hidden form を削除する
                 btn.closest('.schedule-line-block')?.remove();
                 document.getElementById(`line-form-${lineId}`)?.remove();
-                showFlash(data.message || `Line #${lineId} を削除しました。`, 'success');
+                window.showToast(data.message || `Line #${lineId} を削除しました。`, { variant: 'success' });
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '削除に失敗しました。', 'danger');
+                window.showToast(err.message || '削除に失敗しました。', { variant: 'danger' });
                 btn.disabled = false;
             }
         }
@@ -475,18 +463,6 @@
             document.querySelector('meta[name="csrf-token"]')?.content ||
             document.querySelector('input[name="_token"]')?.value;
 
-        function showFlash(message, type = 'success') {
-            const area = document.getElementById('flash-area');
-            if (!area || !message) return;
-            const wrap = document.createElement('div');
-            wrap.innerHTML = `
-      <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-        ${message}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>`;
-            area.prepend(wrap.firstElementChild);
-        }
-
         function persistFlash(message, type = 'success') {
             try { sessionStorage.setItem('flash', JSON.stringify({ message, type, t: Date.now() })); } catch (e) {}
         }
@@ -496,12 +472,12 @@
                 const raw = sessionStorage.getItem('flash');
                 if (!raw) return;
                 const { message, type } = JSON.parse(raw);
-                if (message) showFlash(message, type || 'success');
+                if (message) window.showToast(message, { variant: type || 'success' });
                 sessionStorage.removeItem('flash');
             } catch (e) {}
         }
 
-        restoreFlashOnce();
+        document.addEventListener('DOMContentLoaded', restoreFlashOnce);
 
         let copyCtx = { url: null, lineId: null, currentUser: '' };
 
@@ -536,8 +512,8 @@
             const memoInput = document.getElementById('copy-memo');
             const memo = memoInput?.value?.trim() || null;
 
-            if (!start || !end) { showFlash('開始日と終了日を入力してください。', 'danger'); return; }
-            if (start > end) { showFlash('終了日は開始日以降にしてください。', 'danger'); return; }
+            if (!start || !end) { window.showToast('開始日と終了日を入力してください。', { variant: 'danger' }); return; }
+            if (start > end) { window.showToast('終了日は開始日以降にしてください。', { variant: 'danger' }); return; }
             if (!copyCtx.url) return;
 
             try {
@@ -562,7 +538,7 @@
                 window.location.href = new URL(window.location.href).toString();
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '複写に失敗しました。', 'danger');
+                window.showToast(err.message || '複写に失敗しました。', { variant: 'danger' });
             } finally {
                 bootstrap.Modal.getOrCreateInstance(document.getElementById('copyLineModal')).hide();
             }
@@ -594,16 +570,7 @@
             window.location.href = new URL(window.location.href).toString();
         } catch (err) {
             console.error(err);
-            const area = document.getElementById('flash-area');
-            if (area) {
-                const wrap = document.createElement('div');
-                wrap.innerHTML = `
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-          ${err.message || '追加に失敗しました。'}
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>`;
-                area.prepend(wrap.firstElementChild);
-            }
+            window.showToast(err.message || '追加に失敗しました。', { variant: 'danger' });
         }
     });
 </script>
@@ -612,18 +579,6 @@
         const csrf =
             document.querySelector('meta[name="csrf-token"]')?.content ||
             document.querySelector('input[name="_token"]')?.value;
-
-        function showFlash(message, type = 'success') {
-            const area = document.getElementById('flash-area');
-            if (!area || !message) return;
-            const wrap = document.createElement('div');
-            wrap.innerHTML = `
-      <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-        ${message}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>`;
-            area.prepend(wrap.firstElementChild);
-        }
 
         function persistFlash(message, type = 'success') {
             try { sessionStorage.setItem('flash', JSON.stringify({ message, type, t: Date.now() })); } catch (e) {}
@@ -663,7 +618,7 @@
                 } catch (e) { console.warn('collect error:', e); }
             });
 
-            if (!items.length) { showFlash('保存対象がありません。', 'danger'); return; }
+            if (!items.length) { window.showToast('保存対象がありません。', { variant: 'danger' }); return; }
 
             try {
                 const res = await fetch(`{{ route('schedule_lines.bulk_update') }}`, {
@@ -680,7 +635,7 @@
                 if (res.ok && (data.ok || data.updated > 0)) {
                     if (data.errors && data.errors.length) {
                         const list = data.errors.map(e => `#${e.id ?? '-'}: ${e.messages.join(' / ')}`).join('<br>');
-                        showFlash(`${data.message}<br>${list}`, 'warning');
+                        window.showToast(`${data.message} / ${list}`, { variant: 'warning' });
                     } else {
                         persistFlash(data.message || '一括保存が完了しました。', 'success');
                         window.location.href = new URL(window.location.href).toString();
@@ -691,7 +646,7 @@
                 }
             } catch (err) {
                 console.error(err);
-                showFlash(err.message || '一括保存に失敗しました。', 'danger');
+                window.showToast(err.message || '一括保存に失敗しました。', { variant: 'danger' });
             }
         });
     })();

--- a/resources/views/user/profile/employment/details.blade.php
+++ b/resources/views/user/profile/employment/details.blade.php
@@ -12,11 +12,6 @@
             <h4 class="mb-0">{{ $user->name }}さんの雇用履歴</h4>
         </div>
 
-        {{-- ステータスメッセージ --}}
-        @if(session('status'))
-        <div class="alert alert-success">{{ session('status') }}</div>
-        @endif
-
         {{-- 雇用期間ごとのカード --}}
         @forelse($employmentTerms as $term)
         <div class="card mb-3">


### PR DESCRIPTION
## Flash メッセージの Toast 統一

### 背景

各 Controller / Blade でバラバラだった flash メッセージ表示を、既存の Toast 基盤に統一しました。

今回使用するセッションキーは以下です。

- `toast`
- `toast_errors`

---

## Toast 基盤の仕組み

※ 既存基盤のため、今回変更なし。

### Controller

return redirect()
    ->with('toast', 'メッセージ')
    ->with('toast_errors', ['エラー1', 'エラー2']);

### `app.blade.php`

<div id="toastFlash"
     data-toast='@json(session("toast"))'
     data-errors='@json(session("toast_errors"))'>
</div>

- `toast`：成功メッセージとして表示（`bg-success`）
- `toast_errors`：エラーメッセージ配列として表示（`bg-danger` × n件）

### `toast.js`

document.addEventListener('DOMContentLoaded', () => {
    window.showToast(message, { variant });
});

Bootstrap 5 Toast を動的に生成・表示します。

---

## Controller の変更

対象：9ファイル

旧キーを Toast 用キーに統一しました。  
既存メッセージ文言はそのまま維持しています。

| 旧キー | 新キー | 対象 Controller |
|---|---|---|
| `status` | `toast` | `AdminController`, `RoleChangeController`, `EmploymentTermController`, `ScheduleLineController`, `LeaveController` |
| `success` | `toast` | `LeaveController` |
| `error` | `toast_errors` | `LeaveController`, `ExpenseEditController` |
| `import_success` | `toast` | `ScheduleCsvController`, `LessonCsvController`, `UserCsvController` |
| `import_errors` | `toast_errors` | `ScheduleCsvController`, `LessonCsvController`, `UserCsvController` |

---

## Blade の変更

対象：8ファイル

Toast と二重表示になる個別 `alert` のみ削除しました。

| ファイル | 変更内容 |
|---|---|
| `commons/messages.blade.php` | `session('status')` alert ブロックを削除 |
| `user/profile/employment/details.blade.php` | `session('status')` alert を削除 |
| `leaves/create.blade.php` | `session('success')` alert を削除 |
| `calendar/absenceReportAll.blade.php` | `session('success')` / `session('error')` alert を削除 |
| `csv/schedule_csv.blade.php` | `session('import_success')` / `session('import_errors')` alert を削除 |
| `csv/lesson_csv.blade.php` | `session('import_success')` / `session('import_errors')` alert を削除 |
| `csv/user_csv.blade.php` | `session('import_success')` / `session('import_errors')` alert を削除 |

---

## JS の Ajax フィードバックを Toast 化

対象：

- `schedule/lineEdit.blade.php`
- `schedule/detailsEdit.blade.php`

削除・複写・一括保存・追加の Ajax 操作用に定義されていたローカル `showFlash()` を、既存 Toast 基盤の `window.showToast()` に置き換えました。

### 変更前

function showFlash(message, type = 'success') {
    const area = document.getElementById('flash-area');
    area.prepend(/* alert div */);
}

### 変更後

window.showToast(message, { variant: type });

---

## リロードをまたぐ成功メッセージ対応

複写・追加・一括保存など、Ajax 成功後にページリロードを行う処理では、`sessionStorage` 経由で Toast メッセージを復元するようにしました。

### Ajax 成功時

persistFlash(data.message, 'success');
window.location.href = ...;

### リロード後

document.addEventListener('DOMContentLoaded', function restoreFlashOnce() {
    const { message, type } = JSON.parse(sessionStorage.getItem('flash'));
    window.showToast(message, { variant: type });
    sessionStorage.removeItem('flash');
});

---

## タイミング修正

Vite は `app.js` を `<script type="module">` で出力するため、`window.showToast` の定義はモジュール読み込み完了後になります。

一方、`@stack('scripts')` のインライン IIFE はそれより先に実行される場合があり、旧コードでは `restoreFlashOnce()` 実行時に `window.showToast` が `undefined` となり、Toast が表示されない問題がありました。

そのため、復元処理を `DOMContentLoaded` リスナー内に移動し、`window.showToast` 定義後に実行されるよう修正しました。

---

## 変更しなかったもの

以下は今回の対象外として変更していません。

- validation error
  - `withErrors`
  - `$errors->any()`
  - `@error`
- JSON / Ajax レスポンス本体
  - `response()->json()`
- 既に Toast 化済みの Controller
  - `LeaveManageController`
  - `PostController`
  - など