### PR TITLE
nginxのアクセスログをstdoutに出力し実IPを記録する

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -7,6 +7,12 @@ server {
 
     client_max_body_size 20M;
 
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 0.0.0.0/0;
+
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
     }

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -17,7 +17,7 @@ php artisan view:cache
 # migrateはDB接続後に必要なら有効化
 # php artisan migrate --force
 
-php-fpm -D
+php-fpm -D -d "access.log=/dev/null"
 
 # Render Web Service は 0.0.0.0:$PORT でHTTP待ち受けする必要がある
 sed -i -E "s/listen 80[^;]*;/listen 0.0.0.0:${PORT:-10000};/" /etc/nginx/sites-available/default


### PR DESCRIPTION
- real_ip_header X-Forwarded-For でRenderのプロキシから実IPを取得
- access_log /dev/stdout でRender Dashboardにログを表示
- PHP-FPMのアクセスログを無効化（nginxログと重複するため）