### PR TITLE
TrustProxiesを設定

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
## 問題の原因

### 1. クライアントIPが `127.0.0.1` として記録される

Render はリバースプロキシ経由で Laravel アプリへリクエストを転送している。

現在の Routehub では `TrustProxies` の設定が不足しており、Render 側のプロキシを信頼できていないため、実際のクライアントIPではなく `127.0.0.1` などの内部IPが記録されている。

#### 修正対象

`app/Http/Middleware/TrustProxies.php`

#### 修正内容

Render のリバースプロキシを信頼するように `$proxies` を設定する。

---

### 2. Laravelログが Render Dashboard に表示されない

現在のログ出力先が主に `storage/logs/laravel.log` になっているため、Render Dashboard のログに表示されていない。

Render は基本的に `STDOUT` / `STDERR` に出力されたログを収集する。

比較対象のプロジェクトでは、以下のように `stderr` を含むログスタックが設定されている。

```env
LOG_STACK=single,stderr