### PR TITLE
認可をPolicy/Gateへ統一し管理系処理の二重防御を整理

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -24,6 +24,8 @@ class AdminController extends Controller
      */
     public function dashboard(Request $request): View
     {
+        $this->authorize('viewAny', User::class);
+
         // 検索対象フィールドのホワイトリスト
         $allowedFields = ['employee_code', 'name', 'phone_number'];
 
@@ -69,6 +71,8 @@ class AdminController extends Controller
 
     public function showForm()
     {
+        $this->authorize('create', User::class);
+
         // 現在のスコープ（地区・部署）を登録フォームで確認表示するために渡す
         // currentScope() が内部で district/department を with() 済みのため load() 不要
         $scope = $this->scopeService->currentScope();
@@ -81,6 +85,8 @@ class AdminController extends Controller
      */
     public function register(UserRequest $request): RedirectResponse
     {
+        $this->authorize('create', User::class);
+
         $data = $request->validated();
 
         DB::transaction(function () use ($data, &$user) {
@@ -121,6 +127,8 @@ class AdminController extends Controller
      */
     public function search(Request $request): View
     {
+        $this->authorize('viewAny', User::class);
+
         $allowedFields = ['employee_code', 'name', 'phone_number'];
 
         $word   = trim((string) $request->query('search_word', ''));

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -17,14 +17,12 @@ class CalendarController extends Controller
     public function index(Request $request, ?User $user = null)
     {
         $viewer = Auth::user();
-        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
-        $viewUser = $user ?? ($isAdmin ? null : $viewer);
-        if (!$isAdmin && ($viewUser?->id !== $viewer->id)) {
-            abort(403);
-        }
+        $canViewAnyUser = $viewer->can('viewAny', User::class);
+        $viewUser = $user ?? ($canViewAnyUser ? null : $viewer);
+        $this->authorize('view', $user ?? $viewer);
 
         // スコープが切り替わった後に古いユーザーのURLが残っている場合はリセット
-        if ($isAdmin && $viewUser !== null) {
+        if ($canViewAnyUser && $viewUser !== null) {
             $currentDid = $this->scopeService->currentDistrictId();
             if ($currentDid !== null && $viewUser->district_id !== $currentDid) {
                 return redirect()->route('calendar.index');
@@ -32,7 +30,7 @@ class CalendarController extends Controller
         }
 
         // 管理者だけにセレクト用リストを渡す（district/department で直接絞り込み）
-        $userOptions = $viewer->hasRole(['admin', 'super_admin'])
+        $userOptions = $canViewAnyUser
             ? User::query()
                 ->when($this->scopeService->currentDistrictId(),
                     fn($q, $did) => $q->where('district_id', $did))
@@ -60,7 +58,7 @@ class CalendarController extends Controller
             $rawUserId = $request->query('user_id');
             $noUserSelected = $rawUserId === null || $rawUserId === '' || $rawUserId === 'null' || (int)$rawUserId <= 0;
 
-            if ($noUserSelected && $viewer->hasRole(['admin', 'super_admin'])) {
+            if ($noUserSelected && $viewer->can('viewAny', User::class)) {
                 $holidays = app(\App\Services\Calendar\Providers\HolidayProvider::class)->provide($viewer, $start, $end);
                 $closures = app(\App\Services\Calendar\Providers\ClosureProvider::class)->provide($viewer, $start, $end);
                 $holidayDates = array_flip(array_map(fn($e) => $e->dateKey, $holidays));
@@ -70,9 +68,8 @@ class CalendarController extends Controller
             }
 
             $targetUserId = (int) $request->query('user_id', $viewer->id);
-            if (!$viewer->hasRole(['admin', 'super_admin']) && $targetUserId !== $viewer->id) abort(403);
-
             $user = User::findOrFail($targetUserId);
+            $this->authorize('view', $user);
 
             $events = $resolver->build($user, $start, $end);
             return response()->json($events);

--- a/app/Http/Controllers/CommuterPassAdvisorController.php
+++ b/app/Http/Controllers/CommuterPassAdvisorController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ScheduleLine;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -13,6 +14,8 @@ class CommuterPassAdvisorController extends Controller
 {
     public function index(Request $request)
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         // --- 入力値（画面再表示用） ---
         $inFrom = $request->query('from');
         $inTo   = $request->query('to');

--- a/app/Http/Controllers/CommuterPassController.php
+++ b/app/Http/Controllers/CommuterPassController.php
@@ -19,10 +19,7 @@ class CommuterPassController extends Controller
 
         $isAdminMode = $user !== null;
         $target      = $user ?: $me;
-
-        if ($isAdminMode && !$me->hasAnyRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+        $this->authorize('view', $target);
 
         return view('routes.registerPass', [
             'target'      => $target,
@@ -40,10 +37,7 @@ class CommuterPassController extends Controller
         $me = $request->user();
         $isAdminMode = $user !== null;
         $target      = $user ?: $me;
-
-        if ($isAdminMode && !$me->hasAnyRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+        $this->authorize('update', $target);
 
         $data = $this->validateRequest($request);
 

--- a/app/Http/Controllers/CsvController.php
+++ b/app/Http/Controllers/CsvController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
+
 class CsvController extends Controller
 {
     public function index()
     {
+        $this->authorize('viewAny', User::class);
         return view('csv.csv_list');
     }
 }

--- a/app/Http/Controllers/CurrentScopeController.php
+++ b/app/Http/Controllers/CurrentScopeController.php
@@ -21,11 +21,8 @@ class CurrentScopeController extends Controller
             'scope_id' => ['required', 'integer'],
         ]);
 
-        $exists = UserManagementScope::where('id', $validated['scope_id'])
-            ->where('user_id', $request->user()->id)
-            ->exists();
-
-        abort_unless($exists, 403);
+        $scope = UserManagementScope::findOrFail($validated['scope_id']);
+        $this->authorize('select', $scope);
 
         $request->session()->put('selected_scope_id', $validated['scope_id']);
 

--- a/app/Http/Controllers/EmploymentTermController.php
+++ b/app/Http/Controllers/EmploymentTermController.php
@@ -15,6 +15,8 @@ class EmploymentTermController extends Controller
      */
     public function details(User $user): View
     {
+        $this->authorize('view', $user);
+
         $employmentTerms = $user->employmentTerms()
             ->with('leavePeriods')
             ->orderByDesc('start_date')
@@ -29,6 +31,8 @@ class EmploymentTermController extends Controller
     public function edit(EmploymentTerm $employmentTerm): View
     {
         $user = $employmentTerm->user;
+        $this->authorize('update', $user);
+
         return view('user.profile.employment.edit', compact('employmentTerm', 'user'));
     }
 
@@ -37,6 +41,8 @@ class EmploymentTermController extends Controller
      */
     public function update(EmploymentTermRequest $request, EmploymentTerm $employmentTerm): RedirectResponse
     {
+        $this->authorize('update', $employmentTerm->user);
+
         $data = $request->validated();
 
         // 簡易重複チェック：同一ユーザーの他の employment_term と期間が重複しないか確認

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Event;
+use App\Models\User;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -17,6 +18,8 @@ class EventAssignController extends Controller
 
     public function edit(Request $request)
     {
+        $this->authorize('viewAny', Event::class);
+
         $userOptions = $this->scopeService->targetUserQuery()
             ->select('id', 'first_name', 'family_name', 'employee_code')
             ->orderBy('employee_code')
@@ -128,6 +131,8 @@ class EventAssignController extends Controller
 
     public function update(Request $request, Event $event)
     {
+        $this->authorize('update', $event);
+
         $validated = $request->validate([
             'event_date'        => ['required', 'date'],
             'original_user_id'  => ['nullable', 'exists:users,id'],
@@ -163,6 +168,7 @@ class EventAssignController extends Controller
 
         $validated['start_time'] = $normalizeTime($request->input('start_time', ''));
         $validated['end_time']   = $normalizeTime($request->input('end_time', ''));
+        $this->authorizeReferencedUsers($validated);
 
         // ⬇︎ total_duration 未入力で start/end がある場合は自動計算
         if (empty($validated['total_duration']) && $validated['start_time'] && $validated['end_time']) {
@@ -184,13 +190,15 @@ class EventAssignController extends Controller
 
     public function destroy(Request $request, Event $event)
     {
-        // 必要ならポリシー/権限チェックをここで
+        $this->authorize('delete', $event);
         $event->delete();
         return back()->with('toast', 'Deleted');
     }
 
     public function store(Request $request)
     {
+        $this->authorize('create', Event::class);
+
         $validated = $request->validate([
             'event_date'        => ['required', 'date'],
             'original_user_id'  => ['nullable', 'exists:users,id'],
@@ -227,6 +235,7 @@ class EventAssignController extends Controller
             $validated['total_duration'] = sprintf('%d:%02d', intdiv($mins, 60), $mins % 60);
         }
 
+        $this->authorizeReferencedUsers($validated);
         $validated['district_id']   = $this->scopeService->currentDistrictId();
         $validated['department_id'] = $this->scopeService->currentDepartmentId();
         Event::create($validated);
@@ -236,6 +245,8 @@ class EventAssignController extends Controller
 
     public function storeBlank(Request $request)
     {
+        $this->authorize('create', Event::class);
+
         // リクエストやURLクエリから event_date を取得（POSTでもGETでも対応）
         $date = $request->input('event_date', now()->toDateString());
 
@@ -253,6 +264,8 @@ class EventAssignController extends Controller
 
     public function bulkUpdate(Request $request)
     {
+        $this->authorize('viewAny', Event::class);
+
         $items = $request->input('items', []);
         if (!is_array($items) || empty($items)) {
             return response()->json(['ok' => false, 'message' => '対象がありません'], 422);
@@ -283,6 +296,13 @@ class EventAssignController extends Controller
                 continue;
             }
             $data = $v->validated();
+            $event = Event::find($data['id']);
+            if (! $event) {
+                $results[] = ['id' => $data['id'], 'ok' => false, 'errors' => ['Event not found.']];
+                continue;
+            }
+            $this->authorize('update', $event);
+            $this->authorizeReferencedUsers($data);
 
             // H:i → H:i:s に正規化
             foreach (['start_time', 'end_time'] as $k) {
@@ -302,7 +322,6 @@ class EventAssignController extends Controller
                 $data['total_duration'] = sprintf('%d:%02d', intdiv($mins, 60), $mins % 60);
             }
 
-            $event = Event::find($data['id']);
             $event->fill($data)->save(); // Observerがあれば最終整合を取ってくれます
 
             $results[] = ['id' => $event->id, 'ok' => true];
@@ -328,6 +347,8 @@ class EventAssignController extends Controller
 
     public function sublistPreview(Request $request)
     {
+        $this->authorize('viewAny', Event::class);
+
         return view('pdf.preview', [
             'type'        => 'sublist',
             'queryString' => $request->getQueryString() ?? '',
@@ -336,6 +357,8 @@ class EventAssignController extends Controller
 
     public function confirmationsPreview(Request $request)
     {
+        $this->authorize('viewAny', Event::class);
+
         return view('pdf.preview', [
             'type'        => 'confirmations',
             'queryString' => $request->getQueryString() ?? '',
@@ -344,6 +367,8 @@ class EventAssignController extends Controller
 
     public function exportSubPdfJson(Request $request)
     {
+        $this->authorize('viewAny', Event::class);
+
         $mode = $request->string('mode')->lower()->value();
         if (!in_array($mode, ['tentative', 'final', 'master'], true)) {
             $mode = 'tentative';
@@ -447,6 +472,8 @@ class EventAssignController extends Controller
 
     public function exportConfirmationsPdfJson(Request $request)
     {
+        $this->authorize('viewAny', Event::class);
+
         $mode = $request->string('mode')->lower()->value();
         if (!in_array($mode, ['alp', 'ot'], true)) {
             $mode = 'alp';
@@ -562,5 +589,18 @@ class EventAssignController extends Controller
             ->orderBy('school_name')
             ->orderBy('start_time')
             ->orderBy('assigned_user_id');
+    }
+
+    private function authorizeReferencedUsers(array $payload): void
+    {
+        foreach (['original_user_id', 'assigned_user_id'] as $key) {
+            $userId = $payload[$key] ?? null;
+            if ($userId === null || $userId === '') {
+                continue;
+            }
+
+            $targetUser = User::findOrFail((int) $userId);
+            $this->authorize('view', $targetUser);
+        }
     }
 }

--- a/app/Http/Controllers/ExpenseApiController.php
+++ b/app/Http/Controllers/ExpenseApiController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\Expense;
 use App\Models\ExpenseReport;
 use App\Models\CommuterPass;
-use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Carbon\Carbon;
@@ -50,12 +49,7 @@ class ExpenseApiController extends Controller
         ]);
 
         $report = ExpenseReport::findOrFail($data['expense_report_id']);
-
-        // 権限（本人 or 管理者）: 必要に応じて置き換え
-        if (method_exists($req->user(), 'isAdmin') && !$req->user()->isAdmin()) {
-            abort_unless($req->user()->id === $report->user_id, 403);
-        }
-        abort_unless(in_array($report->user_id, app(CurrentScopeService::class)->targetUserIds()), 403);
+        $this->authorize('update', $report);
 
         $this->abortIfLocked($report);
 
@@ -89,10 +83,8 @@ class ExpenseApiController extends Controller
     public function update(Request $req, Expense $expense)
     {
         $report = $expense->report;
+        $this->authorize('update', $expense);
 
-        if (method_exists($req->user(), 'isAdmin') && !$req->user()->isAdmin()) {
-            abort_unless($req->user()->id === $report->user_id, 403);
-        }
         $this->abortIfLocked($report);
 
         $data = $req->validate([
@@ -120,10 +112,8 @@ class ExpenseApiController extends Controller
     public function destroy(Request $req, Expense $expense)
     {
         $report = $expense->report;
+        $this->authorize('delete', $expense);
 
-        if (method_exists($req->user(), 'isAdmin') && !$req->user()->isAdmin()) {
-            abort_unless($req->user()->id === $report->user_id, 403);
-        }
         $this->abortIfLocked($report);
 
         $expense->delete();

--- a/app/Http/Controllers/ExpenseEditController.php
+++ b/app/Http/Controllers/ExpenseEditController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use App\Models\ExpenseReport;
 use App\Services\CommutingExpenses\RouteDeclarationService;
-use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
 use App\Enums\ExpenseReportStatus;
@@ -23,11 +22,7 @@ class ExpenseEditController extends Controller
     // 管理者用 /expenses/{user}/edit
     public function adminEdit(User $user, Request $req)
     {
-        // ここは運用に合わせて調整: 例) isAdmin() 判定
-        if (!method_exists($req->user(), 'isAdmin') || !$req->user()->isAdmin()) {
-            abort(403);
-        }
-        abort_unless(in_array($user->id, app(CurrentScopeService::class)->targetUserIds()), 404);
+        $this->authorize('view', $user);
         return $this->renderFor($user, $req);
     }
 
@@ -167,10 +162,8 @@ class ExpenseEditController extends Controller
 
     public function submit(ExpenseReport $report, Request $request)
     {
-        // 認可：本人 or 管理者（Policy推奨）
+        $this->authorize('submit', $report);
         $user = $request->user();
-        $authorized = $user->id === $report->user_id || (method_exists($user, 'isAdmin') && $user->isAdmin());
-        abort_unless($authorized, 403);
 
         // 既に提出済みなら何もしない（冪等）
         if ($report->status !== ExpenseReportStatus::SUBMITTED->value) {
@@ -194,11 +187,10 @@ class ExpenseEditController extends Controller
 
     public function unsubmit(Request $request, ExpenseReport $report)
     {
-        // 後ほどポリシーの実装を行う
-        // $this->authorize('unsubmit', $report);
+        $this->authorize('unsubmit', $report);
 
         // ここは「SUBMITTED のときだけ戻せる」などルールを入れてもOK
-        if ($report->status !== ExpenseReportStatus::SUBMITTED) {
+        if ($report->status !== ExpenseReportStatus::SUBMITTED->value) {
             return back()->with('error', 'Only submitted reports can be unsubmitted.');
         }
 
@@ -216,6 +208,8 @@ class ExpenseEditController extends Controller
      */
     public function generateMonthly(Request $request)
     {
+        $this->authorize('manage', ExpenseReport::class);
+
         // 画面側から送ってくる year/month（なければ今月）
         $year  = (int) $request->input('year', now()->year);
         $month = (int) $request->input('month', now()->month);
@@ -238,6 +232,8 @@ class ExpenseEditController extends Controller
      */
     public function cleanupEmpty(Request $request)
     {
+        $this->authorize('manage', ExpenseReport::class);
+
         // 画面から year/month が送られてきたらそれを使う
         // 何も無ければ「今から2ヶ月前」を対象にする
         if ($request->filled('year') && $request->filled('month')) {

--- a/app/Http/Controllers/ExpenseReportController.php
+++ b/app/Http/Controllers/ExpenseReportController.php
@@ -14,6 +14,8 @@ class ExpenseReportController extends Controller
 
     public function show(Request $request)
     {
+        $this->authorize('manage', ExpenseReport::class);
+
         // Asia/Tokyo 前提
         $today = Carbon::now('Asia/Tokyo');
 

--- a/app/Http/Controllers/LeaveApplyController.php
+++ b/app/Http/Controllers/LeaveApplyController.php
@@ -55,7 +55,7 @@ class LeaveApplyController extends Controller
         }
 
         return $this->applyCore(
-            (int) $request->input('user_id'),
+            (int) auth()->id(),
             (array) $request->input('dates', []),
             (string) $request->input('reason', ''),
             (int) auth()->id(),
@@ -70,7 +70,7 @@ class LeaveApplyController extends Controller
      */
     public function createForUser(User $user)
     {
-        $this->authorize('manage', $user); // 任意（Policyがあれば）
+        $this->authorize('manage', $user);
         return view('leaves.alpApply', [
             'action'     => route('leave.apply.storeForUser', $user),
             'targetUser' => $user,
@@ -82,7 +82,7 @@ class LeaveApplyController extends Controller
      */
     public function storeForUser(LeaveApplyRequest $request, User $user): RedirectResponse
     {
-        $this->authorize('manage', $user); // 任意
+        $this->authorize('manage', $user);
 
         // ★ 申請タイプ & 添付処理（管理者経由でも同じ）
         $type = (string) $request->input('type', 'paid'); // paid|special
@@ -101,7 +101,7 @@ class LeaveApplyController extends Controller
         }
 
         return $this->applyCore(
-            (int) $user->id,
+            $user->id,
             (array) $request->input('dates', []),
             (string) $request->input('reason', ''),
             (int) auth()->id(),

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -29,6 +29,9 @@ class LeaveController extends Controller
     {
         // 承認フローがある場合は pending から始めるなど調整してください
         $targetUser = \App\Models\User::find((int) $request->input('user_id'));
+        abort_if(! $targetUser, 404);
+        $this->authorize('manage', $targetUser);
+
         $leave = Leave::create([
             'user_id'       => (int)$request->input('user_id'),
             'start_date'    => $request->date('start_date'),
@@ -78,11 +81,7 @@ class LeaveController extends Controller
      */
     public function absence(Request $request, User $user)
     {
-        $viewer  = Auth::user();
-        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
-        if (!$isAdmin && $viewer->id !== $user->id) {
-            abort(403);
-        }
+        $this->authorize('view', $user);
 
         // 表示するレコード
         $leaves = Leave::query()
@@ -160,11 +159,7 @@ class LeaveController extends Controller
      */
     public function report(Request $request, Leave $leave)
     {
-        $viewer  = Auth::user();
-        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
-        if (!$isAdmin && $viewer->id !== $leave->user_id) {
-            abort(403);
-        }
+        $this->authorize('report', $leave);
 
         if ($leave->kind !== 'absence') {
             return back()->with('error', 'This leave is not target for absence self-report.');
@@ -215,11 +210,8 @@ class LeaveController extends Controller
 
     public function allReport(Request $request)
     {
-        $viewer  = Auth::user();
-        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
-        if (!$isAdmin) {
-            abort(403);
-        }
+        $this->authorize('viewAny', Leave::class);
+        $viewer = Auth::user();
 
         // フィルタ値を取得（バリデーション）
         $validated = $request->validate([
@@ -331,11 +323,7 @@ class LeaveController extends Controller
 
     public function download(Leave $leave)
     {
-        $viewer  = Auth::user();
-        $isAdmin = $viewer->hasRole(['admin', 'super_admin']);
-        if (!$isAdmin && $viewer->id !== $leave->user_id) {
-            abort(403);
-        }
+        $this->authorize('download', $leave);
 
         $attachment = $leave->attachment;
         if (!$attachment) {

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\Leave;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use Illuminate\Validation\Rule;
 
@@ -19,118 +18,119 @@ class LeaveManageController extends Controller
      * - 月/ユーザーで絞り込み
      * - イベントカード風スタイルで各行を編集UI化
      */
-public function edit(Request $request)
-{
-    // 1) ユーザー候補
-    $userOptions = $this->scopeService->targetUserQuery()
-        ->select('id', 'first_name', 'family_name', 'employee_code')
-        ->orderBy('employee_code')
-        ->limit(500)
-        ->get();
+    public function edit(Request $request)
+    {
+        $this->authorize('manage', Leave::class);
 
-    // 2) パラメータ取得
-    $leaveId     = $request->input('leave_id'); // ★個別編集用パラメータ
-    $userId      = $request->input('user_id');
-    $kind        = $request->input('kind');
-    $excused     = $request->input('excused');
-    $status      = $request->input('status');
-    $specialType = $request->input('special_type');
-    $handleType  = $request->input('handle_type');
-    $reason      = $request->input('reason');
+        // 1) ユーザー候補
+        $userOptions = $this->scopeService->targetUserQuery()
+            ->select('id', 'first_name', 'family_name', 'employee_code')
+            ->orderBy('employee_code')
+            ->limit(500)
+            ->get();
 
-    $startDate   = $request->input('start_date');
-    $endDate     = $request->input('end_date');
+        // 2) パラメータ取得
+        $leaveId     = $request->input('leave_id'); // ★個別編集用パラメータ
+        $userId      = $request->input('user_id');
+        $kind        = $request->input('kind');
+        $excused     = $request->input('excused');
+        $status      = $request->input('status');
+        $specialType = $request->input('special_type');
+        $handleType  = $request->input('handle_type');
+        $reason      = $request->input('reason');
 
-    // 3) 日付ルール
-    // end のみ → エラー
-    if ($endDate && !$startDate) {
-        return back()
-            ->withErrors(['start_date' => '開始日を指定してください。'])
-            ->withInput();
+        $startDate   = $request->input('start_date');
+        $endDate     = $request->input('end_date');
+
+        // 3) 日付ルール
+        // end のみ → エラー
+        if ($endDate && !$startDate) {
+            return back()
+                ->withErrors(['start_date' => '開始日を指定してください。'])
+                ->withInput();
+        }
+
+        // start > end → エラー
+        if ($startDate && $endDate && $startDate > $endDate) {
+            return back()
+                ->withErrors(['start_date' => '開始日は終了日より前に設定してください。'])
+                ->withInput();
+        }
+
+        // 日付フォーマット関数
+        $fmtDate = fn($v) => $v ? Carbon::parse($v)->format('Y-m-d') : '';
+        $fmtTime = fn($v) => $v ? Carbon::parse($v)->format('H:i')   : '';
+
+        // 4) クエリ（Event版と同順序・構成）
+        $leaves = Leave::query()
+            ->with(['user:id,first_name,family_name,employee_code'])
+            ->where('district_id', $this->scopeService->currentDistrictId())
+            ->where('department_id', $this->scopeService->currentDepartmentId())
+            ->when($leaveId,     fn($q) => $q->where('id', $leaveId)) // ★個別編集用パラメータ: leave_id があれば最優先で一意絞り込み
+            ->when($userId,      fn($q) => $q->where('user_id', $userId))
+            ->when($kind,        fn($q) => $q->where('kind', $kind))
+            ->when($excused,     fn($q) => $q->where('excused', $excused))
+            ->when($status,      fn($q) => $q->where('status', $status))
+            ->when($specialType, fn($q) => $q->whereLikeInsensitive('special_type', $specialType))
+            ->when($handleType,  fn($q) => $q->whereLikeInsensitive('handle_type', $handleType))
+            ->when($reason,      fn($q) => $q->whereLikeInsensitive('reason', $reason))
+            // ⬇︎ 日付フィルタ（単日= start_date、期間= start_date..end_date）
+            //   → end_effective = COALESCE(end_date, start_date) として区間重なりを一本化
+            ->when($startDate && $endDate, function ($q) use ($startDate, $endDate) {
+                $q->whereDate('start_date', '<=', $endDate)
+                  ->whereRaw('DATE(COALESCE(end_date, start_date)) >= ?', [$startDate]);
+            })
+            ->when($startDate && !$endDate, function ($q) use ($startDate) {
+                $q->whereDate('start_date', '<=', $startDate)
+                  ->whereRaw('DATE(COALESCE(end_date, start_date)) >= ?', [$startDate]);
+            })
+            ->orderByDesc('start_date')
+            ->orderBy('time_start')
+            ->orderBy('user_id')
+            ->paginate(24)
+            ->withQueryString();
+
+        // 5) オプション
+        $statusOptions = [
+            'approved' => 'Approved',
+            'pending'  => 'Pending',
+            'rejected' => 'Rejected',
+            'cancelled'    => 'Cancelled',
+        ];
+        $kindOptions = [
+            'paid'            => 'ALP',
+            'absence_to_paid' => 'MT to ALP',
+            'special'         => 'Special',
+            'absence'         => 'MT',
+            'adjustment'      => 'Adjustment',
+            'left_early'      => 'Left Early',
+            'late'            => 'Late',
+            'other'           => 'Other',
+        ];
+        $excusedOptions = [
+            'excused'   => 'Excused',
+            'unexcused' => 'Unexcused',
+        ];
+
+        // 6) 表示
+        return view('calendar.leaveEdit', compact(
+            'leaves',
+            'userOptions',
+            'statusOptions',
+            'kindOptions',
+            'excusedOptions',
+            'fmtDate',
+            'fmtTime'
+        ));
     }
-
-    // start > end → エラー
-    if ($startDate && $endDate && $startDate > $endDate) {
-        return back()
-            ->withErrors(['start_date' => '開始日は終了日より前に設定してください。'])
-            ->withInput();
-    }
-
-    // 日付フォーマット関数
-    $fmtDate = fn($v) => $v ? Carbon::parse($v)->format('Y-m-d') : '';
-    $fmtTime = fn($v) => $v ? Carbon::parse($v)->format('H:i')   : '';
-
-    // 4) クエリ（Event版と同順序・構成）
-    $leaves = Leave::query()
-        ->with(['user:id,first_name,family_name,employee_code'])
-        ->where('district_id', $this->scopeService->currentDistrictId())
-        ->where('department_id', $this->scopeService->currentDepartmentId())
-        ->when($leaveId,     fn($q) => $q->where('id', $leaveId)) // ★個別編集用パラメータ: leave_id があれば最優先で一意絞り込み
-        ->when($userId,      fn($q) => $q->where('user_id', $userId))
-        ->when($kind,        fn($q) => $q->where('kind', $kind))
-        ->when($excused,     fn($q) => $q->where('excused', $excused))
-        ->when($status,      fn($q) => $q->where('status', $status))
-        ->when($specialType, fn($q) => $q->whereLikeInsensitive('special_type', $specialType))
-        ->when($handleType,  fn($q) => $q->whereLikeInsensitive('handle_type', $handleType))
-        ->when($reason,      fn($q) => $q->whereLikeInsensitive('reason', $reason))
-        // ⬇︎ 日付フィルタ（単日= start_date、期間= start_date..end_date）
-        //   → end_effective = COALESCE(end_date, start_date) として区間重なりを一本化
-        ->when($startDate && $endDate, function ($q) use ($startDate, $endDate) {
-            $q->whereDate('start_date', '<=', $endDate)
-              ->whereRaw('DATE(COALESCE(end_date, start_date)) >= ?', [$startDate]);
-        })
-        ->when($startDate && !$endDate, function ($q) use ($startDate) {
-            $q->whereDate('start_date', '<=', $startDate)
-              ->whereRaw('DATE(COALESCE(end_date, start_date)) >= ?', [$startDate]);
-        })
-        ->orderByDesc('start_date')
-        ->orderBy('time_start')
-        ->orderBy('user_id')
-        ->paginate(24)
-        ->withQueryString();
-
-    // 5) オプション
-    $statusOptions = [
-        'approved' => 'Approved',
-        'pending'  => 'Pending',
-        'rejected' => 'Rejected',
-        'cancelled'    => 'Cancelled',
-    ];
-    $kindOptions = [
-        'paid'            => 'ALP',
-        'absence_to_paid' => 'MT to ALP',
-        'special'         => 'Special',
-        'absence'         => 'MT',
-        'adjustment'      => 'Adjustment',
-        'left_early'      => 'Left Early',
-        'late'            => 'Late',
-        'other'           => 'Other',
-    ];
-    $excusedOptions = [
-        'excused'   => 'Excused',
-        'unexcused' => 'Unexcused',
-    ];
-
-    // 6) 表示
-    return view('calendar.leaveEdit', compact(
-        'leaves',
-        'userOptions',
-        'statusOptions',
-        'kindOptions',
-        'excusedOptions',
-        'fmtDate',
-        'fmtTime'
-    ));
-}
     /** 保存（更新） */
     public function update(Request $request, Leave $leave)
     {
-        // 権限（念のため。ルートにもmiddlewareあり）
-        if (!Auth::user()->hasRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+        $this->authorize('update', $leave);
 
         $data = $this->validateLeave($request);
+        $targetUser = \App\Models\User::findOrFail((int) $data['user_id']);
+        $this->authorize('manage', $targetUser);
 
         // ビジネスルール（時間の一貫性：片方のみ指定 → バリデーションで弾く）
         // 追加チェック（任意）：time_start < time_end
@@ -153,9 +153,7 @@ public function edit(Request $request)
     /** 削除 */
     public function destroy(Request $request, Leave $leave)
     {
-        if (!Auth::user()->hasRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+        $this->authorize('delete', $leave);
 
         $leave->delete();
 
@@ -200,9 +198,7 @@ public function edit(Request $request)
     /** 空白Leave 追加 */
     public function storeBlank(Request $request)
     {
-        if (!auth()->user()->hasRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+        $this->authorize('manage', Leave::class);
 
         // 必須: user_id, start_date
         $data = $request->validate([
@@ -232,9 +228,7 @@ public function edit(Request $request)
     /** 一括更新 */
     public function bulkUpdate(Request $request)
     {
-        if (!auth()->user()->hasRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
+        $this->authorize('manage', Leave::class);
 
         $items = $request->input('items', []);
         if (!is_array($items) || empty($items)) {
@@ -279,7 +273,12 @@ public function edit(Request $request)
 
         // 一括反映
         foreach ($validated['items'] as $it) {
-            $leave = Leave::find($it['id']);
+            $leave = Leave::findOrFail($it['id']);
+            $this->authorize('update', $leave);
+
+            $targetUser = \App\Models\User::findOrFail((int) $it['user_id']);
+            $this->authorize('manage', $targetUser);
+
             $leave->fill([
                 'user_id'     => $it['user_id'],
                 'start_date'  => $it['start_date'],

--- a/app/Http/Controllers/LessonCsvController.php
+++ b/app/Http/Controllers/LessonCsvController.php
@@ -17,11 +17,15 @@ class LessonCsvController extends Controller
 
     public function show()
     {
+        $this->authorize('viewAny', Lesson::class);
+
         return view('csv.lesson_csv');
     }
 
     public function export()
     {
+        $this->authorize('viewAny', Lesson::class);
+
         $lessons  = Lesson::orderBy('id')->get();
         $filename = 'lessons_' . now()->format('Ymd_His') . '.csv';
 
@@ -48,6 +52,8 @@ class LessonCsvController extends Controller
 
     public function import(Request $request)
     {
+        $this->authorize('viewAny', Lesson::class);
+
         $request->validate([
             'csv_file' => ['required', 'file', 'mimes:csv,txt'],
         ]);

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -63,7 +63,7 @@ class NotificationController extends Controller
 
     public function markAsRead(Request $request, DatabaseNotification $notification)
     {
-        abort_unless($notification->notifiable_id === $request->user()->id, 403);
+        $this->authorize('view-notification', $notification);
         $notification->markAsRead();
         return back();
     }
@@ -77,8 +77,7 @@ class NotificationController extends Controller
     // 詳細へ進む中継（自動既読）
     public function go(Request $request, DatabaseNotification $notification)
     {
-        // 自分の通知だけ許可
-        abort_unless($notification->notifiable_id === $request->user()->id, 403);
+        $this->authorize('view-notification', $notification);
 
         // data['url'] に詳細ページのURLを入れてある前提
         $url = $notification->data['url'] ?? route('notifications.index');

--- a/app/Http/Controllers/ReceivedPostController.php
+++ b/app/Http/Controllers/ReceivedPostController.php
@@ -6,9 +6,7 @@ use App\Models\Post;
 use App\Models\User;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use App\Models\Comment;
-use Illuminate\Support\Facades\DB;
 use App\Models\Attachment;
 use Illuminate\Support\Facades\Storage;
 
@@ -20,10 +18,10 @@ class ReceivedPostController extends Controller
     private function resolveTarget(Request $r): User
     {
         $me = $r->user();
-        $isAdmin = $me->hasAnyRole(['admin', 'super_admin']);
+        $canViewAnyUser = $me->can('viewAny', User::class);
         $code = trim((string) $r->query('employee_code', ''));
 
-        if ($isAdmin && $code !== '') {
+        if ($canViewAnyUser && $code !== '') {
             $u = $this->scopeService->targetUserQuery()->where('employee_code', $code)->first();
             if ($u) return $u;
         }
@@ -33,6 +31,7 @@ class ReceivedPostController extends Controller
     public function index(Request $r)
     {
         $target = $this->resolveTarget($r);
+        $this->authorize('view', $target);
 
         // target宛の受信のみ
         $posts = Post::query()
@@ -60,22 +59,19 @@ class ReceivedPostController extends Controller
     public function show(Request $r, Post $post)
     {
         $me = $r->user();
+        $this->authorize('view', $post);
 
         // 代理切替はそのまま（閲覧権限の判定も現状通り）
         $target = $me;
         $isProxy = false;
-        if ($me->isAdmin() && $r->filled('employee_code')) {
+        if ($me->can('viewAny', User::class) && $r->filled('employee_code')) {
             $target = $this->scopeService->targetUserQuery()->where('employee_code', $r->query('employee_code'))->firstOrFail();
             if ($target->id !== $me->id) $isProxy = true;
         }
-
-        $isAuthor   = $post->user_id === $me->id;
-        $isViewerMe = $post->viewers()->where('users.id', $me->id)->exists();
-        abort_unless($isAuthor || $isViewerMe || $me->isAdmin(), 403);
-        $isAdmin = $me->isAdmin();
+        $isAdmin = $me->can('viewAny', User::class);
 
         // === 可視ロジック ===
-        if ($me->isAdmin()) {
+        if ($isAdmin) {
             // 管理者：全件（親だけrootにして全部ツリー表示）
             $comments = Comment::query()
                 ->where('post_id', $post->id)
@@ -123,11 +119,7 @@ class ReceivedPostController extends Controller
     public function storeComment(Request $r, Post $post)
     {
         $me = $r->user();
-
-        // 閲覧可能者のみコメント可（投稿者 / 宛先 / 管理者）
-        $isAuthor   = $post->user_id === $me->id;
-        $isViewerMe = $post->viewers()->where('users.id', $me->id)->exists();
-        abort_unless($isAuthor || $isViewerMe || $me->hasAnyRole(['admin', 'super_admin']), 403);
+        $this->authorize('comment', $post);
 
         // 返信許可（期限含む）
         if (method_exists($post, 'allowsReplies') && !$post->allowsReplies()) {
@@ -161,12 +153,10 @@ class ReceivedPostController extends Controller
     public function confirm(Request $r, Post $post)
     {
         $me = $r->user();
-
-        // 自分宛かチェック
-        $isRecipient = $post->viewers()->where('users.id', $me->id)->exists();
+        $this->authorize('confirm', $post);
 
         // 代理確認は不可。自分宛でない、または代理切替が行われている場合は弾く
-        if (!$isRecipient || $r->filled('employee_code')) {
+        if ($r->filled('employee_code')) {
             return back()->with('toast_errors', [
                 'You cannot confirm on behalf of others.'
             ]);

--- a/app/Http/Controllers/RouteDeclarationController.php
+++ b/app/Http/Controllers/RouteDeclarationController.php
@@ -21,9 +21,10 @@ class RouteDeclarationController extends Controller
         $viewer = Auth::user();
 
         $targetUser = $viewer;
-        if ($viewer->hasRole(['admin', 'super_admin']) && $request->filled('user_id')) {
+        if ($viewer->can('viewAny', User::class) && $request->filled('user_id')) {
             $targetUser = $this->scopeService->targetUserQuery()->findOrFail($request->query('user_id'));
         }
+        $this->authorize('view', $targetUser);
 
         $declarations = $svc->allForUser($targetUser);
 
@@ -37,8 +38,7 @@ class RouteDeclarationController extends Controller
     public function showUser(User $user, RouteDeclarationService $svc)
     {
         $viewer = Auth::user();
-        if (!$viewer->hasRole(['admin', 'super_admin'])) abort(403);
-        if (!in_array($user->id, $this->scopeService->targetUserIds())) abort(404);
+        $this->authorize('view', $user);
 
         $declarations = $svc->allForUser($user);
 
@@ -61,14 +61,7 @@ class RouteDeclarationController extends Controller
         // admin 経由かどうか
         $isAdminMode = $user !== null;
         $target      = $user ?: $me;
-
-        if ($isAdminMode && !$me->hasAnyRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
-
-        if ($isAdminMode && !in_array($target->id, $this->scopeService->targetUserIds())) {
-            abort(404);
-        }
+        $this->authorize('view', $target);
 
         return view('routes.create', [
             'target'      => $target,      // 申告対象ユーザー
@@ -86,14 +79,7 @@ class RouteDeclarationController extends Controller
         $me = $request->user();
         $isAdminMode = $user !== null;
         $target      = $user ?: $me;
-
-        if ($isAdminMode && !$me->hasAnyRole(['admin', 'super_admin'])) {
-            abort(403);
-        }
-
-        if ($isAdminMode && !in_array($target->id, $this->scopeService->targetUserIds())) {
-            abort(404);
-        }
+        $this->authorize('update', $target);
 
         $data = $this->validateRequest($request);
 
@@ -144,6 +130,8 @@ class RouteDeclarationController extends Controller
      */
     public function report(Request $request)
     {
+        $this->authorize('viewAny', User::class);
+
         // active_on 日付（デフォルト：今日）
         $activeOn = $request->date('active_on')
             ? $request->date('active_on')->format('Y-m-d')

--- a/app/Http/Controllers/ScheduleCsvController.php
+++ b/app/Http/Controllers/ScheduleCsvController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ScheduleLine;
 use App\Services\ScheduleCsv\ScheduleCsvExportService;
 use App\Services\ScheduleCsv\ScheduleCsvImportService;
 use Illuminate\Http\Request;
@@ -12,17 +13,23 @@ class ScheduleCsvController extends Controller
 {
     public function show()
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         return view('csv.schedule_csv');
     }
 
     public function export(ScheduleCsvExportService $service)
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         $filename = 'schedules_' . now()->format('Ymd_His') . '.csv';
         return $service->streamCsv($filename);
     }
 
     public function import(Request $request, ScheduleCsvImportService $service)
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         $request->validate([
             'csv_file' => ['required', 'file', 'mimes:csv,txt'],
         ]);

--- a/app/Http/Controllers/ScheduleDetailController.php
+++ b/app/Http/Controllers/ScheduleDetailController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Lesson;
 use App\Models\ScheduleLine;
 use App\Models\ScheduleDetail;
-use App\Models\Lesson;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -18,6 +18,8 @@ class ScheduleDetailController extends Controller
     // 詳細編集画面
     public function edit(ScheduleLine $line)
     {
+        $this->authorize('view', $line);
+
         // スコープ検証：lineのdistrict/departmentが現在のスコープと一致しなければ一覧へ戻す
         $districtId   = $this->scopeService->currentDistrictId();
         $departmentId = $this->scopeService->currentDepartmentId();
@@ -72,6 +74,8 @@ class ScheduleDetailController extends Controller
     // 一括保存（表示されている明細のみ）
     public function bulkUpdate(Request $request, ScheduleLine $line)
     {
+        $this->authorize('update', $line);
+
         $items = $request->input('items', []);
         if (!is_array($items) || empty($items)) {
             return response()->json(['ok' => false, 'message' => 'No items to update.'], 422);
@@ -98,6 +102,7 @@ class ScheduleDetailController extends Controller
                     $errors[] = ['id' => $detailId, 'messages' => ['Detail not found.']];
                     continue;
                 }
+                $this->authorize('update', $detail);
 
                 $v = Validator::make($raw, [
                     'lesson_code'     => ['required', 'string', 'max:255'],
@@ -124,6 +129,7 @@ class ScheduleDetailController extends Controller
                     $errors[] = ['id' => $detailId, 'messages' => ['lesson_code / ps_unique_lesson_code not found.']];
                     continue;
                 }
+                $this->authorize('update', $lesson);
 
                 // 2) schedule_details を更新
                 $detail->lesson_id    = $lesson->id;
@@ -172,6 +178,8 @@ class ScheduleDetailController extends Controller
     // lesson_code または ps_unique_lesson_code → レッスン情報取得（AJAX）
     public function findLessonByCode(string $code)
     {
+        $this->authorize('viewAny', Lesson::class);
+
         $lesson = Lesson::query()
             ->select(['id', 'lesson_name', 'lesson_code', 'ps_unique_lesson_code', 'note', 'lesson_minute'])
             ->where(function ($q) use ($code) {
@@ -191,11 +199,14 @@ class ScheduleDetailController extends Controller
 
     public function storeBlank(ScheduleLine $line)
     {
+        $this->authorize('update', $line);
+
         DB::beginTransaction();
         try {
             // lesson: 既存の先頭 or プレースホルダ作成
             $lesson = Lesson::query()->orderBy('id')->first();
             if (!$lesson) {
+                $this->authorize('create', Lesson::class);
                 $lesson = Lesson::create([
                     'lesson_name'   => '未設定',
                     'lesson_code'   => 'TEMP',
@@ -233,6 +244,8 @@ class ScheduleDetailController extends Controller
 
     public function copy(ScheduleDetail $detail)
     {
+        $this->authorize('copy', $detail);
+
         DB::beginTransaction();
         try {
             $created = $detail->replicate(['id', 'created_at', 'updated_at']);
@@ -287,6 +300,8 @@ class ScheduleDetailController extends Controller
 
     public function destroy(ScheduleDetail $detail)
     {
+        $this->authorize('delete', $detail);
+
         try {
             $startDisplay = $detail->start_hm;
             $lessonCode   = optional($detail->lesson)->lesson_code ?? '-';

--- a/app/Http/Controllers/ScheduleLineController.php
+++ b/app/Http/Controllers/ScheduleLineController.php
@@ -19,6 +19,8 @@ class ScheduleLineController extends Controller
 
     public function edit(Request $request)
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         // フィルタ
         $activeOn = $request->has('active_on')
             ? $request->input('active_on') : now()->toDateString();
@@ -155,6 +157,8 @@ class ScheduleLineController extends Controller
 
     public function update(Request $request, ScheduleLine $line)
     {
+        $this->authorize('update', $line);
+
         $data = $request->validate([
             'user_id'         => ['nullable', 'exists:users,id'],
             'dow'             => ['required', 'integer', Rule::in([0, 1, 2, 3, 4, 5, 6])],
@@ -173,6 +177,7 @@ class ScheduleLineController extends Controller
             }],
             'handover_memo'   => ['nullable', 'string', 'max:2000'],
         ]);
+        $this->authorizeUserAssignment($data['user_id'] ?? null);
 
         $line->fill($data)->save();
 
@@ -181,6 +186,8 @@ class ScheduleLineController extends Controller
 
     public function bulkUpdate(Request $request): JsonResponse
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         $items = $request->input('items', []);
         if (!is_array($items) || empty($items)) {
             return response()->json(['ok' => false, 'message' => 'No items to update.'], 422);
@@ -203,6 +210,7 @@ class ScheduleLineController extends Controller
                     $errors[] = ['id' => $lineId, 'messages' => ['Line not found.']];
                     continue;
                 }
+                $this->authorize('update', $line);
 
                 $v = Validator::make($raw, [
                     'user_id'         => ['nullable', 'exists:users,id'],
@@ -229,6 +237,7 @@ class ScheduleLineController extends Controller
                 }
 
                 $data = $v->validated();
+                $this->authorizeUserAssignment($data['user_id'] ?? null);
                 $data['start_time'] = $data['start_time'] . ':00';
                 $data['end_time']   = $data['end_time']   . ':00';
 
@@ -260,12 +269,15 @@ class ScheduleLineController extends Controller
 
     public function store(Request $request)
     {
+        $this->authorize('create', ScheduleLine::class);
+
         $data = $request->validate([
             'user_id'       => ['nullable', 'exists:users,id'],
             'school_name'   => ['nullable', 'string', 'max:255'],
             'dow'           => ['nullable', 'integer', 'between:0,6'],
             'department_id' => ['nullable', 'integer', 'exists:departments,id'],
         ]);
+        $this->authorizeUserAssignment($data['user_id'] ?? null);
 
         $line = new ScheduleLine();
         $line->user_id         = $data['user_id'] ?? null;
@@ -290,6 +302,8 @@ class ScheduleLineController extends Controller
 
     public function destroy(Request $request, ScheduleLine $line): JsonResponse
     {
+        $this->authorize('delete', $line);
+
         try {
             if (method_exists($line, 'details')) {
                 $line->details()->delete();
@@ -315,12 +329,15 @@ class ScheduleLineController extends Controller
 
     public function copy(Request $request, ScheduleLine $line): \Illuminate\Http\JsonResponse
     {
+        $this->authorize('copy', $line);
+
         $data = $request->validate([
             'effective_start' => ['required', 'date'],
             'effective_end'   => ['required', 'date', 'after_or_equal:effective_start'],
             'user_id'         => ['nullable', 'exists:users,id'],
             'handover_memo'   => ['nullable', 'string', 'max:2000'],
         ]);
+        $this->authorizeUserAssignment($data['user_id'] ?? null);
 
         $newStart = \Carbon\Carbon::parse($data['effective_start'])->startOfDay();
         $newEnd   = \Carbon\Carbon::parse($data['effective_end'])->startOfDay();
@@ -521,5 +538,15 @@ class ScheduleLineController extends Controller
         }
 
         return $segments;
+    }
+
+    private function authorizeUserAssignment(?int $userId): void
+    {
+        if ($userId === null) {
+            return;
+        }
+
+        $user = User::findOrFail($userId);
+        $this->authorize('view', $user);
     }
 }

--- a/app/Http/Controllers/SchoolTimetableController.php
+++ b/app/Http/Controllers/SchoolTimetableController.php
@@ -16,6 +16,8 @@ class SchoolTimetableController extends Controller
 
     public function index(Request $request)
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         $schoolName = trim((string)$request->input('school', ''));
         $dow = $request->has('dow') && $request->input('dow') !== ''
             ? (int)$request->input('dow')
@@ -75,6 +77,8 @@ class SchoolTimetableController extends Controller
     // API: school_name（+ 任意で dow）で絞った schedule_lines + details を JSON で返す
     public function lines(Request $request)
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         $schoolName = trim((string)$request->input('school', ''));
         $activeOn   = $request->input('active_on', now()->toDateString());
         $dow = $request->has('dow') && $request->input('dow') !== ''
@@ -163,6 +167,8 @@ class SchoolTimetableController extends Controller
     // API: school_code / school_name 一覧（datalist 用）
     public function schools()
     {
+        $this->authorize('viewAny', ScheduleLine::class);
+
         $schools = School::query()
             ->where('is_active', true)
             ->orderBy('school_name')
@@ -174,6 +180,8 @@ class SchoolTimetableController extends Controller
     // API: lesson 一覧（datalist 用）
     public function lessonList()
     {
+        $this->authorize('viewAny', Lesson::class);
+
         $lessons = Lesson::query()
             ->orderBy('lesson_code')
             ->get(['id', 'lesson_code', 'ps_unique_lesson_code']);

--- a/app/Http/Controllers/SentPostController.php
+++ b/app/Http/Controllers/SentPostController.php
@@ -11,7 +11,7 @@ class SentPostController extends Controller
     {
         $me = $request->user();
 
-        $isAdmin = $me->hasAnyRole(['admin', 'super_admin']); // spatie/permission想定
+        $isAdmin = $me->can('viewAny', Post::class);
 
         $posts = Post::query()
             ->with(['author:id,first_name,family_name,employee_code']) // authorリレーション前提（下に補足あり）

--- a/app/Http/Controllers/UserCsvController.php
+++ b/app/Http/Controllers/UserCsvController.php
@@ -30,11 +30,15 @@ class UserCsvController extends Controller
 
     public function show()
     {
+        $this->authorize('viewAny', User::class);
+
         return view('csv.user_csv');
     }
 
     public function export()
     {
+        $this->authorize('viewAny', User::class);
+
         $users = User::with([
             'district',
             'department',
@@ -83,6 +87,8 @@ class UserCsvController extends Controller
 
     public function import(Request $request)
     {
+        $this->authorize('viewAny', User::class);
+
         $request->validate([
             'csv_file' => ['required', 'file', 'mimes:csv,txt'],
         ]);

--- a/app/Http/Controllers/UserSearchController.php
+++ b/app/Http/Controllers/UserSearchController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
 
@@ -11,6 +12,8 @@ class UserSearchController extends Controller
 
     public function index(Request $r)
     {
+        $this->authorize('viewAny', User::class);
+
         // ▼ old('recipients') でIDしか復元できない場合に、Vueのチップ表示用にユーザー情報を取得する
         $ids = trim((string) $r->query('ids', ''));
         if ($ids !== '') {

--- a/app/Http/Requests/EmploymentTermRequest.php
+++ b/app/Http/Requests/EmploymentTermRequest.php
@@ -11,7 +11,7 @@ class EmploymentTermRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()->isAdmin();
+        return $this->user() !== null;
     }
 
     /**

--- a/app/Http/Requests/LeaveApplyRequest.php
+++ b/app/Http/Requests/LeaveApplyRequest.php
@@ -11,7 +11,7 @@ class LeaveApplyRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return auth()->check();
+        return $this->user() !== null;
     }
 
     /**
@@ -22,7 +22,7 @@ class LeaveApplyRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id'    => ['required', 'exists:users,id'],
+            'user_id'    => ['nullable', 'exists:users,id'],
             'dates'      => ['required', 'array', 'min:1'],
             'dates.*'    => ['required', 'date'], // 必要なら after_or_equal:today 等を追加
             'reason'     => ['nullable', 'string'],

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Services\CurrentScopeService;
+
+class EventPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function view(User $user, Event $event): bool
+    {
+        return $this->canManage($user, $event);
+    }
+
+    public function update(User $user, Event $event): bool
+    {
+        return $this->canManage($user, $event);
+    }
+
+    public function delete(User $user, Event $event): bool
+    {
+        return $this->canManage($user, $event);
+    }
+
+    private function canManage(User $user, Event $event): bool
+    {
+        $scope = app(CurrentScopeService::class);
+
+        return $user->isAdmin()
+            && $event->district_id === $scope->currentDistrictId()
+            && $event->department_id === $scope->currentDepartmentId();
+    }
+}

--- a/app/Policies/ExpensePolicy.php
+++ b/app/Policies/ExpensePolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Expense;
+use App\Models\User;
+use App\Services\CurrentScopeService;
+
+class ExpensePolicy
+{
+    public function update(User $actor, Expense $expense): bool
+    {
+        return $this->canManage($actor, $expense);
+    }
+
+    public function delete(User $actor, Expense $expense): bool
+    {
+        return $this->canManage($actor, $expense);
+    }
+
+    private function canManage(User $actor, Expense $expense): bool
+    {
+        $report = $expense->report;
+
+        if (! $report) {
+            return false;
+        }
+
+        return $actor->id === $report->user_id
+            || (
+                $actor->isAdmin()
+                && in_array($report->user_id, app(CurrentScopeService::class)->targetUserIds(), true)
+            );
+    }
+}

--- a/app/Policies/ExpenseReportPolicy.php
+++ b/app/Policies/ExpenseReportPolicy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ExpenseReport;
+use App\Models\User;
+use App\Services\CurrentScopeService;
+
+class ExpenseReportPolicy
+{
+    public function view(User $actor, ExpenseReport $report): bool
+    {
+        return $actor->id === $report->user_id || $this->isScopedAdminFor($actor, $report);
+    }
+
+    public function update(User $actor, ExpenseReport $report): bool
+    {
+        return $actor->id === $report->user_id || $this->isScopedAdminFor($actor, $report);
+    }
+
+    public function submit(User $actor, ExpenseReport $report): bool
+    {
+        return $actor->id === $report->user_id || $this->isScopedAdminFor($actor, $report);
+    }
+
+    public function unsubmit(User $actor, ExpenseReport $report): bool
+    {
+        return $this->isScopedAdminFor($actor, $report);
+    }
+
+    public function manage(User $actor): bool
+    {
+        return $actor->isAdmin();
+    }
+
+    private function isScopedAdminFor(User $actor, ExpenseReport $report): bool
+    {
+        return $actor->isAdmin()
+            && in_array($report->user_id, app(CurrentScopeService::class)->targetUserIds(), true);
+    }
+}

--- a/app/Policies/LeavePolicy.php
+++ b/app/Policies/LeavePolicy.php
@@ -4,12 +4,67 @@ namespace App\Policies;
 
 use App\Models\Leave;
 use App\Models\User;
+use App\Services\CurrentScopeService;
 
 class LeavePolicy
 {
     public function view(User $user, Leave $leave): bool
     {
         return $user->id === $leave->user_id
-            || $user->isAdmin();
+            || $this->canManageScopedLeave($user, $leave);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function cancel(User $user, Leave $leave): bool
+    {
+        return $user->id === $leave->user_id
+            || $this->canManageScopedLeave($user, $leave);
+    }
+
+    public function report(User $user, Leave $leave): bool
+    {
+        return $user->id === $leave->user_id
+            || $this->canManageScopedLeave($user, $leave);
+    }
+
+    public function download(User $user, Leave $leave): bool
+    {
+        return $user->id === $leave->user_id
+            || $this->canManageScopedLeave($user, $leave);
+    }
+
+    public function manage(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function update(User $user, Leave $leave): bool
+    {
+        return $this->canManageScopedLeave($user, $leave);
+    }
+
+    public function delete(User $user, Leave $leave): bool
+    {
+        return $this->canManageScopedLeave($user, $leave);
+    }
+
+    private function canManageScopedLeave(User $actor, Leave $leave): bool
+    {
+        if (! $actor->isAdmin()) {
+            return false;
+        }
+
+        if ($leave->user_id !== null) {
+            return in_array($leave->user_id, app(CurrentScopeService::class)->targetUserIds(), true);
+        }
+
+        $scope = app(CurrentScopeService::class);
+
+        return $leave->district_id === $scope->currentDistrictId()
+            && $leave->department_id === $scope->currentDepartmentId();
     }
 }

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Lesson;
+use App\Models\User;
+
+class LessonPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function update(User $user, Lesson $lesson): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function delete(User $user, Lesson $lesson): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -13,7 +13,7 @@ class PostPolicy
      */
     public function viewAny(User $user): bool
     {
-        //
+        return $user->isAdmin();
     }
 
     /**
@@ -31,7 +31,17 @@ class PostPolicy
      */
     public function create(User $user): bool
     {
-        return $user->hasAnyRole(['admin', 'super_admin']);
+        return $user->isAdmin();
+    }
+
+    public function comment(User $user, Post $post): bool
+    {
+        return $this->view($user, $post);
+    }
+
+    public function confirm(User $user, Post $post): bool
+    {
+        return $post->viewers()->where('users.id', $user->id)->exists();
     }
 
     /**

--- a/app/Policies/ScheduleDetailPolicy.php
+++ b/app/Policies/ScheduleDetailPolicy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ScheduleDetail;
+use App\Models\User;
+use App\Services\CurrentScopeService;
+
+class ScheduleDetailPolicy
+{
+    public function view(User $user, ScheduleDetail $detail): bool
+    {
+        return $this->canManage($user, $detail);
+    }
+
+    public function update(User $user, ScheduleDetail $detail): bool
+    {
+        return $this->canManage($user, $detail);
+    }
+
+    public function delete(User $user, ScheduleDetail $detail): bool
+    {
+        return $this->canManage($user, $detail);
+    }
+
+    public function copy(User $user, ScheduleDetail $detail): bool
+    {
+        return $this->canManage($user, $detail);
+    }
+
+    private function canManage(User $user, ScheduleDetail $detail): bool
+    {
+        $line = $detail->scheduleLine;
+        $scope = app(CurrentScopeService::class);
+
+        return $user->isAdmin()
+            && $line !== null
+            && $line->district_id === $scope->currentDistrictId();
+    }
+}

--- a/app/Policies/ScheduleLinePolicy.php
+++ b/app/Policies/ScheduleLinePolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ScheduleLine;
+use App\Models\User;
+use App\Services\CurrentScopeService;
+
+class ScheduleLinePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function view(User $user, ScheduleLine $line): bool
+    {
+        return $this->canManage($user, $line);
+    }
+
+    public function update(User $user, ScheduleLine $line): bool
+    {
+        return $this->canManage($user, $line);
+    }
+
+    public function delete(User $user, ScheduleLine $line): bool
+    {
+        return $this->canManage($user, $line);
+    }
+
+    public function copy(User $user, ScheduleLine $line): bool
+    {
+        return $this->canManage($user, $line);
+    }
+
+    private function canManage(User $user, ScheduleLine $line): bool
+    {
+        $scope = app(CurrentScopeService::class);
+
+        return $user->isAdmin()
+            && $line->district_id === $scope->currentDistrictId();
+    }
+}

--- a/app/Policies/UserManagementScopePolicy.php
+++ b/app/Policies/UserManagementScopePolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\UserManagementScope;
+
+class UserManagementScopePolicy
+{
+    public function select(User $actor, UserManagementScope $scope): bool
+    {
+        return $actor->isAdmin() && $scope->user_id === $actor->id;
+    }
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,7 +3,7 @@
 namespace App\Policies;
 
 use App\Models\User;
-use Illuminate\Auth\Access\Response;
+use App\Services\CurrentScopeService;
 
 class UserPolicy
 {
@@ -12,7 +12,7 @@ class UserPolicy
      */
     public function viewAny(User $user): bool
     {
-        //
+        return $user->isAdmin();
     }
 
     /**
@@ -20,15 +20,15 @@ class UserPolicy
      */
     public function view(User $currentUser, User $targetUser): bool
     {
-        // 自分自身 または 管理者であれば true
-        return $currentUser->is($targetUser) || $currentUser->isAdmin();
+        return $currentUser->is($targetUser)
+            || $this->isScopedAdminFor($currentUser, $targetUser);
     }
     /**
      * Determine whether the user can create models.
      */
     public function create(User $user): bool
     {
-        //
+        return $user->isAdmin();
     }
 
     /**
@@ -36,8 +36,8 @@ class UserPolicy
      */
     public function update(User $currentUser, User $targetUser): bool
     {
-        // 自分自身 または 管理者であれば true
-        return $currentUser->is($targetUser) || $currentUser->isAdmin();
+        return $currentUser->is($targetUser)
+            || $this->isScopedAdminFor($currentUser, $targetUser);
     }
 
     /**
@@ -66,8 +66,17 @@ class UserPolicy
 
     public function applyRoleChange(User $actor, User $target): bool
     {
-        // admin 以上なら申請可
-        if ($actor->hasRole(['admin', 'super_admin'])) return true;
-        return false;
+        return $this->isScopedAdminFor($actor, $target);
+    }
+
+    public function manage(User $actor, User $target): bool
+    {
+        return $this->isScopedAdminFor($actor, $target);
+    }
+
+    private function isScopedAdminFor(User $actor, User $target): bool
+    {
+        return $actor->isAdmin()
+            && in_array($target->id, app(CurrentScopeService::class)->targetUserIds(), true);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,25 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use App\Models\ApprovalRequest;
+use App\Models\Event;
+use App\Models\Expense;
+use App\Models\ExpenseReport;
+use App\Models\Lesson;
+use App\Models\ScheduleDetail;
+use App\Models\ScheduleLine;
+use App\Models\UserManagementScope;
+use App\Policies\ApprovalRequestPolicy;
+use App\Policies\EventPolicy;
+use App\Policies\ExpensePolicy;
+use App\Policies\ExpenseReportPolicy;
+use App\Policies\LessonPolicy;
+use App\Policies\ScheduleDetailPolicy;
+use App\Policies\ScheduleLinePolicy;
+use App\Policies\UserManagementScopePolicy;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,9 +30,17 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        \App\Models\User::class  => \App\Policies\UserPolicy::class,
-        \App\Models\Leave::class => \App\Policies\LeavePolicy::class,
-        \App\Models\Post::class  => \App\Policies\PostPolicy::class,
+        \App\Models\User::class                => \App\Policies\UserPolicy::class,
+        \App\Models\Leave::class               => \App\Policies\LeavePolicy::class,
+        \App\Models\Post::class                => \App\Policies\PostPolicy::class,
+        ApprovalRequest::class                 => ApprovalRequestPolicy::class,
+        Event::class                           => EventPolicy::class,
+        ExpenseReport::class                   => ExpenseReportPolicy::class,
+        Expense::class                         => ExpensePolicy::class,
+        Lesson::class                          => LessonPolicy::class,
+        ScheduleLine::class                    => ScheduleLinePolicy::class,
+        ScheduleDetail::class                  => ScheduleDetailPolicy::class,
+        UserManagementScope::class             => UserManagementScopePolicy::class,
     ];
 
     /**
@@ -23,6 +48,11 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->registerPolicies();
+
+        Gate::define('view-notification', function (\App\Models\User $user, DatabaseNotification $notification): bool {
+            return $notification->notifiable_type === \App\Models\User::class
+                && (int) $notification->notifiable_id === $user->id;
+        });
     }
 }


### PR DESCRIPTION
## 認可処理の Policy / Gate 統一

### 背景

各 Controller 内に分散していた `isAdmin()` / `hasRole()` / `abort(403)` などの直書き認可判定を整理し、認可方針を以下の形に統一しました。

- Route middleware：`auth` / `role` による入口制御
- Policy / Gate：Controller 内での最終認可判定

これにより、Controller 内のロール分岐を削減し、認可ロジックを Policy / Gate 側へ集約しました。

---

## 主な変更内容

### 認可方針の統一

- 認可方針を `Route(auth/role)` + `Policy/Gate(最終判定)` に統一
- Controller 内の `isAdmin()` / `hasRole()` / `abort(403)` 直判定を大幅に削減
- Controller に残っていたロール分岐の一部も `can(...)` ベースへ整理
- `FormRequest::authorize()` は認可本体ではなく、最小限の通過条件に寄せる方針へ整理

---

## AuthServiceProvider / Gate

- `AuthServiceProvider` に認可登録を追加
- Notification 向け Gate を定義
- 既存 Policy / 新規 Policy を登録

---

## 既存 Policy の拡張

以下の既存 Policy を拡張しました。

- `UserPolicy`
- `LeavePolicy`
- `PostPolicy`

### 主な対応

- 投稿閲覧・返信・確認・代理閲覧の認可を `PostPolicy` / `UserPolicy` に整理
- 休暇申請・代理申請・休暇管理・欠席報告の認可を `LeavePolicy` に整理

---

## 新規追加 Policy

以下の Policy を新規追加しました。

- `ExpenseReportPolicy`
- `ExpensePolicy`
- `UserManagementScopePolicy`
- `EventPolicy`
- `ScheduleLinePolicy`
- `ScheduleDetailPolicy`
- `LessonPolicy`

---

## 経費関連

- 経費関連の本人 / 管理者 / スコープ内判定を Policy 化
- `ExpenseReportController` に認可を追加
- `ExpenseReportPolicy` / `ExpensePolicy` に判定を集約

---

## 休暇関連

- 休暇申請・代理申請・休暇管理・欠席報告の認可を Policy 化
- `LeaveApply` の自己申請では、入力された `user_id` を信用せず `auth()->id()` を使用
- 本人申請と代理申請の責務を明確化

---

## 投稿関連

- 投稿閲覧・返信・確認・代理閲覧の認可を `PostPolicy` / `UserPolicy` に整理
- Controller 側の直接的なロール判定を削減

---

## EventAssignController

以下の処理に認可を追加しました。

- 一覧
- 作成
- 更新
- 削除
- 一括更新
- PDF系出力

---

## ScheduleLineController

以下の処理に認可を追加しました。

- 作成
- 更新
- 削除
- 複写
- 一括更新

---

## ScheduleDetailController

`ScheduleDetailController` はこれまで `auth` のみだったため、以下の更新系処理を Policy で明示的に保護しました。

- 詳細編集
- 追加
- 複写
- 削除
- 一括更新

---

## 管理画面系 Controller

以下の管理画面系 Controller に `authorize()` を追加しました。

- `AdminController`
- `ExpenseReportController`
- `SchoolTimetableController`
- `UserSearchController`
- `CommuterPassAdvisorController`
- CSV 各種 Controller
- `OverTimeController`

---

## テストについて

既存テストの失敗は `/` の `302` リダイレクトによるものであり、今回の認可変更起因ではありません。

---
