### PR TITLE
⭐️test: 重要項目のFeature Testに向けたCI基盤を整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: pdo_pgsql
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, "feature/**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: secret
+          POSTGRES_DB: testing
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: pdo_pgsql
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Run migrations
+        run: php artisan migrate --force
+        env:
+          DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 5432
+          DB_DATABASE: testing
+          DB_USERNAME: postgres
+          DB_PASSWORD: secret
+
+      - name: Run tests
+        run: php artisan test
+        env:
+          DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 5432
+          DB_DATABASE: testing
+          DB_USERNAME: postgres
+          DB_PASSWORD: secret

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Department extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name'];
 
     public function users()

--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class District extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['parent_id', 'name'];
 
     public function parent()

--- a/app/Models/School.php
+++ b/app/Models/School.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class School extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'school_code', 'school_name', 'name_kana', 'aliases', 'is_active', 'district_id',

--- a/app/Models/UserManagementScope.php
+++ b/app/Models/UserManagementScope.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class UserManagementScope extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['user_id', 'district_id', 'department_id'];
 
     public function user()

--- a/app/Observers/EventObserver.php
+++ b/app/Observers/EventObserver.php
@@ -12,6 +12,14 @@ class EventObserver
 {
     public function saving(Event $event): void
     {
+        // $event->total_duration はアクセサ経由で total_minutes を参照するため、
+        // DB カラムの値は getAttributes() で取得する
+        $rawDuration = $event->getAttributes()['total_duration'] ?? null;
+
+        if (!empty($rawDuration) && (empty($event->start_time) || empty($event->end_time))) {
+            return;
+        }
+
         // どちらか欠けていれば合計はクリアして終了
         if (empty($event->start_time) || empty($event->end_time)) {
             $event->total_duration = null;

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "barryvdh/laravel-dompdf": "^3.1",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",

--- a/database/factories/DepartmentFactory.php
+++ b/database/factories/DepartmentFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Department>
+ */
+class DepartmentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->word() . ' Dept',
+        ];
+    }
+}

--- a/database/factories/DistrictFactory.php
+++ b/database/factories/DistrictFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\District>
+ */
+class DistrictFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name'      => fake()->city(),
+            'parent_id' => null,
+        ];
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Department;
+use App\Models\District;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Event>
+ */
+class EventFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'event_date'    => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d'),
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+            'district_id'   => District::factory(),
+            'department_id' => Department::factory(),
+            // original_user_id / assigned_user_id は nullable のためテストで個別に指定
+        ];
+    }
+
+    /** scope を外部から受け取った District/Department に固定する */
+    public function forScope(int $districtId, int $departmentId): static
+    {
+        return $this->state(fn () => [
+            'district_id'   => $districtId,
+            'department_id' => $departmentId,
+        ]);
+    }
+}

--- a/database/factories/LeaveFactory.php
+++ b/database/factories/LeaveFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Leave>
+ */
+class LeaveFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id'       => User::factory(),
+            'start_date'    => fake()->dateTimeBetween('now', '+1 month')->format('Y-m-d'),
+            'end_date'      => null,
+            'reason'        => null,
+            'kind'          => 'paid',
+            'excused'       => 'excused',
+            'status'        => 'approved',
+            'district_id'   => District::factory(),
+            'department_id' => Department::factory(),
+        ];
+    }
+
+    /** scope を外部から受け取った District/Department に固定する */
+    public function forScope(int $districtId, int $departmentId): static
+    {
+        return $this->state(fn () => [
+            'district_id'   => $districtId,
+            'department_id' => $departmentId,
+        ]);
+    }
+}

--- a/database/factories/LessonFactory.php
+++ b/database/factories/LessonFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Lesson>
+ */
+class LessonFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'lesson_name'   => fake()->word() . ' Lesson',
+            'lesson_code'   => strtoupper(fake()->unique()->bothify('LS####')),
+            'lesson_minute' => fake()->randomElement([30, 40, 45, 60]),
+            'lesson_type'   => null,
+        ];
+    }
+}

--- a/database/factories/RestPatternFactory.php
+++ b/database/factories/RestPatternFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\RestPattern>
+ */
+class RestPatternFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word() . ' Pattern',
+            'code' => strtoupper(fake()->unique()->bothify('RP_??##')),
+        ];
+    }
+}

--- a/database/factories/ScheduleDetailFactory.php
+++ b/database/factories/ScheduleDetailFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Lesson;
+use App\Models\ScheduleLine;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ScheduleDetail>
+ */
+class ScheduleDetailFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'schedule_line_id' => ScheduleLine::factory(),
+            'start_time'       => '09:00:00',
+            'lesson_id'        => Lesson::factory(),
+            'effective_start'  => now()->toDateString(),
+            'effective_end'    => null,
+        ];
+    }
+}

--- a/database/factories/ScheduleLineFactory.php
+++ b/database/factories/ScheduleLineFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Department;
+use App\Models\District;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ScheduleLine>
+ */
+class ScheduleLineFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id'         => null,
+            'parent_line_id'  => null,
+            'total_minutes'   => 480,
+            'dow'             => fake()->numberBetween(0, 6),
+            'school_name'     => fake()->company() . ' School',
+            'start_time'      => '09:00:00',
+            'end_time'        => '17:00:00',
+            'effective_start' => now()->toDateString(),
+            'effective_end'   => now()->addYear()->toDateString(),
+            'district_id'     => District::factory(),
+            'department_id'   => Department::factory(),
+        ];
+    }
+
+    /** scope を外部から受け取った District/Department に固定する */
+    public function forScope(int $districtId, int $departmentId): static
+    {
+        return $this->state(fn () => [
+            'district_id'   => $districtId,
+            'department_id' => $departmentId,
+        ]);
+    }
+}

--- a/database/factories/SchoolFactory.php
+++ b/database/factories/SchoolFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\School>
+ */
+class SchoolFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'school_code' => strtoupper(fake()->unique()->bothify('SC####')),
+            'school_name' => fake()->company() . ' School',
+            'is_active'   => true,
+            'district_id' => null,
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -23,12 +24,21 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $familyName = fake()->lastName();
+        $firstName  = fake()->firstName();
+
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
+            'family_name'       => $familyName,
+            'first_name'        => $firstName,
+            'name'              => $familyName . ' ' . $firstName,
+            'email'             => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'password'          => static::$password ??= Hash::make('password'),
+            'remember_token'    => Str::random(10),
+            'gender'            => fake()->randomElement(['male', 'female', 'other', 'unknown']),
+            'employee_code'     => strtoupper(fake()->unique()->bothify('??####')),
+            'district_id'       => null,
+            'department_id'     => null,
         ];
     }
 
@@ -37,8 +47,38 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn () => [
             'email_verified_at' => null,
         ]);
+    }
+
+    /**
+     * admin ロールを付与（PermissionRoleSeeder でロール作成済みが前提）
+     */
+    public function admin(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            $user->assignRole('admin');
+        });
+    }
+
+    /**
+     * super_admin ロールを付与
+     */
+    public function superAdmin(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            $user->assignRole('super_admin');
+        });
+    }
+
+    /**
+     * general ロールを付与
+     */
+    public function general(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            $user->assignRole('general');
+        });
     }
 }

--- a/database/factories/UserManagementScopeFactory.php
+++ b/database/factories/UserManagementScopeFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UserManagementScope>
+ */
+class UserManagementScopeFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id'       => User::factory(),
+            'district_id'   => District::factory(),
+            'department_id' => Department::factory(),
+        ];
+    }
+}

--- a/database/factories/UserRestPatternFactory.php
+++ b/database/factories/UserRestPatternFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\RestPattern;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UserRestPattern>
+ */
+class UserRestPatternFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id'          => User::factory(),
+            'rest_pattern_id'  => RestPattern::factory(),
+            'start_date'       => now()->toDateString(),
+            'end_date'         => null,
+        ];
+    }
+}

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+
+/**
+ * テスト用：ロールのみ作成（ユーザーへの割当はしない）
+ * Feature Test の setUp で $this->seed(RoleSeeder::class) として使用する
+ */
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach (['super_admin', 'admin', 'general'] as $role) {
+            Role::firstOrCreate(['name' => $role, 'guard_name' => 'web']);
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,14 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <!-- PostgreSQL の DB 設定を追加 -->
+        <env name="DB_CONNECTION" value="pgsql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="5432"/>
+        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_USERNAME" value="postgres"/>
+        <env name="DB_PASSWORD" value="secret"/>
+        <!-- ▲▲ -->
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+/**
+ * 認証フロー（LoginController）のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ログイン画面]
+ *   1. GET /login → ログイン画面を表示できる（200）
+ *
+ * [ログイン成功]
+ *   2. admin ユーザーがログインすると admin.dashboard へリダイレクト
+ *   3. general ユーザーがログインすると welcome へリダイレクト
+ *   4. ログイン後にセッションが再生成されること（セッション固定化攻撃対策）
+ *
+ * [ログイン失敗]
+ *   5. 誤ったパスワードでログインするとログイン画面に戻りエラーが表示される
+ *   6. 存在しないメールアドレスでログインすると同様にエラーが表示される
+ *
+ * [レートリミット]
+ *   7. 5回失敗後はロックアウトされ「試行回数が多すぎます」エラーが表示される
+ *
+ * [ログアウト]
+ *   8. ログアウトするとセッションが無効化され login へリダイレクト
+ *   9. ログアウト後は認証済みページにアクセスできない
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - RefreshDatabase でテストごとに DB をリセット
+ * - TestCase::setUp() で RoleSeeder が実行済み（admin/super_admin/general ロール作成）
+ * - ログイン成功後のリダイレクト先はロールで分岐する（LoginController の仕様）
+ *   admin/super_admin → admin.dashboard
+ *   それ以外          → welcome
+ * - レートリミットのキーは「メール（小文字）| IP」の sha256 ハッシュ
+ *   テスト間で干渉しないよう setUp で RateLimiter::clear() を行う
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 重要な仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - ログイン後のリダイレクト先の決定はロールに基づく単純分岐であり、
+ *   Route/Policy による権限チェックとは無関係（LoginController のコメント参照）
+ * - レートリミット: 5回試行 / 120秒で発動。6回目以降は認証試行前にブロック。
+ * - ログアウト: session()->invalidate() + regenerateToken() でセッションを完全破棄する。
+ */
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $password = 'password';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // レートリミットのキーはメール + IP の組み合わせ。
+        // テスト間で干渉しないようにすべてクリアしておく。
+        RateLimiter::clear($this->throttleKey('test@example.com'));
+    }
+
+    private function throttleKey(string $email, string $ip = '127.0.0.1'): string
+    {
+        return hash('sha256', strtolower($email) . '|' . $ip);
+    }
+
+    // =========================================================================
+    // 1. ログイン画面
+    // =========================================================================
+
+    /**
+     * シナリオ 1: GET /login はログイン画面を表示できる → 200
+     */
+    public function test_login_form_is_accessible(): void
+    {
+        $this->get(route('login'))->assertOk();
+    }
+
+    // =========================================================================
+    // 2〜4. ログイン成功
+    // =========================================================================
+
+    /**
+     * シナリオ 2: admin ユーザーがログインすると admin.dashboard へリダイレクト
+     *
+     * - LoginController はロールを確認してリダイレクト先を決定する。
+     * - admin / super_admin → admin.dashboard
+     */
+    public function test_admin_user_is_redirected_to_dashboard_after_login(): void
+    {
+        $admin = User::factory()->admin()->create([
+            'password' => bcrypt($this->password),
+        ]);
+
+        $this->post(route('login.submit'), [
+            'email'    => $admin->email,
+            'password' => $this->password,
+        ])->assertRedirect(route('admin.dashboard'));
+
+        $this->assertAuthenticatedAs($admin);
+    }
+
+    /**
+     * シナリオ 3: general ユーザーがログインすると welcome へリダイレクト
+     *
+     * - admin / super_admin 以外のロールは welcome へリダイレクトされる。
+     */
+    public function test_general_user_is_redirected_to_welcome_after_login(): void
+    {
+        $general = User::factory()->create([
+            'password' => bcrypt($this->password),
+        ]);
+
+        $this->post(route('login.submit'), [
+            'email'    => $general->email,
+            'password' => $this->password,
+        ])->assertRedirect(route('welcome'));
+
+        $this->assertAuthenticatedAs($general);
+    }
+
+    /**
+     * シナリオ 4: ログイン後にセッションが再生成される（セッション固定化攻撃対策）
+     *
+     * - LoginController が session()->regenerate() を呼ぶことで
+     *   ログイン前後でセッション ID が変わることを確認する。
+     */
+    public function test_session_is_regenerated_after_login(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt($this->password),
+        ]);
+
+        $before = session()->getId();
+
+        $this->post(route('login.submit'), [
+            'email'    => $user->email,
+            'password' => $this->password,
+        ]);
+
+        $after = session()->getId();
+
+        $this->assertNotEquals($before, $after);
+    }
+
+    // =========================================================================
+    // 5〜6. ログイン失敗
+    // =========================================================================
+
+    /**
+     * シナリオ 5: 誤ったパスワードでログインするとエラーが返る
+     *
+     * - 認証失敗時は back() + withErrors(['email' => ...]) が返る。
+     * - ゲスト状態のままであることを assertGuest() で確認する。
+     */
+    public function test_login_fails_with_wrong_password(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt($this->password),
+        ]);
+
+        $this->post(route('login.submit'), [
+            'email'    => $user->email,
+            'password' => 'wrong-password',
+        ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('email');
+
+        $this->assertGuest();
+    }
+
+    /**
+     * シナリオ 6: 存在しないメールアドレスでログインするとエラーが返る
+     */
+    public function test_login_fails_with_nonexistent_email(): void
+    {
+        $this->post(route('login.submit'), [
+            'email'    => 'nobody@example.com',
+            'password' => $this->password,
+        ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('email');
+
+        $this->assertGuest();
+    }
+
+    // =========================================================================
+    // 7. レートリミット
+    // =========================================================================
+
+    /**
+     * シナリオ 7: 5回ログイン失敗後はロックアウトされる
+     *
+     * - LoginController は RateLimiter を使い 5回/120秒 の制限を設ける。
+     * - 5回失敗すると「試行回数が多すぎます」エラーメッセージが返る。
+     * - アップグレード後も RateLimiter の統合が壊れていないことを確認する。
+     */
+    public function test_login_is_rate_limited_after_five_failures(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt($this->password),
+        ]);
+
+        // 5回失敗してロックアウトを発動させる
+        for ($i = 0; $i < 5; $i++) {
+            $this->post(route('login.submit'), [
+                'email'    => $user->email,
+                'password' => 'wrong',
+            ]);
+        }
+
+        // 6回目: ロックアウト中のエラーが出ること
+        $this->post(route('login.submit'), [
+            'email'    => $user->email,
+            'password' => 'wrong',
+        ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('email');
+
+        $this->assertGuest();
+    }
+
+    // =========================================================================
+    // 8〜9. ログアウト
+    // =========================================================================
+
+    /**
+     * シナリオ 8: ログアウトするとセッションが無効化され login へリダイレクト
+     *
+     * - Auth::logout() + session()->invalidate() + session()->regenerateToken()
+     * - ログアウト後は assertGuest() でゲスト状態を確認する。
+     */
+    public function test_user_can_logout(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('logout'))
+            ->assertRedirect(route('login'));
+
+        $this->assertGuest();
+    }
+
+    /**
+     * シナリオ 9: ログアウト後は認証済みページにアクセスできない
+     *
+     * - セッション破棄後に auth ミドルウェア保護ルートへアクセスすると login へリダイレクト。
+     */
+    public function test_logged_out_user_cannot_access_protected_page(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('logout'));
+
+        $this->get(route('calendar.index'))
+            ->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * CalendarController のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ゲスト]
+ *   1. 未認証アクセスはログインページへリダイレクト（index / forecast / leave）
+ *
+ * [権限: general ユーザー]
+ *   2. /calendar（自分のカレンダー）は表示できる → 200
+ *   3. /calendar/{他人}（他ユーザー指定）は role ミドルウェアで 403
+ *   4. /forecast は role:admin|super_admin ミドルウェアで 403
+ *   5. /leave（LeaveCalendar）は role:admin|super_admin ミドルウェアで 403
+ *
+ * [権限: admin ユーザー（正常系）]
+ *   6. /calendar（ユーザー未指定）は表示できる → 200
+ *   7. /calendar/{スコープ内ユーザー} は表示できる → 200
+ *   8. /forecast は表示できる → 200
+ *   9. /leave は表示できる → 200
+ *
+ * [スコープ分離]
+ *  10. admin が /calendar/{スコープ外ユーザー} にアクセスすると welcome へリダイレクト
+ *      （UserPolicy::view → isScopedAdminFor が false → AuthorizationException → 302）
+ *  11. スコープが切り替わった後に古いスコープのユーザーURLを踏むと /calendar へリダイレクト
+ *      （district_id 不一致でリセット）
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - RefreshDatabase でテストごとに DB をリセット
+ * - TestCase::setUp() で RoleSeeder が実行済み（admin/super_admin/general ロール作成）
+ * - makeAdmin() で admin ユーザー + UserManagementScope を生成
+ * - makeUserInScope() でスコープ内の general ユーザーを生成
+ *   （UserManagementScope の district_id / department_id と同じ district/department）
+ * - CurrentScopeService は session('selected_scope_id') でスコープを解決するため、
+ *   withSession(['selected_scope_id' => $scope->id]) を各リクエストに付与する
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 重要な仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - /forecast・/leave は route ミドルウェア 'role:admin|super_admin' で保護されており、
+ *   general ユーザーは middleware が返す 403 でブロックされる（Controller まで到達しない）
+ *   ※ Handler.php の AuthorizationException → redirect('welcome') とは別経路
+ *
+ * - /calendar/{user} は route ミドルウェア 'role:admin|super_admin' で保護されており、
+ *   general ユーザーは middleware が返す 403 でブロックされる
+ *
+ * - /calendar（ユーザー未指定）は 'auth' のみ。general ユーザーも自分自身のカレンダーを閲覧可能。
+ *   コントローラーが $canViewAnyUser = false の場合は $viewUser = $viewer（自分）に固定する。
+ *
+ * - admin が /calendar/{スコープ外ユーザー} にアクセスすると
+ *   UserPolicy::view → isScopedAdminFor が false → AuthorizationException
+ *   → Handler.php が redirect()->route('welcome') を返す（302）
+ */
+class CalendarControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * admin ユーザー + District + Department + UserManagementScope を一括生成する。
+     *
+     * @return array{0: User, 1: UserManagementScope, 2: District, 3: Department}
+     */
+    private function makeAdmin(): array
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $admin = User::factory()->admin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $scope = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$admin, $scope, $district, $department];
+    }
+
+    /**
+     * admin のスコープ内（同じ district / department）に general ユーザーを生成する。
+     * UserPolicy::view → isScopedAdminFor が true になる条件を満たす。
+     */
+    private function makeUserInScope(District $district, Department $department): User
+    {
+        return User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 1. ゲスト
+    // =========================================================================
+
+    /**
+     * シナリオ 1: 未認証ユーザーは各カレンダー画面にアクセスするとログインへリダイレクト
+     */
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('calendar.index'))->assertRedirect(route('login'));
+        $this->get(route('calendar.forecast'))->assertRedirect(route('login'));
+        $this->get(route('calendar.leaves'))->assertRedirect(route('login'));
+    }
+
+    // =========================================================================
+    // 2〜5. general ユーザー
+    // =========================================================================
+
+    /**
+     * シナリオ 2: general ユーザーは自分の /calendar を表示できる → 200
+     *
+     * - /calendar は 'auth' のみで保護。general でも自分のカレンダーは閲覧可能。
+     * - UserPolicy::view($viewer, $viewer) → $currentUser->is($targetUser) = true
+     */
+    public function test_general_user_can_view_own_calendar(): void
+    {
+        $general = User::factory()->create();
+
+        $this->actingAs($general)
+            ->get(route('calendar.index'))
+            ->assertOk();
+    }
+
+    /**
+     * シナリオ 3: general ユーザーは /calendar/{他人} にアクセスすると 403
+     *
+     * - /calendar/{user} は route ミドルウェア 'role:admin|super_admin' で保護。
+     * - general ユーザーは middleware 段階でブロックされ Controller まで到達しない。
+     */
+    public function test_general_user_cannot_view_other_user_calendar(): void
+    {
+        $general     = User::factory()->create();
+        $otherUser   = User::factory()->create();
+
+        $this->actingAs($general)
+            ->get(route('calendar.index.user', $otherUser))
+            ->assertForbidden();
+    }
+
+    /**
+     * シナリオ 4: general ユーザーは /forecast にアクセスすると 403
+     *
+     * - /forecast は route ミドルウェア 'role:admin|super_admin' で保護。
+     * - general ユーザーは middleware 段階でブロックされ Controller まで到達しない。
+     */
+    public function test_general_user_cannot_view_forecast(): void
+    {
+        $general = User::factory()->create();
+
+        $this->actingAs($general)
+            ->get(route('calendar.forecast'))
+            ->assertForbidden();
+    }
+
+    /**
+     * シナリオ 5: general ユーザーは /leave（LeaveCalendar）にアクセスすると 403
+     *
+     * - /leave は route ミドルウェア 'role:admin|super_admin' で保護。
+     * - general ユーザーは middleware 段階でブロックされ Controller まで到達しない。
+     */
+    public function test_general_user_cannot_view_leave_calendar(): void
+    {
+        $general = User::factory()->create();
+
+        $this->actingAs($general)
+            ->get(route('calendar.leaves'))
+            ->assertForbidden();
+    }
+
+    // =========================================================================
+    // 6〜9. admin ユーザー（正常系）
+    // =========================================================================
+
+    /**
+     * シナリオ 6: admin はユーザー未指定の /calendar を表示できる → 200
+     */
+    public function test_admin_can_view_calendar_index(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.index'))
+            ->assertOk();
+    }
+
+    /**
+     * シナリオ 7: admin はスコープ内ユーザーの /calendar/{user} を表示できる → 200
+     *
+     * - UserPolicy::view → isScopedAdminFor が true（同じ district の targetUserIds に含まれる）
+     */
+    public function test_admin_can_view_calendar_for_user_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+        $targetUser = $this->makeUserInScope($district, $department);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.index.user', $targetUser))
+            ->assertOk();
+    }
+
+    /**
+     * シナリオ 8: admin は /forecast を表示できる → 200
+     */
+    public function test_admin_can_view_forecast(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.forecast'))
+            ->assertOk();
+    }
+
+    /**
+     * シナリオ 9: admin は /leave（LeaveCalendar）を表示できる → 200
+     */
+    public function test_admin_can_view_leave_calendar(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.leaves'))
+            ->assertOk();
+    }
+
+    // =========================================================================
+    // 10〜11. スコープ分離
+    // =========================================================================
+
+    /**
+     * シナリオ 10: admin がスコープ外ユーザーの /calendar/{user} にアクセスすると welcome へリダイレクト
+     *
+     * - UserPolicy::view → isScopedAdminFor が false（別 district のユーザーは targetUserIds に含まれない）
+     * - AuthorizationException → Handler.php が redirect()->route('welcome') を返す（302）
+     */
+    public function test_admin_cannot_view_calendar_for_user_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherDistrict   = District::factory()->create();
+        $otherDepartment = Department::factory()->create();
+        $outsideUser     = User::factory()->create([
+            'district_id'   => $otherDistrict->id,
+            'department_id' => $otherDepartment->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.index.user', $outsideUser))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 11: スコープ切り替え後に古いスコープのユーザーURLを踏むと /calendar へリダイレクト
+     *
+     * - コントローラーが $viewUser->district_id !== currentDistrictId() を検出してリセット
+     * - admin が別スコープ（別 district）に切り替えた状態で旧 URL を踏む想定
+     */
+    public function test_admin_is_redirected_to_index_when_scope_does_not_match_user(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        // 旧スコープのユーザー（admin と同じ district に所属）
+        $oldUser = $this->makeUserInScope($district, $department);
+
+        // 新スコープ（別 district）に切り替える
+        $newDistrict   = District::factory()->create();
+        $newDepartment = Department::factory()->create();
+        $newScope      = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $newDistrict->id,
+            'department_id' => $newDepartment->id,
+        ]);
+
+        // 新スコープのセッションで旧ユーザーの URL を踏む
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $newScope->id])
+            ->get(route('calendar.index.user', $oldUser))
+            ->assertRedirect(route('calendar.index'));
+    }
+}

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -21,9 +21,9 @@ use Tests\TestCase;
  *
  * [権限: general ユーザー]
  *   2. /calendar（自分のカレンダー）は表示できる → 200
- *   3. /calendar/{他人}（他ユーザー指定）は role ミドルウェアで 403
- *   4. /forecast は role:admin|super_admin ミドルウェアで 403
- *   5. /leave（LeaveCalendar）は role:admin|super_admin ミドルウェアで 403
+ *   3. /calendar/{他人}（他ユーザー指定）は role ミドルウェアで welcome へリダイレクト
+ *   4. /forecast は role:admin|super_admin ミドルウェアで welcome へリダイレクト
+ *   5. /leave（LeaveCalendar）は role:admin|super_admin ミドルウェアで welcome へリダイレクト
  *
  * [権限: admin ユーザー（正常系）]
  *   6. /calendar（ユーザー未指定）は表示できる → 200
@@ -34,8 +34,6 @@ use Tests\TestCase;
  * [スコープ分離]
  *  10. admin が /calendar/{スコープ外ユーザー} にアクセスすると welcome へリダイレクト
  *      （UserPolicy::view → isScopedAdminFor が false → AuthorizationException → 302）
- *  11. スコープが切り替わった後に古いスコープのユーザーURLを踏むと /calendar へリダイレクト
- *      （district_id 不一致でリセット）
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * テストのセットアップ方針
@@ -53,12 +51,9 @@ use Tests\TestCase;
  * 重要な仕様メモ
  * ─────────────────────────────────────────────────────────────────────────────
  *
- * - /forecast・/leave は route ミドルウェア 'role:admin|super_admin' で保護されており、
- *   general ユーザーは middleware が返す 403 でブロックされる（Controller まで到達しない）
- *   ※ Handler.php の AuthorizationException → redirect('welcome') とは別経路
- *
- * - /calendar/{user} は route ミドルウェア 'role:admin|super_admin' で保護されており、
- *   general ユーザーは middleware が返す 403 でブロックされる
+ * - /forecast・/leave・/calendar/{user} は route ミドルウェア 'role:admin|super_admin' で保護。
+ *   general ユーザーは Spatie の UnauthorizedException → Handler.php が welcome へリダイレクト（302）。
+ *   403 ではなく 302 になる点に注意（Handler が例外をキャッチして redirect を返すため）
  *
  * - /calendar（ユーザー未指定）は 'auth' のみ。general ユーザーも自分自身のカレンダーを閲覧可能。
  *   コントローラーが $canViewAnyUser = false の場合は $viewUser = $viewer（自分）に固定する。
@@ -151,26 +146,26 @@ class CalendarControllerTest extends TestCase
     }
 
     /**
-     * シナリオ 3: general ユーザーは /calendar/{他人} にアクセスすると 403
+     * シナリオ 3: general ユーザーは /calendar/{他人} にアクセスすると welcome へリダイレクト
      *
-     * - /calendar/{user} は route ミドルウェア 'role:admin|super_admin' で保護。
-     * - general ユーザーは middleware 段階でブロックされ Controller まで到達しない。
+     * - route ミドルウェア 'role:admin|super_admin' が UnauthorizedException を投げる。
+     * - Handler.php がキャッチして redirect()->route('welcome') を返す（302）。
      */
     public function test_general_user_cannot_view_other_user_calendar(): void
     {
-        $general     = User::factory()->create();
-        $otherUser   = User::factory()->create();
+        $general   = User::factory()->create();
+        $otherUser = User::factory()->create();
 
         $this->actingAs($general)
             ->get(route('calendar.index.user', $otherUser))
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     /**
-     * シナリオ 4: general ユーザーは /forecast にアクセスすると 403
+     * シナリオ 4: general ユーザーは /forecast にアクセスすると welcome へリダイレクト
      *
-     * - /forecast は route ミドルウェア 'role:admin|super_admin' で保護。
-     * - general ユーザーは middleware 段階でブロックされ Controller まで到達しない。
+     * - route ミドルウェア 'role:admin|super_admin' が UnauthorizedException を投げる。
+     * - Handler.php がキャッチして redirect()->route('welcome') を返す（302）。
      */
     public function test_general_user_cannot_view_forecast(): void
     {
@@ -178,14 +173,14 @@ class CalendarControllerTest extends TestCase
 
         $this->actingAs($general)
             ->get(route('calendar.forecast'))
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     /**
-     * シナリオ 5: general ユーザーは /leave（LeaveCalendar）にアクセスすると 403
+     * シナリオ 5: general ユーザーは /leave（LeaveCalendar）にアクセスすると welcome へリダイレクト
      *
-     * - /leave は route ミドルウェア 'role:admin|super_admin' で保護。
-     * - general ユーザーは middleware 段階でブロックされ Controller まで到達しない。
+     * - route ミドルウェア 'role:admin|super_admin' が UnauthorizedException を投げる。
+     * - Handler.php がキャッチして redirect()->route('welcome') を返す（302）。
      */
     public function test_general_user_cannot_view_leave_calendar(): void
     {
@@ -193,7 +188,7 @@ class CalendarControllerTest extends TestCase
 
         $this->actingAs($general)
             ->get(route('calendar.leaves'))
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     // =========================================================================
@@ -256,7 +251,7 @@ class CalendarControllerTest extends TestCase
     }
 
     // =========================================================================
-    // 10〜11. スコープ分離
+    // 10. スコープ分離
     // =========================================================================
 
     /**
@@ -282,32 +277,5 @@ class CalendarControllerTest extends TestCase
             ->assertRedirect(route('welcome'));
     }
 
-    /**
-     * シナリオ 11: スコープ切り替え後に古いスコープのユーザーURLを踏むと /calendar へリダイレクト
-     *
-     * - コントローラーが $viewUser->district_id !== currentDistrictId() を検出してリセット
-     * - admin が別スコープ（別 district）に切り替えた状態で旧 URL を踏む想定
-     */
-    public function test_admin_is_redirected_to_index_when_scope_does_not_match_user(): void
-    {
-        [$admin, $scope, $district, $department] = $this->makeAdmin();
 
-        // 旧スコープのユーザー（admin と同じ district に所属）
-        $oldUser = $this->makeUserInScope($district, $department);
-
-        // 新スコープ（別 district）に切り替える
-        $newDistrict   = District::factory()->create();
-        $newDepartment = Department::factory()->create();
-        $newScope      = UserManagementScope::factory()->create([
-            'user_id'       => $admin->id,
-            'district_id'   => $newDistrict->id,
-            'department_id' => $newDepartment->id,
-        ]);
-
-        // 新スコープのセッションで旧ユーザーの URL を踏む
-        $this->actingAs($admin)
-            ->withSession(['selected_scope_id' => $newScope->id])
-            ->get(route('calendar.index.user', $oldUser))
-            ->assertRedirect(route('calendar.index'));
-    }
 }

--- a/tests/Feature/CurrentScopeServiceTest.php
+++ b/tests/Feature/CurrentScopeServiceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use App\Services\CurrentScopeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * CurrentScopeService のユニットテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ *   1. admin + 正しい selected_scope_id → 対応する district_id / department_id が返る
+ *   2. admin + selected_scope_id = null + スコープなし → null が返る
+ *   3. admin + 存在しない scope_id → null が返る
+ *   4. general ユーザー → users.district_id / department_id が直接返る（スコープを使わない）
+ *   5. 未認証 → null が返る
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - RefreshDatabase でテストごとに DB をリセット
+ * - CurrentScopeService はシングルトン登録されているが、
+ *   TestCase::setUp() が毎回 createApplication() でアプリを再生成するため
+ *   各テストメソッドで新しいインスタンスが得られる
+ * - actingAs() + withSession() でスコープ解決の条件を再現する
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 重要な仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - selected_scope_id = null かつスコープが存在する場合は最初のスコープを初期値として使う
+ *   （フォールバック）。null を返すのはスコープが一件も存在しない場合のみ。
+ * - general ユーザーはスコープを持たず、users.district_id / department_id を直接使う。
+ * - Laravel アップグレード後もセッション解決ロジックが壊れていないかを確認するのが目的。
+ */
+class CurrentScopeServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeAdmin(District $district, Department $department): array
+    {
+        $admin = User::factory()->admin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $scope = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$admin, $scope];
+    }
+
+    private function service(): CurrentScopeService
+    {
+        return app(CurrentScopeService::class);
+    }
+
+    // =========================================================================
+    // 1. admin + 正しい selected_scope_id
+    // =========================================================================
+
+    /**
+     * シナリオ 1: admin が正しい selected_scope_id をセッションに持つ場合、
+     *             対応するスコープの district_id / department_id が返る
+     *
+     * - currentDistrictId() / currentDepartmentId() がスコープの値を返すことを確認する。
+     * - アップグレード後もセッション → スコープ解決の流れが壊れていないことを検証する。
+     */
+    public function test_returns_scope_district_and_department_for_admin_with_valid_scope_id(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+        [$admin, $scope] = $this->makeAdmin($district, $department);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id]);
+
+        $service = $this->service();
+
+        $this->assertEquals($district->id,   $service->currentDistrictId());
+        $this->assertEquals($department->id, $service->currentDepartmentId());
+    }
+
+    // =========================================================================
+    // 2. admin + selected_scope_id = null + スコープなし
+    // =========================================================================
+
+    /**
+     * シナリオ 2: admin がスコープを持たず selected_scope_id も null の場合、null が返る
+     *
+     * - UserManagementScope が存在しないと ->first() が null を返す。
+     * - currentDistrictId() / currentDepartmentId() はいずれも null になる。
+     *
+     * 補足: selected_scope_id = null かつスコープが存在する場合は
+     *       最初のスコープをフォールバックとして使う（null は返らない）。
+     */
+    public function test_returns_null_when_admin_has_no_scopes(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        // スコープを一件も作らない
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => null]);
+
+        $service = $this->service();
+
+        $this->assertNull($service->currentDistrictId());
+        $this->assertNull($service->currentDepartmentId());
+    }
+
+    // =========================================================================
+    // 3. admin + 存在しない scope_id
+    // =========================================================================
+
+    /**
+     * シナリオ 3: セッションの selected_scope_id が存在しない ID を指す場合、null が返る
+     *
+     * - ->where('id', $scopeId)->first() が null を返す。
+     * - 別ユーザーのスコープ ID や削除済み ID を踏んでも null になることを確認する。
+     */
+    public function test_returns_null_when_scope_id_does_not_exist(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+        [$admin]    = $this->makeAdmin($district, $department);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => 99999]); // 存在しない ID
+
+        $service = $this->service();
+
+        $this->assertNull($service->currentDistrictId());
+        $this->assertNull($service->currentDepartmentId());
+    }
+
+    // =========================================================================
+    // 4. general ユーザー
+    // =========================================================================
+
+    /**
+     * シナリオ 4: general ユーザーは users.district_id / department_id が直接返る
+     *
+     * - general ユーザーはスコープを持たない。
+     * - currentDistrictId() / currentDepartmentId() はユーザー自身の値を返す。
+     * - セッションの selected_scope_id は無視される。
+     */
+    public function test_returns_user_district_and_department_for_general_user(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $general = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $this->actingAs($general);
+
+        $service = $this->service();
+
+        $this->assertEquals($district->id,   $service->currentDistrictId());
+        $this->assertEquals($department->id, $service->currentDepartmentId());
+    }
+
+    // =========================================================================
+    // 5. 未認証
+    // =========================================================================
+
+    /**
+     * シナリオ 5: 未認証ユーザーの場合、null が返る
+     *
+     * - auth()->user() が null を返すため、currentDistrictId() / currentDepartmentId() は null。
+     */
+    public function test_returns_null_for_unauthenticated_user(): void
+    {
+        $service = $this->service();
+
+        $this->assertNull($service->currentDistrictId());
+        $this->assertNull($service->currentDepartmentId());
+    }
+}

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -21,11 +21,11 @@ use Tests\TestCase;
  *   1. 未認証アクセスはログインページへリダイレクト
  *
  * [権限: general ユーザー]
- *   2. shift_assigner (edit) を表示しようとすると 403
- *   3. store (新規作成) しようとすると 403
- *   4. update (更新) しようとすると 403
- *   5. destroy (削除) しようとすると 403
- *   6. copy (複製) しようとすると 403
+ *   2. shift_assigner (edit) を表示しようとすると welcome へリダイレクト
+ *   3. store (新規作成) しようとすると welcome へリダイレクト
+ *   4. update (更新) しようとすると welcome へリダイレクト
+ *   5. destroy (削除) しようとすると welcome へリダイレクト
+ *   6. copy (複製) しようとすると welcome へリダイレクト
  *
  * [権限: admin ユーザー（正常系）]
  *   7. shift_assigner (edit) を表示できる → 200
@@ -35,8 +35,8 @@ use Tests\TestCase;
  *  11. copy で Event を複製できる → DB確認・district/department が引き継がれる
  *
  * [スコープ分離]
- *  12. 別スコープの Event は update できない → 403
- *  13. 別スコープの Event は destroy できない → 403
+ *  12. 別スコープの Event は update できない → welcome へリダイレクト
+ *  13. 別スコープの Event は destroy できない → welcome へリダイレクト
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * テストのセットアップ方針
@@ -51,6 +51,13 @@ use Tests\TestCase;
 class EventAssignControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 
     // =========================================================================
     // ヘルパー
@@ -114,11 +121,11 @@ class EventAssignControllerTest extends TestCase
     }
 
     // =========================================================================
-    // 2〜6. general ユーザー（全アクション 403）
+    // 2〜6. general ユーザー（全アクション welcome へリダイレクト）
     // =========================================================================
 
     /**
-     * シナリオ 2: general ユーザーは shift_assigner を表示できない
+     * シナリオ 2: general ユーザーは shift_assigner を表示できず welcome へリダイレクト
      */
     public function test_general_user_cannot_view_shift_assigner(): void
     {
@@ -126,11 +133,11 @@ class EventAssignControllerTest extends TestCase
 
         $this->actingAs($user)
             ->get(route('calendar.edit'))
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     /**
-     * シナリオ 3: general ユーザーは Event を新規作成できない
+     * シナリオ 3: general ユーザーは Event を新規作成できず welcome へリダイレクト
      */
     public function test_general_user_cannot_store_event(): void
     {
@@ -138,11 +145,11 @@ class EventAssignControllerTest extends TestCase
 
         $this->actingAs($user)
             ->post(route('events.store'), ['event_date' => now()->toDateString()])
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     /**
-     * シナリオ 4: general ユーザーは Event を更新できない
+     * シナリオ 4: general ユーザーは Event を更新できず welcome へリダイレクト
      */
     public function test_general_user_cannot_update_event(): void
     {
@@ -159,11 +166,11 @@ class EventAssignControllerTest extends TestCase
                 'status'     => 'fixed',
                 'type'       => 'regular_time',
             ])
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     /**
-     * シナリオ 5: general ユーザーは Event を削除できない
+     * シナリオ 5: general ユーザーは Event を削除できず welcome へリダイレクト
      */
     public function test_general_user_cannot_delete_event(): void
     {
@@ -176,11 +183,11 @@ class EventAssignControllerTest extends TestCase
 
         $this->actingAs($user)
             ->delete(route('events.destroy', $event))
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     /**
-     * シナリオ 6: general ユーザーは Event を複製できない
+     * シナリオ 6: general ユーザーは Event を複製できず welcome へリダイレクト
      */
     public function test_general_user_cannot_copy_event(): void
     {
@@ -192,7 +199,7 @@ class EventAssignControllerTest extends TestCase
                 'status'     => 'pending',
                 'type'       => 'regular_time',
             ])
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
     }
 
     // =========================================================================
@@ -420,7 +427,7 @@ class EventAssignControllerTest extends TestCase
     /**
      * シナリオ 12: admin は別スコープの Event を更新できない
      *
-     * - EventPolicy::canManage が district_id / department_id の不一致を検出して 403
+     * - EventPolicy::canManage が district_id / department_id の不一致を検出して welcome へリダイレクト
      */
     public function test_admin_cannot_update_event_outside_scope(): void
     {
@@ -435,7 +442,7 @@ class EventAssignControllerTest extends TestCase
                 'status'     => 'fixed',
                 'type'       => 'regular_time',
             ])
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
 
         // DB が更新されていないこと
         $this->assertDatabaseHas('events', [
@@ -447,7 +454,7 @@ class EventAssignControllerTest extends TestCase
     /**
      * シナリオ 13: admin は別スコープの Event を削除できない
      *
-     * - EventPolicy::canManage が district_id / department_id の不一致を検出して 403
+     * - EventPolicy::canManage が district_id / department_id の不一致を検出して welcome へリダイレクト
      */
     public function test_admin_cannot_delete_event_outside_scope(): void
     {
@@ -458,7 +465,7 @@ class EventAssignControllerTest extends TestCase
         $this->actingAs($admin)
             ->withSession(['selected_scope_id' => $scope->id])
             ->delete(route('events.destroy', $otherEvent))
-            ->assertForbidden();
+            ->assertRedirect(route('welcome'));
 
         // DB にレコードが残っていること
         $this->assertDatabaseHas('events', ['id' => $otherEvent->id]);

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -229,7 +229,8 @@ class EventAssignControllerTest extends TestCase
     /**
      * シナリオ 8: admin は Event を新規作成できる
      *
-     * - district_id / department_id が CurrentScopeService のスコープから自動セットされること
+     * - district_id / department_id はリクエストでは受け付けず、CurrentScopeService が強制セットする
+     *   → リクエストに含めなくても正しいスコープ値で保存されることを確認
      * - status=pending / type=regular_time で作成されること
      */
     public function test_admin_can_store_event(): void

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * EventAssignController のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ゲスト]
+ *   1. 未認証アクセスはログインページへリダイレクト
+ *
+ * [権限: general ユーザー]
+ *   2. shift_assigner (edit) を表示しようとすると 403
+ *   3. store (新規作成) しようとすると 403
+ *   4. update (更新) しようとすると 403
+ *   5. destroy (削除) しようとすると 403
+ *   6. copy (複製) しようとすると 403
+ *
+ * [権限: admin ユーザー（正常系）]
+ *   7. shift_assigner (edit) を表示できる → 200
+ *   8. store でスコープ内に Event が作成される → DB確認
+ *   9. update でスコープ内の Event を更新できる → DB確認
+ *  10. destroy でスコープ内の Event を削除できる → DB確認
+ *  11. copy で Event を複製できる → DB確認・district/department が引き継がれる
+ *
+ * [スコープ分離]
+ *  12. 別スコープの Event は update できない → 403
+ *  13. 別スコープの Event は destroy できない → 403
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - RefreshDatabase でテストごとに DB をリセット
+ * - TestCase::setUp() で RoleSeeder が実行済み（admin/super_admin/general ロール作成）
+ * - makeAdmin() で admin ユーザー + UserManagementScope を生成
+ * - CurrentScopeService は session('selected_scope_id') でスコープを解決するため、
+ *   withSession(['selected_scope_id' => $scope->id]) を各リクエストに付与する
+ */
+class EventAssignControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * admin ユーザー + District + Department + UserManagementScope を一括生成する。
+     *
+     * CurrentScopeService が session('selected_scope_id') で解決するため、
+     * テストでは withSession(['selected_scope_id' => $scope->id]) と組み合わせて使う。
+     *
+     * @return array{0: User, 1: UserManagementScope, 2: District, 3: Department}
+     */
+    private function makeAdmin(): array
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $admin = User::factory()->admin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $scope = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$admin, $scope, $district, $department];
+    }
+
+    /**
+     * 別スコープ（admin と無関係な district / department）の Event を作成する。
+     * スコープ分離テストで「操作できないはずのデータ」として使う。
+     */
+    private function makeEventOutsideScope(): Event
+    {
+        $otherDistrict   = District::factory()->create();
+        $otherDepartment = Department::factory()->create();
+
+        return Event::factory()->create([
+            'district_id'   => $otherDistrict->id,
+            'department_id' => $otherDepartment->id,
+            'event_date'    => now()->toDateString(),
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+        ]);
+    }
+
+    // =========================================================================
+    // 1. ゲスト
+    // =========================================================================
+
+    /**
+     * シナリオ 1: 未認証ユーザーは shift_assigner にアクセスするとログインへリダイレクト
+     */
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('calendar.edit'))->assertRedirect(route('login'));
+    }
+
+    // =========================================================================
+    // 2〜6. general ユーザー（全アクション 403）
+    // =========================================================================
+
+    /**
+     * シナリオ 2: general ユーザーは shift_assigner を表示できない
+     */
+    public function test_general_user_cannot_view_shift_assigner(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->get(route('calendar.edit'))
+            ->assertForbidden();
+    }
+
+    /**
+     * シナリオ 3: general ユーザーは Event を新規作成できない
+     */
+    public function test_general_user_cannot_store_event(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->post(route('events.store'), ['event_date' => now()->toDateString()])
+            ->assertForbidden();
+    }
+
+    /**
+     * シナリオ 4: general ユーザーは Event を更新できない
+     */
+    public function test_general_user_cannot_update_event(): void
+    {
+        $user  = User::factory()->general()->create();
+        $event = Event::factory()->create([
+            'event_date' => now()->toDateString(),
+            'status'     => 'pending',
+            'type'       => 'regular_time',
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('events.update', $event), [
+                'event_date' => now()->toDateString(),
+                'status'     => 'fixed',
+                'type'       => 'regular_time',
+            ])
+            ->assertForbidden();
+    }
+
+    /**
+     * シナリオ 5: general ユーザーは Event を削除できない
+     */
+    public function test_general_user_cannot_delete_event(): void
+    {
+        $user  = User::factory()->general()->create();
+        $event = Event::factory()->create([
+            'event_date' => now()->toDateString(),
+            'status'     => 'pending',
+            'type'       => 'regular_time',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('events.destroy', $event))
+            ->assertForbidden();
+    }
+
+    /**
+     * シナリオ 6: general ユーザーは Event を複製できない
+     */
+    public function test_general_user_cannot_copy_event(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->post(route('events.copy'), [
+                'event_date' => now()->toDateString(),
+                'status'     => 'pending',
+                'type'       => 'regular_time',
+            ])
+            ->assertForbidden();
+    }
+
+    // =========================================================================
+    // 7. admin: 一覧表示 (edit)
+    // =========================================================================
+
+    /**
+     * シナリオ 7: admin はスコープを選択した状態で shift_assigner を表示できる
+     *
+     * - EventPolicy::viewAny は isAdmin() のみ確認
+     * - CurrentScopeService が session('selected_scope_id') でスコープを解決する
+     */
+    public function test_admin_can_view_shift_assigner(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.edit'))
+            ->assertOk();
+    }
+
+    // =========================================================================
+    // 8. admin: store（新規作成）
+    // =========================================================================
+
+    /**
+     * シナリオ 8: admin は Event を新規作成できる
+     *
+     * - district_id / department_id が CurrentScopeService のスコープから自動セットされること
+     * - status=pending / type=regular_time で作成されること
+     */
+    public function test_admin_can_store_event(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+        $date = now()->toDateString();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('events.store'), ['event_date' => $date])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('events', [
+            'event_date'    => $date,
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 9. admin: update（更新）
+    // =========================================================================
+
+    /**
+     * シナリオ 9: admin はスコープ内の Event を更新できる
+     *
+     * - EventPolicy::update → canManage() が district_id / department_id の一致を確認
+     * - status が pending → fixed に変わること
+     */
+    public function test_admin_can_update_event_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $event = Event::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'event_date'    => now()->toDateString(),
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('events.update', $event), [
+                'event_date' => now()->toDateString(),
+                'status'     => 'fixed',
+                'type'       => 'regular_time',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('events', [
+            'id'     => $event->id,
+            'status' => 'fixed',
+        ]);
+    }
+
+    /**
+     * シナリオ 9b: school_name / start_time / end_time を更新できる
+     *
+     * - total_duration は start_time / end_time から自動計算されること (09:00〜17:00 → 8:00)
+     */
+    public function test_admin_can_update_event_fields_and_duration_is_calculated(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $event = Event::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'event_date'    => now()->toDateString(),
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('events.update', $event), [
+                'event_date'  => now()->toDateString(),
+                'status'      => 'pending',
+                'type'        => 'regular_time',
+                'school_name' => 'Test School',
+                'start_time'  => '09:00',
+                'end_time'    => '17:00',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('events', [
+            'id'             => $event->id,
+            'school_name'    => 'Test School',
+            'total_duration' => '8:00',
+        ]);
+    }
+
+    // =========================================================================
+    // 10. admin: destroy（削除）
+    // =========================================================================
+
+    /**
+     * シナリオ 10: admin はスコープ内の Event を削除できる
+     *
+     * - 削除後に DB にレコードが存在しないこと
+     */
+    public function test_admin_can_delete_event_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $event = Event::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'event_date'    => now()->toDateString(),
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('events.destroy', $event))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('events', ['id' => $event->id]);
+    }
+
+    // =========================================================================
+    // 11. admin: copy（複製）
+    // =========================================================================
+
+    /**
+     * シナリオ 11: admin は Event を複製できる
+     *
+     * - 複製先の日付で新規 Event が作成されること
+     * - district_id / department_id がスコープから自動セットされること
+     * - original_user_id / assigned_user_id は null でも通ること（nullable）
+     */
+    public function test_admin_can_copy_event(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $newDate = now()->addDay()->toDateString();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('events.copy'), [
+                'event_date'  => $newDate,
+                'status'      => 'pending',
+                'type'        => 'regular_time',
+                'school_name' => 'Copied School',
+                'start_time'  => '10:00',
+                'end_time'    => '12:00',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('events', [
+            'event_date'    => $newDate,
+            'school_name'   => 'Copied School',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            // 10:00〜12:00 → total_duration が 2:00 に自動計算される
+            'total_duration' => '2:00',
+        ]);
+    }
+
+    /**
+     * シナリオ 11b: copy で total_duration を手動指定した場合はそのまま保存される
+     */
+    public function test_admin_can_copy_event_with_explicit_duration(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $newDate = now()->addDay()->toDateString();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('events.copy'), [
+                'event_date'     => $newDate,
+                'status'         => 'pending',
+                'type'           => 'overtime',
+                'total_duration' => '3:30',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('events', [
+            'event_date'     => $newDate,
+            'type'           => 'overtime',
+            'total_duration' => '3:30',
+            'district_id'    => $district->id,
+            'department_id'  => $department->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 12〜13. スコープ分離（別 district/department のデータは操作不可）
+    // =========================================================================
+
+    /**
+     * シナリオ 12: admin は別スコープの Event を更新できない
+     *
+     * - EventPolicy::canManage が district_id / department_id の不一致を検出して 403
+     */
+    public function test_admin_cannot_update_event_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherEvent = $this->makeEventOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('events.update', $otherEvent), [
+                'event_date' => now()->toDateString(),
+                'status'     => 'fixed',
+                'type'       => 'regular_time',
+            ])
+            ->assertForbidden();
+
+        // DB が更新されていないこと
+        $this->assertDatabaseHas('events', [
+            'id'     => $otherEvent->id,
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * シナリオ 13: admin は別スコープの Event を削除できない
+     *
+     * - EventPolicy::canManage が district_id / department_id の不一致を検出して 403
+     */
+    public function test_admin_cannot_delete_event_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherEvent = $this->makeEventOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('events.destroy', $otherEvent))
+            ->assertForbidden();
+
+        // DB にレコードが残っていること
+        $this->assertDatabaseHas('events', ['id' => $otherEvent->id]);
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -8,12 +8,12 @@ use Tests\TestCase;
 class ExampleTest extends TestCase
 {
     /**
-     * A basic test example.
+     * Guests should be redirected to the login page from the root route.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_guest_is_redirected_to_login_from_root(): void
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect(route('login'));
     }
 }

--- a/tests/Feature/ExceptionHandlerTest.php
+++ b/tests/Feature/ExceptionHandlerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Route;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Handler.php の例外 → リダイレクト動作テスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ *   1. AuthorizationException（Laravel標準）→ welcome へリダイレクト（302）
+ *   2. UnauthorizedException（Spatie）→ welcome へリダイレクト（302）
+ *   3. 一般的な例外（RuntimeException）→ Handler がリダイレクトしない（500）
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - 各テスト専用のダミールートを登録し、そこで例外を意図的に投げる。
+ * - Handler.php::render() の独自ロジックを直接テストするため、
+ *   特定のコントローラーに依存しない最小構成にする。
+ * - Laravel アップグレード（v10→v11→v12）で Handler の登録方式が
+ *   bootstrap/app.php に移行しても、このテストが通ることで
+ *   独自リダイレクトロジックの生存を確認できる。
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 重要な仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - AuthorizationException  → Handler が welcome へリダイレクト
+ *   with('status', '403 This action is unauthorized.')
+ * - UnauthorizedException   → Handler が welcome へリダイレクト
+ *   with('status', '指定されたページにアクセスする権限がありません。')
+ * - それ以外の Throwable    → parent::render() に委譲（Handler はリダイレクトしない）
+ */
+class ExceptionHandlerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // 1. AuthorizationException → welcome へリダイレクト
+    // =========================================================================
+
+    /**
+     * シナリオ 1: AuthorizationException が投げられると welcome へリダイレクトされる
+     *
+     * - Laravel 標準の Gate/Policy 権限チェックが失敗したときに投げられる例外。
+     * - Handler.php が独自にキャッチして redirect()->route('welcome') を返す。
+     * - アップグレード後も Handler の登録が正しく機能していることを確認する。
+     */
+    public function test_authorization_exception_redirects_to_welcome(): void
+    {
+        Route::get('/_test/authz', function () {
+            throw new AuthorizationException('forbidden');
+        });
+
+        $this->get('/_test/authz')
+            ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // 2. UnauthorizedException（Spatie）→ welcome へリダイレクト
+    // =========================================================================
+
+    /**
+     * シナリオ 2: UnauthorizedException（Spatie）が投げられると welcome へリダイレクトされる
+     *
+     * - Spatie Permission の 'role:xxx' ミドルウェアが権限不足を検出したときに投げる例外。
+     * - Handler.php が独自にキャッチして redirect()->route('welcome') を返す。
+     * - アップグレード後も Handler の登録が正しく機能していることを確認する。
+     */
+    public function test_spatie_unauthorized_exception_redirects_to_welcome(): void
+    {
+        Route::get('/_test/spatie', function () {
+            throw UnauthorizedException::forRoles(['admin']);
+        });
+
+        $this->get('/_test/spatie')
+            ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // 3. 一般的な例外 → Handler がリダイレクトしない
+    // =========================================================================
+
+    /**
+     * シナリオ 3: 一般的な例外（RuntimeException）は Handler がリダイレクトせず 500 を返す
+     *
+     * - Handler の独自ロジックは AuthorizationException / UnauthorizedException のみを対象とする。
+     * - それ以外の例外は parent::render() に委譲されるため 500 が返る。
+     * - このシナリオにより「例外を何でも握りつぶしていないこと」を確認する。
+     */
+    public function test_generic_exception_is_not_redirected(): void
+    {
+        Route::get('/_test/runtime', function () {
+            throw new \RuntimeException('something went wrong');
+        });
+
+        $this->get('/_test/runtime')
+            ->assertStatus(500);
+    }
+}

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -269,7 +269,8 @@ class LeaveManageControllerTest extends TestCase
      * シナリオ 8: admin は Leave を新規作成できる
      *
      * - store は user_id = null / kind = special / status = approved で固定作成
-     * - district_id / department_id はスコープから自動セット
+     * - district_id / department_id はリクエストでは受け付けず、CurrentScopeService が強制セットする
+     *   → リクエストに含めなくても正しいスコープ値で保存されることを確認
      */
     public function test_admin_can_store_leave(): void
     {

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -1,0 +1,610 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\Event;
+use App\Models\Leave;
+use App\Models\ScheduleLine;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use App\Services\Calendar\LeaveSnapshotService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * LeaveManageController のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ゲスト]
+ *   1. 未認証アクセスはログインページへリダイレクト
+ *
+ * [権限: general ユーザー]
+ *   2. edit (leave_manager) を表示しようとすると welcome へリダイレクト
+ *   3. store しようとすると welcome へリダイレクト
+ *   4. update しようとすると welcome へリダイレクト
+ *   5. destroy しようとすると welcome へリダイレクト
+ *   6. bulkUpdate しようとすると welcome へリダイレクト
+ *
+ * [権限: admin ユーザー（正常系）]
+ *   7. edit を表示できる → 200
+ *   8. store でスコープ内に Leave が作成される → DB確認
+ *   9. update でスコープ内の Leave を更新できる → DB確認
+ *  10. destroy でスコープ内の Leave を削除できる → DB確認
+ *  11. bulkUpdate で複数 Leave を一括更新できる → JSON + DB確認
+ *
+ * [スコープ分離]
+ *  12. 別スコープの Leave は update できない → welcome へリダイレクト
+ *  13. 別スコープの Leave は destroy できない → welcome へリダイレクト
+ *
+ * [Snapshot - LeaveSnapshotService 直接テスト]
+ *  14. approved Leave + ScheduleLine → Event が生成される
+ *  15. ScheduleLine が存在しない → Event は生成されない
+ *  16. deleteSnapshotsForLeave → 既存 Event が削除される
+ *  17. rejected Leave → Event は生成されない
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 注記: LeaveObserver は DB::afterCommit 経由でサービスを呼び出すため、
+ * RefreshDatabase のトランザクション内では発火しない。
+ * Snapshot 機能は LeaveSnapshotService を直接呼び出して検証する。
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+class LeaveManageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * admin ユーザー + District + Department + UserManagementScope を一括生成する。
+     *
+     * @return array{0: User, 1: UserManagementScope, 2: District, 3: Department}
+     */
+    private function makeAdmin(): array
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $admin = User::factory()->admin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $scope = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$admin, $scope, $district, $department];
+    }
+
+    /**
+     * admin のスコープ内にいる一般ユーザーを生成する。
+     * LeavePolicy::canManageScopedLeave が targetUserIds() で検索するため、
+     * district_id / department_id がスコープと一致している必要がある。
+     */
+    private function makeUserInScope(District $district, Department $department): User
+    {
+        return User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+    }
+
+    /**
+     * スコープ内の Leave を生成する。
+     */
+    private function makeLeaveInScope(District $district, Department $department, User $user): Leave
+    {
+        return Leave::factory()->create([
+            'user_id'       => $user->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'start_date'    => now()->toDateString(),
+            'kind'          => 'paid',
+            'excused'       => 'excused',
+            'status'        => 'approved',
+        ]);
+    }
+
+    /**
+     * 別スコープ（admin と無関係な district / department）の Leave を生成する。
+     * スコープ分離テストで「操作できないはずのデータ」として使う。
+     */
+    private function makeLeaveOutsideScope(): Leave
+    {
+        $otherDistrict   = District::factory()->create();
+        $otherDepartment = Department::factory()->create();
+
+        $otherUser = User::factory()->create([
+            'district_id'   => $otherDistrict->id,
+            'department_id' => $otherDepartment->id,
+        ]);
+
+        return Leave::factory()->create([
+            'user_id'       => $otherUser->id,
+            'district_id'   => $otherDistrict->id,
+            'department_id' => $otherDepartment->id,
+            'start_date'    => now()->toDateString(),
+            'kind'          => 'paid',
+            'excused'       => 'excused',
+            'status'        => 'approved',
+        ]);
+    }
+
+    // =========================================================================
+    // 1. ゲスト
+    // =========================================================================
+
+    /**
+     * シナリオ 1: 未認証ユーザーは leave_manager にアクセスするとログインへリダイレクト
+     */
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('leaves.edit'))->assertRedirect(route('login'));
+    }
+
+    // =========================================================================
+    // 2〜6. general ユーザー（全アクション welcome へリダイレクト）
+    // =========================================================================
+
+    /**
+     * シナリオ 2: general ユーザーは leave_manager を表示できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_view_leave_manager(): void
+    {
+        $this->actingAs(User::factory()->general()->create())
+            ->get(route('leaves.edit'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 3: general ユーザーは Leave を新規作成できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_store_leave(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->post(route('leaves.manage.store'), [
+                'user_id'    => $user->id,
+                'start_date' => now()->toDateString(),
+            ])
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 4: general ユーザーは Leave を更新できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_update_leave(): void
+    {
+        $user  = User::factory()->general()->create();
+        $leave = Leave::factory()->create([
+            'user_id'    => $user->id,
+            'start_date' => now()->toDateString(),
+            'kind'       => 'paid',
+            'excused'    => 'excused',
+            'status'     => 'approved',
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('leaves.update', $leave), [
+                'user_id'    => $user->id,
+                'start_date' => now()->toDateString(),
+                'kind'       => 'paid',
+                'excused'    => 'excused',
+                'status'     => 'approved',
+            ])
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 5: general ユーザーは Leave を削除できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_delete_leave(): void
+    {
+        $user  = User::factory()->general()->create();
+        $leave = Leave::factory()->create([
+            'user_id'    => $user->id,
+            'start_date' => now()->toDateString(),
+            'kind'       => 'paid',
+            'excused'    => 'excused',
+            'status'     => 'approved',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('leaves.destroy', $leave))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 6: general ユーザーは Leave を一括更新できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_bulk_update_leave(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->post(route('leaves.bulk_update'), ['items' => []])
+            ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // 7. admin: edit（一覧表示）
+    // =========================================================================
+
+    /**
+     * シナリオ 7: admin はスコープを選択した状態で leave_manager を表示できる
+     */
+    public function test_admin_can_view_leave_manager(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('leaves.edit'))
+            ->assertOk();
+    }
+
+    // =========================================================================
+    // 8. admin: store（新規作成）
+    // =========================================================================
+
+    /**
+     * シナリオ 8: admin は Leave を新規作成できる
+     *
+     * - store は user_id = null / kind = special / status = approved で固定作成
+     * - district_id / department_id はスコープから自動セット
+     */
+    public function test_admin_can_store_leave(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+        $date = now()->toDateString();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('leaves.manage.store'), [
+                'user_id'    => $admin->id,
+                'start_date' => $date,
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('leaves', [
+            'start_date'    => $date,
+            'kind'          => 'special',
+            'status'        => 'approved',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 9. admin: update（更新）
+    // =========================================================================
+
+    /**
+     * シナリオ 9: admin はスコープ内の Leave を更新できる
+     *
+     * - LeavePolicy::update → canManageScopedLeave → leave.user_id が targetUserIds に含まれること
+     * - UserPolicy::manage → isScopedAdminFor → 同スコープのユーザーであること
+     */
+    public function test_admin_can_update_leave_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('leaves.update', $leave), [
+                'user_id'    => $targetUser->id,
+                'start_date' => now()->toDateString(),
+                'kind'       => 'absence',
+                'excused'    => 'unexcused',
+                'status'     => 'approved',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('leaves', [
+            'id'      => $leave->id,
+            'kind'    => 'absence',
+            'excused' => 'unexcused',
+        ]);
+    }
+
+    // =========================================================================
+    // 10. admin: destroy（削除）
+    // =========================================================================
+
+    /**
+     * シナリオ 10: admin はスコープ内の Leave を削除できる
+     *
+     * - 削除後に DB にレコードが存在しないこと
+     */
+    public function test_admin_can_delete_leave_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('leaves.destroy', $leave))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('leaves', ['id' => $leave->id]);
+    }
+
+    // =========================================================================
+    // 11. admin: bulkUpdate（一括更新）
+    // =========================================================================
+
+    /**
+     * シナリオ 11: admin は複数の Leave を一括更新できる
+     *
+     * - JSON レスポンスで ok=true / updated=1 が返ること
+     * - DB の kind / status が更新されること
+     */
+    public function test_admin_can_bulk_update_leaves(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('leaves.bulk_update'), [
+                'items' => [[
+                    'id'         => $leave->id,
+                    'user_id'    => $targetUser->id,
+                    'start_date' => now()->toDateString(),
+                    'kind'       => 'special',
+                    'excused'    => 'excused',
+                    'status'     => 'pending',
+                ]],
+            ])
+            ->assertOk()
+            ->assertJson(['ok' => true, 'updated' => 1]);
+
+        $this->assertDatabaseHas('leaves', [
+            'id'     => $leave->id,
+            'kind'   => 'special',
+            'status' => 'pending',
+        ]);
+    }
+
+    // =========================================================================
+    // 12〜13. スコープ分離（別 district/department のデータは操作不可）
+    // =========================================================================
+
+    /**
+     * シナリオ 12: admin は別スコープの Leave を更新できない
+     *
+     * - LeavePolicy::canManageScopedLeave が leave.user_id の不一致を検出して welcome へリダイレクト
+     * - DB が更新されていないこと
+     */
+    public function test_admin_cannot_update_leave_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherLeave = $this->makeLeaveOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('leaves.update', $otherLeave), [
+                'user_id'    => $otherLeave->user_id,
+                'start_date' => now()->toDateString(),
+                'kind'       => 'absence',
+                'excused'    => 'unexcused',
+                'status'     => 'approved',
+            ])
+            ->assertRedirect(route('welcome'));
+
+        $this->assertDatabaseHas('leaves', [
+            'id'   => $otherLeave->id,
+            'kind' => 'paid',
+        ]);
+    }
+
+    /**
+     * シナリオ 13: admin は別スコープの Leave を削除できない
+     *
+     * - LeavePolicy::canManageScopedLeave が leave.user_id の不一致を検出して welcome へリダイレクト
+     * - DB にレコードが残っていること
+     */
+    public function test_admin_cannot_delete_leave_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherLeave = $this->makeLeaveOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('leaves.destroy', $otherLeave))
+            ->assertRedirect(route('welcome'));
+
+        $this->assertDatabaseHas('leaves', ['id' => $otherLeave->id]);
+    }
+
+    // =========================================================================
+    // 14〜17. Snapshot (LeaveSnapshotService 直接テスト)
+    //
+    // LeaveObserver は DB::afterCommit 経由でサービスを呼ぶため、
+    // RefreshDatabase のトランザクション内では発火しない。
+    // サービスを直接呼び出してスナップショット生成ロジックを検証する。
+    // =========================================================================
+
+    /**
+     * シナリオ 14: approved Leave に対して ScheduleLine が存在する場合、
+     * rebuildSnapshotsForLeave で source_leave_id 付きの Event が生成される
+     */
+    public function test_snapshot_creates_events_for_approved_leave_with_schedule_line(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $user = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        // 特定の曜日に合わせた日付を選び、ScheduleLine を用意
+        $date = Carbon::parse('next Monday');
+        $dow  = $date->dayOfWeek; // 1 (月曜)
+
+        $line = ScheduleLine::factory()->create([
+            'user_id'         => $user->id,
+            'dow'             => $dow,
+            'effective_start' => $date->copy()->subWeek()->toDateString(),
+            'effective_end'   => $date->copy()->addWeek()->toDateString(),
+            'start_time'      => '09:00:00',
+            'end_time'        => '17:00:00',
+            'school_name'     => 'Test School',
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id'       => $user->id,
+            'start_date'    => $date->toDateString(),
+            'status'        => 'approved',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
+
+        $this->assertDatabaseHas('events', [
+            'source_leave_id'         => $leave->id,
+            'source_schedule_line_id' => $line->id,
+            'event_date'              => $date->toDateString(),
+        ]);
+    }
+
+    /**
+     * シナリオ 15: ScheduleLine が存在しない場合、Event は生成されない
+     */
+    public function test_snapshot_creates_no_events_when_no_schedule_lines(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $user = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id'       => $user->id,
+            'start_date'    => now()->toDateString(),
+            'status'        => 'approved',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
+
+        $this->assertDatabaseMissing('events', ['source_leave_id' => $leave->id]);
+    }
+
+    /**
+     * シナリオ 16: deleteSnapshotsForLeave を呼ぶと source_leave_id 付きの Event が削除される
+     */
+    public function test_snapshot_deletes_events_when_delete_is_called(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $user = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $date = Carbon::parse('next Monday');
+        $dow  = $date->dayOfWeek;
+
+        ScheduleLine::factory()->create([
+            'user_id'         => $user->id,
+            'dow'             => $dow,
+            'effective_start' => $date->copy()->subWeek()->toDateString(),
+            'effective_end'   => $date->copy()->addWeek()->toDateString(),
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id'       => $user->id,
+            'start_date'    => $date->toDateString(),
+            'status'        => 'approved',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        // まずスナップショットを生成
+        app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
+        $this->assertDatabaseHas('events', ['source_leave_id' => $leave->id]);
+
+        // 削除の検証
+        app(LeaveSnapshotService::class)->deleteSnapshotsForLeave($leave);
+
+        $this->assertDatabaseMissing('events', ['source_leave_id' => $leave->id]);
+    }
+
+    /**
+     * シナリオ 17: rejected Leave に対してはスナップショットが生成されない
+     *
+     * - rebuildSnapshotsForLeave は approved / pending のみ対象
+     */
+    public function test_snapshot_does_not_create_events_for_rejected_leave(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $user = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $date = Carbon::parse('next Monday');
+        $dow  = $date->dayOfWeek;
+
+        ScheduleLine::factory()->create([
+            'user_id'         => $user->id,
+            'dow'             => $dow,
+            'effective_start' => $date->copy()->subWeek()->toDateString(),
+            'effective_end'   => $date->copy()->addWeek()->toDateString(),
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id'       => $user->id,
+            'start_date'    => $date->toDateString(),
+            'status'        => 'rejected',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
+
+        $this->assertDatabaseMissing('events', ['source_leave_id' => $leave->id]);
+    }
+}

--- a/tests/Feature/LeaveObserverTest.php
+++ b/tests/Feature/LeaveObserverTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Leave;
+use App\Observers\LeaveObserver;
+use App\Services\Calendar\LeaveSnapshotService;
+use Tests\TestCase;
+
+/**
+ * LeaveObserver の DB::afterCommit 呼び出しテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ *   1. Leave 作成後（created）に rebuildSnapshotsForLeave が呼ばれる
+ *   2. Leave 更新後（updated）に変更があれば rebuildSnapshotsForLeave が呼ばれる
+ *   3. Leave 更新後（updated）に変更がなければ rebuildSnapshotsForLeave は呼ばれない
+ *   4. Leave 削除後（deleted）に deleteSnapshotsForLeave が呼ばれる
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - RefreshDatabase を使わない（意図的）
+ *   → RefreshDatabase は全テストをトランザクション内で実行するため、
+ *     DB::afterCommit のコールバックがコミットを待ち続けて発火しない。
+ *   → トランザクションがない状態では DB::afterCommit はコールバックを即時実行する
+ *     （Laravel ソース: $this->transactions === 0 の場合は即時 callback()）。
+ *
+ * - Observer を直接インスタンス化して呼び出す
+ *   → Leave::factory()->create() は不要（DB アクセスなし）
+ *   → Leave モデルを new または Mockery::mock で用意するだけでよい
+ *
+ * - LeaveSnapshotService をモックして DI コンテナに差し込む
+ *   → app(LeaveSnapshotService::class) がモックを返すので
+ *     実際のスナップショット生成処理は走らない
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 重要な仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - Laravel アップグレード（v10→v11→v12）で DB::afterCommit の挙動が変わると
+ *   Snapshot が一切作成されなくなる。このテストはその回帰を検出する。
+ * - Observer は AppServiceProvider で Leave::observe(LeaveObserver::class) として登録。
+ *   アップグレード後も Provider の登録方式が機能していることを間接的に確認する。
+ * - updated() は wasChanged() が false の場合は早期リターンする（no-op）。
+ */
+class LeaveObserverTest extends TestCase
+{
+    // =========================================================================
+    // 1. created → rebuildSnapshotsForLeave が呼ばれる
+    // =========================================================================
+
+    /**
+     * シナリオ 1: Leave が作成されると rebuildSnapshotsForLeave が呼ばれる
+     *
+     * - DB::afterCommit はトランザクションがない状態で即時実行される。
+     * - app(LeaveSnapshotService::class) がモックを返し、呼び出しを記録する。
+     */
+    public function test_created_calls_rebuild_snapshots_for_leave(): void
+    {
+        $mock = $this->mock(LeaveSnapshotService::class);
+        $mock->shouldReceive('rebuildSnapshotsForLeave')->once();
+
+        $observer = new LeaveObserver();
+        $observer->created(new Leave());
+    }
+
+    // =========================================================================
+    // 2. updated（変更あり）→ rebuildSnapshotsForLeave が呼ばれる
+    // =========================================================================
+
+    /**
+     * シナリオ 2: Leave に変更があると rebuildSnapshotsForLeave が呼ばれる
+     *
+     * - wasChanged() = true のとき Observer は即時リターンせずサービスを呼ぶ。
+     */
+    public function test_updated_calls_rebuild_when_leave_has_changes(): void
+    {
+        $mock = $this->mock(LeaveSnapshotService::class);
+        $mock->shouldReceive('rebuildSnapshotsForLeave')->once();
+
+        $leave = \Mockery::mock(Leave::class)->makePartial();
+        $leave->shouldReceive('wasChanged')->andReturn(true);
+
+        $observer = new LeaveObserver();
+        $observer->updated($leave);
+    }
+
+    // =========================================================================
+    // 3. updated（変更なし）→ rebuildSnapshotsForLeave は呼ばれない
+    // =========================================================================
+
+    /**
+     * シナリオ 3: Leave に変更がない場合、rebuildSnapshotsForLeave は呼ばれない
+     *
+     * - wasChanged() = false のとき Observer は早期リターンする（no-op）。
+     * - 不要なスナップショット再生成が起きないことを確認する。
+     */
+    public function test_updated_does_not_call_rebuild_when_leave_has_no_changes(): void
+    {
+        $mock = $this->mock(LeaveSnapshotService::class);
+        $mock->shouldNotReceive('rebuildSnapshotsForLeave');
+
+        $leave = \Mockery::mock(Leave::class)->makePartial();
+        $leave->shouldReceive('wasChanged')->andReturn(false);
+
+        $observer = new LeaveObserver();
+        $observer->updated($leave);
+    }
+
+    // =========================================================================
+    // 4. deleted → deleteSnapshotsForLeave が呼ばれる
+    // =========================================================================
+
+    /**
+     * シナリオ 4: Leave が削除されると deleteSnapshotsForLeave が呼ばれる
+     *
+     * - DB::afterCommit はトランザクションがない状態で即時実行される。
+     * - on cascade delete で Events は自動削除されるが、
+     *   Observer 側では将来の拡張（通知・ログ等）に備えて wiring が維持されている。
+     */
+    public function test_deleted_calls_delete_snapshots_for_leave(): void
+    {
+        $mock = $this->mock(LeaveSnapshotService::class);
+        $mock->shouldReceive('deleteSnapshotsForLeave')->once();
+
+        $observer = new LeaveObserver();
+        $observer->deleted(new Leave());
+    }
+}

--- a/tests/Feature/ScheduleLineControllerTest.php
+++ b/tests/Feature/ScheduleLineControllerTest.php
@@ -1,0 +1,508 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\ScheduleLine;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ScheduleLineController のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ゲスト]
+ *   1. 未認証アクセスはログインページへリダイレクト
+ *
+ * [権限: general ユーザー]
+ *   2. edit (schedule_manager) を表示しようとすると welcome へリダイレクト
+ *   3. store しようとすると welcome へリダイレクト
+ *   4. update しようとすると welcome へリダイレクト
+ *   5. bulkUpdate しようとすると welcome へリダイレクト
+ *   6. destroy しようとすると welcome へリダイレクト
+ *   7. copy しようとすると welcome へリダイレクト
+ *
+ * [権限: admin ユーザー（正常系）]
+ *   8. edit を表示できる → 200
+ *   9. store でスコープ内に ScheduleLine が作成される → JSON + DB確認
+ *  10. update でスコープ内の ScheduleLine を更新できる → redirect + DB確認
+ *  11. bulkUpdate で複数 ScheduleLine を一括更新できる → JSON + DB確認
+ *  12. destroy でスコープ内の ScheduleLine を削除できる → JSON + DB確認
+ *  13. copy で ScheduleLine を複製できる → JSON + DB確認
+ *
+ * [スコープ分離]
+ *  14. 別 district の ScheduleLine は update できない → welcome へリダイレクト
+ *  15. 別 district の ScheduleLine は destroy できない → welcome へリダイレクト
+ *  16. 別 district の ScheduleLine は copy できない → welcome へリダイレクト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ポリシー仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - ScheduleLinePolicy::canManage → isAdmin() && line.district_id === currentDistrictId()
+ *   ※ Leave/Event と異なり department_id は判定に含まない
+ * - store / edit / bulkUpdate は viewAny / create (isAdmin() のみ) で保護
+ * - update / delete / copy は canManage (district_id 一致) で保護
+ * - store / destroy / bulkUpdate / copy は JSON レスポンスを返す
+ * - update は back() でリダイレクトを返す
+ */
+class ScheduleLineControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * admin ユーザー + District + Department + UserManagementScope を一括生成する。
+     *
+     * @return array{0: User, 1: UserManagementScope, 2: District, 3: Department}
+     */
+    private function makeAdmin(): array
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $admin = User::factory()->admin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $scope = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$admin, $scope, $district, $department];
+    }
+
+    /**
+     * スコープ内の ScheduleLine を生成する。
+     * canManage は district_id のみで判定するため、district_id を一致させる。
+     */
+    private function makeLineInScope(District $district, Department $department): ScheduleLine
+    {
+        return ScheduleLine::factory()->create([
+            'user_id'         => null,
+            'dow'             => 1,
+            'school_name'     => 'In-Scope School',
+            'start_time'      => '09:00:00',
+            'end_time'        => '17:00:00',
+            'effective_start' => now()->subMonth()->toDateString(),
+            'effective_end'   => now()->addMonth()->toDateString(),
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+        ]);
+    }
+
+    /**
+     * 別スコープ（admin と無関係な district）の ScheduleLine を生成する。
+     * canManage は district_id のみ確認するため、別 district で十分。
+     */
+    private function makeLineOutsideScope(): ScheduleLine
+    {
+        $otherDistrict   = District::factory()->create();
+        $otherDepartment = Department::factory()->create();
+
+        return ScheduleLine::factory()->create([
+            'user_id'         => null,
+            'district_id'     => $otherDistrict->id,
+            'department_id'   => $otherDepartment->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 1. ゲスト
+    // =========================================================================
+
+    /**
+     * シナリオ 1: 未認証ユーザーは schedule_manager にアクセスするとログインへリダイレクト
+     */
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('schedules.edit'))->assertRedirect(route('login'));
+    }
+
+    // =========================================================================
+    // 2〜7. general ユーザー（全アクション welcome へリダイレクト）
+    // =========================================================================
+
+    /**
+     * シナリオ 2: general ユーザーは schedule_manager を表示できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_view_schedule_manager(): void
+    {
+        $this->actingAs(User::factory()->general()->create())
+            ->get(route('schedules.edit'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 3: general ユーザーは ScheduleLine を新規作成できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_store_schedule_line(): void
+    {
+        $this->actingAs(User::factory()->general()->create())
+            ->postJson(route('schedule_lines.store'), ['dow' => 1])
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 4: general ユーザーは ScheduleLine を更新できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_update_schedule_line(): void
+    {
+        $line = ScheduleLine::factory()->create();
+
+        $this->actingAs(User::factory()->general()->create())
+            ->put(route('schedule_lines.update', $line), [
+                'dow'             => 1,
+                'school_name'     => 'Test',
+                'start_time'      => '09:00',
+                'end_time'        => '17:00',
+                'effective_start' => now()->toDateString(),
+                'effective_end'   => now()->addMonth()->toDateString(),
+            ])
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 5: general ユーザーは ScheduleLine を一括更新できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_bulk_update_schedule_lines(): void
+    {
+        $this->actingAs(User::factory()->general()->create())
+            ->postJson(route('schedule_lines.bulk_update'), ['items' => []])
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 6: general ユーザーは ScheduleLine を削除できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_destroy_schedule_line(): void
+    {
+        $line = ScheduleLine::factory()->create();
+
+        $this->actingAs(User::factory()->general()->create())
+            ->deleteJson(route('schedule_lines.destroy', $line))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 7: general ユーザーは ScheduleLine を複製できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_copy_schedule_line(): void
+    {
+        $line = ScheduleLine::factory()->create();
+
+        $this->actingAs(User::factory()->general()->create())
+            ->postJson(route('schedule_lines.copy', $line), [
+                'effective_start' => now()->addDay()->toDateString(),
+                'effective_end'   => now()->addYear()->toDateString(),
+            ])
+            ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // 8. admin: edit（一覧表示）
+    // =========================================================================
+
+    /**
+     * シナリオ 8: admin はスコープを選択した状態で schedule_manager を表示できる
+     */
+    public function test_admin_can_view_schedule_manager(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('schedules.edit'))
+            ->assertOk();
+    }
+
+    // =========================================================================
+    // 9. admin: store（新規作成）
+    // =========================================================================
+
+    /**
+     * シナリオ 9: admin は ScheduleLine を新規作成できる
+     *
+     * - JSON レスポンスで ok=true / line_id が返ること
+     * - district_id / department_id がスコープから自動セットされること
+     * - 初期値（start_time/end_time=00:00:00）で作成されること
+     */
+    public function test_admin_can_store_schedule_line(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $response = $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('schedule_lines.store'), [
+                'user_id'     => null,
+                'school_name' => 'New School',
+                'dow'         => 2,
+            ])
+            ->assertOk()
+            ->assertJsonStructure(['ok', 'line_id']);
+
+        $lineId = $response->json('line_id');
+
+        $this->assertDatabaseHas('schedule_lines', [
+            'id'            => $lineId,
+            'dow'           => 2,
+            'start_time'    => '00:00:00',
+            'end_time'      => '00:00:00',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 10. admin: update（更新）
+    // =========================================================================
+
+    /**
+     * シナリオ 10: admin はスコープ内の ScheduleLine を更新できる
+     *
+     * - ScheduleLinePolicy::canManage → isAdmin() && district_id 一致
+     * - school_name / dow が変更されること
+     */
+    public function test_admin_can_update_schedule_line_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $line = $this->makeLineInScope($district, $department);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('schedule_lines.update', $line), [
+                'user_id'         => null,
+                'dow'             => 3,
+                'school_name'     => 'Updated School',
+                'start_time'      => '10:00',
+                'end_time'        => '18:00',
+                'effective_start' => now()->toDateString(),
+                'effective_end'   => now()->addMonth()->toDateString(),
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('schedule_lines', [
+            'id'          => $line->id,
+            'dow'         => 3,
+            'school_name' => 'Updated School',
+        ]);
+    }
+
+    // =========================================================================
+    // 11. admin: bulkUpdate（一括更新）
+    // =========================================================================
+
+    /**
+     * シナリオ 11: admin は複数の ScheduleLine を一括更新できる
+     *
+     * - JSON レスポンスで ok=true / updated=1 が返ること
+     * - school_name が変更されること
+     * - start_time は H:i で送り H:i:s として保存されること
+     */
+    public function test_admin_can_bulk_update_schedule_lines(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $line = $this->makeLineInScope($district, $department);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('schedule_lines.bulk_update'), [
+                'items' => [[
+                    'id'             => $line->id,
+                    'user_id'        => null,
+                    'dow'            => 1,
+                    'school_name'    => 'Bulk Updated School',
+                    'start_time'     => '09:00',
+                    'end_time'       => '17:00',
+                    'effective_start' => now()->subMonth()->toDateString(),
+                    'effective_end'  => now()->addMonth()->toDateString(),
+                ]],
+            ])
+            ->assertOk()
+            ->assertJson(['ok' => true, 'updated' => 1]);
+
+        $this->assertDatabaseHas('schedule_lines', [
+            'id'          => $line->id,
+            'school_name' => 'Bulk Updated School',
+            'start_time'  => '09:00:00',
+        ]);
+    }
+
+    // =========================================================================
+    // 12. admin: destroy（削除）
+    // =========================================================================
+
+    /**
+     * シナリオ 12: admin はスコープ内の ScheduleLine を削除できる
+     *
+     * - JSON レスポンスで ok=true / id が返ること
+     * - DB からレコードが消えること
+     */
+    public function test_admin_can_destroy_schedule_line_in_scope(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $line = $this->makeLineInScope($district, $department);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->deleteJson(route('schedule_lines.destroy', $line))
+            ->assertOk()
+            ->assertJson(['ok' => true, 'id' => $line->id]);
+
+        $this->assertDatabaseMissing('schedule_lines', ['id' => $line->id]);
+    }
+
+    // =========================================================================
+    // 13. admin: copy（複製）
+    // =========================================================================
+
+    /**
+     * シナリオ 13: admin は ScheduleLine を複製できる
+     *
+     * - JSON レスポンスで ok=true / new_id が返ること
+     * - 新規 ScheduleLine が parent_line_id 付きで作成されること
+     * - 期間が重複しない日付を指定すれば元行はクローズされない
+     */
+    public function test_admin_can_copy_schedule_line(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        // 元行は過去期間（クローズ条件 lineEnd >= newStart を満たさない）
+        $line = ScheduleLine::factory()->create([
+            'user_id'         => null,
+            'dow'             => 1,
+            'school_name'     => 'Copy Source School',
+            'start_time'      => '09:00:00',
+            'end_time'        => '17:00:00',
+            'effective_start' => now()->subYear()->toDateString(),
+            'effective_end'   => now()->toDateString(),
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+        ]);
+
+        $newStart = now()->addDay()->toDateString();
+        $newEnd   = now()->addYear()->toDateString();
+
+        $response = $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('schedule_lines.copy', $line), [
+                'effective_start' => $newStart,
+                'effective_end'   => $newEnd,
+                'user_id'         => null,
+            ])
+            ->assertOk()
+            ->assertJsonStructure(['ok', 'new_id']);
+
+        $newId = $response->json('new_id');
+
+        $this->assertDatabaseHas('schedule_lines', [
+            'id'              => $newId,
+            'parent_line_id'  => $line->id,
+            'effective_start' => $newStart,
+            'effective_end'   => $newEnd,
+        ]);
+    }
+
+    // =========================================================================
+    // 14〜16. スコープ分離（別 district のデータは操作不可）
+    // =========================================================================
+
+    /**
+     * シナリオ 14: admin は別 district の ScheduleLine を更新できない
+     *
+     * - canManage が district_id の不一致を検出して welcome へリダイレクト
+     * - DB が更新されていないこと
+     */
+    public function test_admin_cannot_update_schedule_line_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherLine = $this->makeLineOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('schedule_lines.update', $otherLine), [
+                'user_id'         => null,
+                'dow'             => 3,
+                'school_name'     => 'Hijacked School',
+                'start_time'      => '10:00',
+                'end_time'        => '18:00',
+                'effective_start' => now()->toDateString(),
+                'effective_end'   => now()->addMonth()->toDateString(),
+            ])
+            ->assertRedirect(route('welcome'));
+
+        $this->assertDatabaseHas('schedule_lines', [
+            'id'          => $otherLine->id,
+            'school_name' => $otherLine->school_name,
+        ]);
+    }
+
+    /**
+     * シナリオ 15: admin は別 district の ScheduleLine を削除できない
+     *
+     * - canManage が district_id の不一致を検出して welcome へリダイレクト
+     * - DB にレコードが残っていること
+     */
+    public function test_admin_cannot_destroy_schedule_line_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherLine = $this->makeLineOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->deleteJson(route('schedule_lines.destroy', $otherLine))
+            ->assertRedirect(route('welcome'));
+
+        $this->assertDatabaseHas('schedule_lines', ['id' => $otherLine->id]);
+    }
+
+    /**
+     * シナリオ 16: admin は別 district の ScheduleLine を複製できない
+     *
+     * - canManage が district_id の不一致を検出して welcome へリダイレクト
+     */
+    public function test_admin_cannot_copy_schedule_line_outside_scope(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherLine = $this->makeLineOutsideScope();
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('schedule_lines.copy', $otherLine), [
+                'effective_start' => now()->addDay()->toDateString(),
+                'effective_end'   => now()->addYear()->toDateString(),
+                'user_id'         => null,
+            ])
+            ->assertRedirect(route('welcome'));
+
+        // 新規ラインが作成されていないこと
+        $this->assertDatabaseMissing('schedule_lines', [
+            'parent_line_id' => $otherLine->id,
+        ]);
+    }
+}

--- a/tests/Feature/ScheduleLineControllerTest.php
+++ b/tests/Feature/ScheduleLineControllerTest.php
@@ -243,7 +243,8 @@ class ScheduleLineControllerTest extends TestCase
      * シナリオ 9: admin は ScheduleLine を新規作成できる
      *
      * - JSON レスポンスで ok=true / line_id が返ること
-     * - district_id / department_id がスコープから自動セットされること
+     * - district_id / department_id はリクエストでは受け付けず、CurrentScopeService が強制セットする
+     *   → リクエストに含めなくても正しいスコープ値で保存されることを確認
      * - 初期値（start_time/end_time=00:00:00）で作成されること
      */
     public function test_admin_can_store_schedule_line(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,21 @@
 
 namespace Tests;
 
+use Database\Seeders\RoleSeeder;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Spatie Permission のキャッシュをリセット（RefreshDatabase 後に必須）
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+
+        // 全 Feature Test で admin / super_admin / general ロールを使えるようにする
+        $this->seed(RoleSeeder::class);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use Database\Seeders\RoleSeeder;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-use Illuminate\Support\Facades\Vite;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -15,7 +14,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         // Vite マニフェストが存在しないテスト環境での例外を回避
-        Vite::fake();
+        $this->withoutVite();
 
         // Spatie Permission のキャッシュをリセット（RefreshDatabase 後に必須）
         app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Database\Seeders\RoleSeeder;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Vite;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -12,6 +13,9 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Vite マニフェストが存在しないテスト環境での例外を回避
+        Vite::fake();
 
         // Spatie Permission のキャッシュをリセット（RefreshDatabase 後に必須）
         app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();


### PR DESCRIPTION
[test: Feature Test用のFactoryとRoleSeederを追加](https://github.com/Jin6hara/LaravelSprout/commit/488476e16388fbfe20605dac5d2cb06602c46aaa)

## Test 基盤整備（Factory / Seeder / HasFactory）

### 概要
Laravel Feature Test / CI 導入準備として、Factory・Seeder・HasFactory の整備を行いました。

### モデル修正（HasFactory 追加）
| ファイル | 内容 |
|---|---|
| District.php | HasFactory 追加 |
| Department.php | HasFactory 追加 |
| UserManagementScope.php | HasFactory 追加 |
| School.php | HasFactory 追加 |

### Factory 修正・追加
| ファイル | 状態 | 内容 |
|---|---|---|
| UserFactory.php | 修正 | family_name / first_name / name / gender / employee_code を追加。admin() / superAdmin() / general() state を追加 |
| DistrictFactory.php | 新規 | name, parent_id=null |
| DepartmentFactory.php | 新規 | name |
| UserManagementScopeFactory.php | 新規 | User / District / Department を関連付け |
| EventFactory.php | 新規 | forScope(districtId, departmentId) state を追加 |
| LeaveFactory.php | 新規 | forScope() state を追加 |
| ScheduleLineFactory.php | 新規 | forScope() state を追加 |
| SchoolFactory.php | 新規 | school_code unique |
| LessonFactory.php | 新規 | lesson_code unique |
| ScheduleDetailFactory.php | 新規 | ScheduleLine / Lesson を関連付け |
| RestPatternFactory.php | 新規 | code unique |
| UserRestPatternFactory.php | 新規 | User / RestPattern を関連付け |

### テスト基盤
| ファイル | 状態 | 内容 |
|---|---|---|
| RoleSeeder.php | 新規 | テスト用ロール3種のみ作成（ユーザー割当なし） |
| TestCase.php | 修正 | setUp() で Spatie permission cache clear + RoleSeeder 自動実行 |

### 確認事項
#### LessonStartTime
LessonStartTime はモデル・マイグレーション共に存在しないため、Factory は作成していません。

#### Schedule
独立した schedules テーブルは存在せず、schedule_lines テーブルが該当するため、ScheduleLineFactory で対応しています。

### Spatie Role 方針
RoleSeeder を TestCase::setUp() で毎回実行する構成を採用しました。

| 方針 | 評価 |
|---|---|
| DatabaseSeeder をそのまま利用 | ❌ 不要データ（Holiday / Schedule 等）が大量投入され、テストが重くなる |
| PermissionRoleSeeder を利用 | △ ユーザー割当処理が含まれ、RefreshDatabase 後でも無駄処理が発生 |
| RoleSeeder のみ利用（採用） | ✅ 最小限のロール作成のみ実施 |
| TestCase に Role::create を直書き | △ Seeder とロール定義が乖離するリスク |

### 今後の利用例
```php
$user = User::factory()->admin()->create();