### PR TITLE
交通費保存処理をN回直列リクエストからバッチAPIに変更

### DIFF
--- a/app/Http/Controllers/ExpenseApiController.php
+++ b/app/Http/Controllers/ExpenseApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ExpenseApi\BatchSaveExpenseRequest;
 use App\Http\Requests\ExpenseApi\StoreExpenseRequest;
 use App\Http\Requests\ExpenseApi\UpdateExpenseRequest;
 use App\Models\CommuterPass;
@@ -9,6 +10,7 @@ use App\Models\Expense;
 use App\Models\ExpenseReport;
 use App\Enums\ExpenseReportStatus;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class ExpenseApiController extends Controller
 {
@@ -30,6 +32,72 @@ class ExpenseApiController extends Controller
         if (in_array($statusValue, $lockedStatuses, true)) {
             abort(423, 'This expense report is locked (submitted).');
         }
+    }
+
+    /**
+     * 経費明細を一括保存（更新＋新規作成）
+     * PUT /api/expenses/batch — 1リクエストでトランザクション処理
+     */
+    public function batchSave(BatchSaveExpenseRequest $req)
+    {
+        $data   = $req->validated();
+        $report = ExpenseReport::findOrFail($data['report_id']);
+        $this->authorize('update', $report);
+        $this->abortIfLocked($report);
+
+        // updates の全 ID が このレポートに属することを確認
+        $updateIds = collect($data['updates'])->pluck('id');
+        if ($updateIds->isNotEmpty()) {
+            $belongCount = Expense::whereIn('id', $updateIds)
+                ->where('expense_report_id', $report->id)
+                ->count();
+            abort_if($belongCount !== $updateIds->count(), 403, 'Some expense IDs do not belong to this report.');
+        }
+
+        // creates の日付が全てこのレポートの月内であることを確認
+        foreach ($data['creates'] as $c) {
+            $d = Carbon::parse($c['expense_date']);
+            abort_unless(
+                $d->year === $report->year && $d->month === $report->month,
+                422,
+                "Date out of report month: {$c['expense_date']}"
+            );
+        }
+
+        $result = DB::transaction(function () use ($data, $report) {
+            $updated = [];
+            foreach ($data['updates'] as $u) {
+                $exp = Expense::find($u['id']);
+                $exp->fill([
+                    'station_from' => $u['station_from'] ?? null,
+                    'station_to'   => $u['station_to'] ?? null,
+                    'note'         => $u['note'] ?? null,
+                    'cost'         => $u['cost'] ?? 0,
+                    'trip_type'    => $u['trip_type'] ?? $exp->trip_type,
+                    'seq'          => $u['seq'] ?? $exp->seq,
+                ])->save();
+                $updated[] = $exp->fresh();
+            }
+
+            $created = [];
+            foreach ($data['creates'] as $c) {
+                $created[] = Expense::create([
+                    'expense_report_id' => $report->id,
+                    'expense_date'      => $c['expense_date'],
+                    'seq'               => $c['seq'],
+                    'station_from'      => $c['station_from'] ?? null,
+                    'station_to'        => $c['station_to'] ?? null,
+                    'note'              => $c['note'] ?? null,
+                    'cost'              => $c['cost'] ?? 0,
+                    'trip_type'         => $c['trip_type'],
+                    'category'          => $c['category'],
+                ]);
+            }
+
+            return ['updated' => $updated, 'created' => $created];
+        });
+
+        return response()->json($result, 200);
     }
 
     /**

--- a/app/Http/Requests/ExpenseApi/BatchSaveExpenseRequest.php
+++ b/app/Http/Requests/ExpenseApi/BatchSaveExpenseRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\ExpenseApi;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class BatchSaveExpenseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'report_id'               => ['required', 'exists:expense_reports,id'],
+
+            'updates'                  => ['present', 'array'],
+            'updates.*.id'             => ['required', 'integer', 'exists:expenses,id'],
+            'updates.*.station_from'   => ['nullable', 'string', 'max:255'],
+            'updates.*.station_to'     => ['nullable', 'string', 'max:255'],
+            'updates.*.note'           => ['nullable', 'string'],
+            'updates.*.cost'           => ['nullable', 'integer', 'min:0'],
+            'updates.*.trip_type'      => ['nullable', Rule::in(['round_trip', 'one_way'])],
+            'updates.*.seq'            => ['nullable', 'integer', 'min:0'],
+
+            'creates'                  => ['present', 'array'],
+            'creates.*.expense_date'   => ['required', 'date'],
+            'creates.*.seq'            => ['required', 'integer', 'min:0'],
+            'creates.*.station_from'   => ['nullable', 'string', 'max:255'],
+            'creates.*.station_to'     => ['nullable', 'string', 'max:255'],
+            'creates.*.note'           => ['nullable', 'string'],
+            'creates.*.cost'           => ['nullable', 'integer', 'min:0'],
+            'creates.*.trip_type'      => ['required', Rule::in(['round_trip', 'one_way'])],
+            'creates.*.category'       => ['required', Rule::in(['regular', 'irregular'])],
+        ];
+    }
+}

--- a/public/js/expenses.js
+++ b/public/js/expenses.js
@@ -293,42 +293,40 @@
 
         saveBtn.disabled = true; saveBtn.textContent = 'Saving…';
         try {
-          const updates = rows.filter(r => r.id && initialIdSet.has(String(r.id)));
-          for (const u of updates) {
-            const resp = await fetch(`/api/expenses/${u.id}`, {
-              method: 'PUT',
-              headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
-              body: JSON.stringify({
-                station_from: u.from || null,
-                station_to: u.to || null,
-                note: u.note || null,
-                cost: u.cost,
-                trip_type: u.trip,
-                seq: u.seq,
-              }),
-            });
-            if (!resp.ok) throw new Error(`Update failed (ID:${u.id}): ${resp.status} ${await resp.text()}`);
-          }
+          const updates = rows
+            .filter(r => r.id && initialIdSet.has(String(r.id)))
+            .map(u => ({
+              id:           u.id,
+              station_from: u.from || null,
+              station_to:   u.to   || null,
+              note:         u.note || null,
+              cost:         u.cost,
+              trip_type:    u.trip,
+              seq:          u.seq,
+            }));
 
-          const creates = rows.filter(r => !r.id);
-          for (const c of creates) {
-            const seq = Number.isFinite(c.seq) ? c.seq : 100;
-            const resp = await fetch('/api/expenses', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
-              body: JSON.stringify({
-                expense_report_id: reportId,
-                expense_date: c.date,
-                seq: seq,
-                station_from: c.from || null,
-                station_to: c.to || null,
-                note: c.note || null,
-                cost: c.cost,
-                trip_type: c.trip,
-                category: 'regular',
-              }),
-            });
-            if (!resp.ok) throw new Error(`Creation failed (Date:${c.date}): ${resp.status} ${await resp.text()}`);
+          const creates = rows
+            .filter(r => !r.id)
+            .map(c => ({
+              expense_date: c.date,
+              seq:          Number.isFinite(c.seq) ? c.seq : 100,
+              station_from: c.from || null,
+              station_to:   c.to   || null,
+              note:         c.note || null,
+              cost:         c.cost,
+              trip_type:    c.trip,
+              category:     'regular',
+            }));
+
+          const resp = await fetch('/api/expenses/batch', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
+            body: JSON.stringify({ report_id: reportId, updates, creates }),
+          });
+          if (!resp.ok) {
+            let msg = '';
+            try { msg = (await resp.json())?.message || ''; } catch (_) { msg = await resp.text(); }
+            throw new Error(`Save failed: ${resp.status} ${msg}`);
           }
 
           showToast('Saved successfully.', 'success');

--- a/routes/web.php
+++ b/routes/web.php
@@ -185,9 +185,10 @@ Route::middleware(['auth'])->group(function () {
 use App\Http\Controllers\ExpenseApiController;
 
 Route::middleware(['auth'])->group(function () {
-    Route::post('/api/expenses',        [ExpenseApiController::class, 'store'])->name('api.expenses.store');
-    Route::put('/api/expenses/{expense}', [ExpenseApiController::class, 'update'])->name('api.expenses.update');
-    Route::delete('/api/expenses/{expense}', [ExpenseApiController::class, 'destroy'])->name('api.expenses.destroy');
+    Route::post('/api/expenses',              [ExpenseApiController::class, 'store'])->name('api.expenses.store');
+    Route::put('/api/expenses/batch',         [ExpenseApiController::class, 'batchSave'])->name('api.expenses.batch');
+    Route::put('/api/expenses/{expense}',     [ExpenseApiController::class, 'update'])->name('api.expenses.update');
+    Route::delete('/api/expenses/{expense}',  [ExpenseApiController::class, 'destroy'])->name('api.expenses.destroy');
 });
 
 use App\Http\Controllers\ExpenseReportController;

--- a/tests/Feature/ExpenseApiControllerBatchSaveTest.php
+++ b/tests/Feature/ExpenseApiControllerBatchSaveTest.php
@@ -275,9 +275,11 @@ class ExpenseApiControllerBatchSaveTest extends TestCase
     // =========================================================================
 
     /**
-     * シナリオ 6: 他人が所有するレポートへのアクセスは 403
+     * シナリオ 6: 他人が所有するレポートへのアクセスは welcome へリダイレクト（302）
      *
      * - report.user_id と actingAs が一致しない場合
+     * - このアプリの例外ハンドラは AuthorizationException を
+     *   JSON リクエストでも常に welcome へリダイレクトする
      */
     public function test_cannot_batch_save_other_users_report(): void
     {
@@ -288,7 +290,7 @@ class ExpenseApiControllerBatchSaveTest extends TestCase
             'report_id' => $report->id,
             'updates'   => [],
             'creates'   => [],
-        ])->assertForbidden();
+        ])->assertRedirect(route('welcome'));
     }
 
     /**

--- a/tests/Feature/ExpenseApiControllerBatchSaveTest.php
+++ b/tests/Feature/ExpenseApiControllerBatchSaveTest.php
@@ -1,0 +1,516 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ExpenseReportStatus;
+use App\Models\Expense;
+use App\Models\ExpenseReport;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ExpenseApiController::batchSave() のテスト
+ * ルート: PUT /api/expenses/batch
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ゲスト]
+ *   1. 未認証アクセスはログインページへリダイレクト
+ *
+ * [正常系 - 本人操作]
+ *   2. updates のみ（新規行なし）: 200 が返り DB が更新される
+ *   3. creates のみ（既存行なし）: 200 が返り DB に行が挿入される
+ *   4. updates + creates 混在: 200 が返り両方とも DB に反映される
+ *   5. updates / creates が両方空配列: 200 が返り DB は変化しない
+ *
+ * [セキュリティ - 他人のレポート]
+ *   6. 他人のレポートへのアクセスは 403
+ *   7. updates[*].id に別レポートの expense ID を混入すると 403
+ *
+ * [ロック]
+ *   8. SUBMITTED 状態のレポートへのアクセスは 423
+ *   9. APPROVED 状態のレポートへのアクセスは 423
+ *
+ * [バリデーション]
+ *  10. report_id が存在しないレコードを指定すると 422
+ *  11. creates[*].expense_date が対象月の範囲外なら 422
+ *  12. creates[*].trip_type が欠如している行は 422
+ *  13. updates[*].id が未指定（または不正な型）なら 422
+ *
+ * [DB 反映の詳細確認]
+ *  14. updates 後の各フィールド値が正しく保存される
+ *  15. creates 後のレコードが expense_report_id と紐づいて保存される
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 注記: batchSave は ExpenseReportPolicy::update() を使用。
+ * 本人（report.user_id 一致）またはスコープ内 admin のみ操作可能。
+ * ここでは「本人」ケースをメインにテストする。
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+class ExpenseApiControllerBatchSaveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * ユーザーと、そのユーザーの今月の DRAFT レポートを生成する。
+     *
+     * Note: ExpenseReportFactory は employee_first_middle_name という実在しないカラムを
+     * 含むため、ここでは factory を使わず直接 create() する。
+     *
+     * @return array{0: User, 1: ExpenseReport}
+     */
+    private function makeUserWithReport(int $year = 0, int $month = 0): array
+    {
+        $user = User::factory()->general()->create();
+
+        $y = $year ?: now()->year;
+        $m = $month ?: now()->month;
+
+        $report = ExpenseReport::create([
+            'user_id'              => $user->id,
+            'employee_code'        => str_pad((string)$user->id, 4, '0', STR_PAD_LEFT),
+            'employee_family_name' => 'テスト',
+            'employee_first_name'  => null,
+            'year'                 => $y,
+            'month'                => $m,
+            'status'               => ExpenseReportStatus::DRAFT,
+            'total_amount'         => 0,
+        ]);
+
+        return [$user, $report];
+    }
+
+    /**
+     * 指定レポートに紐づく Expense を1件生成する。
+     *
+     * Note: ExpenseFactory は expenses テーブルに存在しない user_id カラムを定義しているため、
+     * ここでは factory を使わず直接 create() する。
+     */
+    private function makeExpense(ExpenseReport $report, array $override = []): Expense
+    {
+        $date = now()->setYear($report->year)->setMonth($report->month)->startOfMonth()->toDateString();
+
+        return Expense::create(array_merge([
+            'expense_report_id' => $report->id,
+            'expense_date'      => $date,
+            'seq'               => 100,
+            'station_from'      => '梅田',
+            'station_to'        => '心斎橋',
+            'cost'              => 240,
+            'trip_type'         => 'round_trip',
+            'category'          => 'regular',
+        ], $override));
+    }
+
+    /**
+     * batchSave リクエストを送信する。
+     *
+     * @param  User           $user
+     * @param  ExpenseReport  $report
+     * @param  array          $updates  更新行の配列
+     * @param  array          $creates  新規作成行の配列
+     */
+    private function putBatch(User $user, ExpenseReport $report, array $updates = [], array $creates = [])
+    {
+        return $this->actingAs($user)->putJson(route('api.expenses.batch'), [
+            'report_id' => $report->id,
+            'updates'   => $updates,
+            'creates'   => $creates,
+        ]);
+    }
+
+    // =========================================================================
+    // 1. ゲスト
+    // =========================================================================
+
+    /**
+     * シナリオ 1: 未認証ユーザーは PUT /api/expenses/batch にアクセスするとリダイレクト
+     */
+    public function test_guest_is_redirected(): void
+    {
+        $this->putJson(route('api.expenses.batch'), [
+            'report_id' => 1,
+            'updates'   => [],
+            'creates'   => [],
+        ])->assertUnauthorized();
+    }
+
+    // =========================================================================
+    // 2〜5. 正常系 - 本人操作
+    // =========================================================================
+
+    /**
+     * シナリオ 2: updates のみ（creates は空）を送信すると 200 が返り既存行が更新される
+     *
+     * - 変更前の station_from / cost / trip_type を変更後の値で上書き
+     * - レスポンスの updated 配列に1件含まれる
+     * - DB にも新しい値が反映されている
+     */
+    public function test_updates_only_returns_200_and_persists_changes(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report);
+
+        $this->putBatch($user, $report, updates: [
+            [
+                'id'           => $expense->id,
+                'station_from' => '天王寺',
+                'station_to'   => '難波',
+                'cost'         => 500,
+                'trip_type'    => 'one_way',
+                'note'         => 'テスト更新',
+                'seq'          => 200,
+            ],
+        ])->assertOk()
+          ->assertJsonCount(1, 'updated')
+          ->assertJsonCount(0, 'created');
+
+        $this->assertDatabaseHas('expenses', [
+            'id'           => $expense->id,
+            'station_from' => '天王寺',
+            'station_to'   => '難波',
+            'cost'         => 500,
+            'trip_type'    => 'one_way',
+        ]);
+    }
+
+    /**
+     * シナリオ 3: creates のみ（updates は空）を送信すると 200 が返り新しい行が挿入される
+     *
+     * - expense_report_id / expense_date / trip_type がそのまま保存される
+     * - レスポンスの created 配列に1件含まれる
+     * - DB に新レコードが存在する
+     */
+    public function test_creates_only_returns_200_and_inserts_row(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $date = now()->setYear($report->year)->setMonth($report->month)->startOfMonth()->toDateString();
+
+        $this->putBatch($user, $report, creates: [
+            [
+                'expense_date' => $date,
+                'seq'          => 1024,
+                'station_from' => '難波',
+                'station_to'   => '新大阪',
+                'cost'         => 320,
+                'trip_type'    => 'round_trip',
+                'category'     => 'regular',
+            ],
+        ])->assertOk()
+          ->assertJsonCount(0, 'updated')
+          ->assertJsonCount(1, 'created');
+
+        $this->assertDatabaseHas('expenses', [
+            'expense_report_id' => $report->id,
+            'expense_date'      => $date,
+            'station_from'      => '難波',
+            'station_to'        => '新大阪',
+            'cost'              => 320,
+        ]);
+    }
+
+    /**
+     * シナリオ 4: updates と creates が混在しても 200 が返り両方 DB に反映される
+     *
+     * - 既存1行の更新 + 新規1行の作成
+     * - updated / created がそれぞれ1件ずつ返る
+     */
+    public function test_mixed_updates_and_creates_both_persist(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $existing = $this->makeExpense($report);
+        $newDate  = now()->setYear($report->year)->setMonth($report->month)->startOfMonth()
+                         ->addDay()->toDateString();
+
+        $this->putBatch(
+            $user,
+            $report,
+            updates: [
+                ['id' => $existing->id, 'station_from' => '桃谷', 'station_to' => '鶴橋',
+                 'cost' => 180, 'trip_type' => 'one_way', 'seq' => 100],
+            ],
+            creates: [
+                ['expense_date' => $newDate, 'seq' => 2048, 'station_from' => '鶴橋',
+                 'station_to' => '天王寺', 'cost' => 210, 'trip_type' => 'round_trip',
+                 'category' => 'regular'],
+            ]
+        )->assertOk()
+         ->assertJsonCount(1, 'updated')
+         ->assertJsonCount(1, 'created');
+
+        $this->assertDatabaseHas('expenses', ['id' => $existing->id, 'station_from' => '桃谷']);
+        $this->assertDatabaseHas('expenses', ['expense_report_id' => $report->id, 'expense_date' => $newDate]);
+    }
+
+    /**
+     * シナリオ 5: updates / creates が両方空配列でも 200 が返り DB は変化しない
+     *
+     * - 「変更なしのSave」を誤ってリクエストした場合も安全に処理される
+     */
+    public function test_empty_updates_and_creates_returns_200_with_no_db_change(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report);
+
+        $this->putBatch($user, $report)
+             ->assertOk()
+             ->assertJson(['updated' => [], 'created' => []]);
+
+        // 既存行は変化していない
+        $this->assertDatabaseHas('expenses', [
+            'id'      => $expense->id,
+            'cost'    => $expense->cost,
+        ]);
+    }
+
+    // =========================================================================
+    // 6〜7. セキュリティ - 他人のレポート / ID混入
+    // =========================================================================
+
+    /**
+     * シナリオ 6: 他人が所有するレポートへのアクセスは 403
+     *
+     * - report.user_id と actingAs が一致しない場合
+     */
+    public function test_cannot_batch_save_other_users_report(): void
+    {
+        [$owner, $report] = $this->makeUserWithReport();
+        $attacker = User::factory()->general()->create();
+
+        $this->actingAs($attacker)->putJson(route('api.expenses.batch'), [
+            'report_id' => $report->id,
+            'updates'   => [],
+            'creates'   => [],
+        ])->assertForbidden();
+    }
+
+    /**
+     * シナリオ 7: updates[*].id に別レポートの expense ID を混入すると 403
+     *
+     * - 正当な report_id を持ちつつ、他人の expense ID を updates に含めた場合
+     * - コントローラの「全 ID がこのレポートに属するか」チェックで検出される
+     */
+    public function test_cannot_update_expense_belonging_to_another_report(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        // 別ユーザーのレポートと expense を作成
+        [$otherUser, $otherReport] = $this->makeUserWithReport();
+        $otherExpense = $this->makeExpense($otherReport);
+
+        $this->putBatch($user, $report, updates: [
+            [
+                'id'           => $otherExpense->id, // 他人の expense ID
+                'station_from' => '不正な変更',
+                'station_to'   => '不正な変更',
+                'cost'         => 9999,
+                'trip_type'    => 'one_way',
+                'seq'          => 100,
+            ],
+        ])->assertForbidden();
+
+        // 他人の expense は変化していない
+        $this->assertDatabaseHas('expenses', [
+            'id'   => $otherExpense->id,
+            'cost' => $otherExpense->cost,
+        ]);
+    }
+
+    // =========================================================================
+    // 8〜9. ロック
+    // =========================================================================
+
+    /**
+     * シナリオ 8: SUBMITTED 状態のレポートへのアクセスは 423
+     *
+     * - 提出済みレポートは編集不可（ロック）
+     */
+    public function test_submitted_report_returns_423(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $report->update(['status' => ExpenseReportStatus::SUBMITTED]);
+
+        $this->putBatch($user, $report)
+             ->assertStatus(423);
+    }
+
+    /**
+     * シナリオ 9: APPROVED 状態のレポートへのアクセスは 423
+     *
+     * - 承認済みレポートも同様にロックされている
+     */
+    public function test_approved_report_returns_423(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $report->update(['status' => ExpenseReportStatus::APPROVED]);
+
+        $this->putBatch($user, $report)
+             ->assertStatus(423);
+    }
+
+    // =========================================================================
+    // 10〜13. バリデーション
+    // =========================================================================
+
+    /**
+     * シナリオ 10: report_id に存在しないIDを指定すると 422
+     */
+    public function test_invalid_report_id_returns_422(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)->putJson(route('api.expenses.batch'), [
+            'report_id' => 999999,
+            'updates'   => [],
+            'creates'   => [],
+        ])->assertUnprocessable();
+    }
+
+    /**
+     * シナリオ 11: creates[*].expense_date が対象月の範囲外なら 422
+     *
+     * - レポートが今月のものに対して、翌月の日付を creates に含めた場合
+     */
+    public function test_creates_with_out_of_month_date_returns_422(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        // 翌月の日付
+        $nextMonthDate = now()->setYear($report->year)->setMonth($report->month)
+                              ->addMonth()->startOfMonth()->toDateString();
+
+        $this->putBatch($user, $report, creates: [
+            [
+                'expense_date' => $nextMonthDate,
+                'seq'          => 100,
+                'station_from' => '梅田',
+                'station_to'   => '難波',
+                'cost'         => 240,
+                'trip_type'    => 'round_trip',
+                'category'     => 'regular',
+            ],
+        ])->assertUnprocessable();
+    }
+
+    /**
+     * シナリオ 12: creates[*].trip_type が欠如している場合は 422
+     *
+     * - trip_type は creates において required
+     */
+    public function test_creates_without_trip_type_returns_422(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $date = now()->setYear($report->year)->setMonth($report->month)->startOfMonth()->toDateString();
+
+        $this->putBatch($user, $report, creates: [
+            [
+                'expense_date' => $date,
+                'seq'          => 100,
+                'station_from' => '梅田',
+                'station_to'   => '難波',
+                'cost'         => 240,
+                // trip_type を意図的に省略
+                'category'     => 'regular',
+            ],
+        ])->assertUnprocessable();
+    }
+
+    /**
+     * シナリオ 13: updates[*].id が未指定の場合は 422
+     *
+     * - id は updates において required
+     */
+    public function test_updates_without_id_returns_422(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $this->putBatch($user, $report, updates: [
+            [
+                // id を意図的に省略
+                'station_from' => '梅田',
+                'station_to'   => '難波',
+                'cost'         => 240,
+                'trip_type'    => 'round_trip',
+                'seq'          => 100,
+            ],
+        ])->assertUnprocessable();
+    }
+
+    // =========================================================================
+    // 14〜15. DB 反映の詳細確認
+    // =========================================================================
+
+    /**
+     * シナリオ 14: updates 後の各フィールド値が正しく DB に保存される
+     *
+     * - station_from / station_to / cost / trip_type / note / seq の全フィールドを確認
+     */
+    public function test_update_persists_all_fields_correctly(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report, ['cost' => 100, 'note' => null]);
+
+        $this->putBatch($user, $report, updates: [
+            [
+                'id'           => $expense->id,
+                'station_from' => '新大阪',
+                'station_to'   => '三ノ宮',
+                'cost'         => 680,
+                'trip_type'    => 'one_way',
+                'note'         => '出張',
+                'seq'          => 512,
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('expenses', [
+            'id'           => $expense->id,
+            'station_from' => '新大阪',
+            'station_to'   => '三ノ宮',
+            'cost'         => 680,
+            'trip_type'    => 'one_way',
+            'note'         => '出張',
+            'seq'          => 512,
+        ]);
+    }
+
+    /**
+     * シナリオ 15: creates 後のレコードが expense_report_id / expense_date で正しく紐づく
+     *
+     * - レスポンスの created[0] に id が含まれる
+     * - DB にレコードが存在し、expense_report_id が report.id に一致する
+     * - creates した行数分だけレコードが増える
+     */
+    public function test_create_persists_with_correct_report_association(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $date = now()->setYear($report->year)->setMonth($report->month)->startOfMonth()->toDateString();
+
+        $beforeCount = Expense::where('expense_report_id', $report->id)->count();
+
+        $response = $this->putBatch($user, $report, creates: [
+            ['expense_date' => $date, 'seq' => 100, 'station_from' => 'A', 'station_to' => 'B',
+             'cost' => 160, 'trip_type' => 'one_way', 'category' => 'regular'],
+            ['expense_date' => $date, 'seq' => 200, 'station_from' => 'C', 'station_to' => 'D',
+             'cost' => 320, 'trip_type' => 'round_trip', 'category' => 'regular'],
+        ]);
+
+        $response->assertOk()->assertJsonCount(2, 'created');
+
+        $afterCount = Expense::where('expense_report_id', $report->id)->count();
+        $this->assertSame($beforeCount + 2, $afterCount);
+
+        // レスポンスの id を使って DB にレコードが存在することを確認
+        $createdId = $response->json('created.0.id');
+        $this->assertDatabaseHas('expenses', [
+            'id'                => $createdId,
+            'expense_report_id' => $report->id,
+        ]);
+    }
+}

--- a/tests/Feature/ExpenseApiControllerTest.php
+++ b/tests/Feature/ExpenseApiControllerTest.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ExpenseReportStatus;
+use App\Models\Expense;
+use App\Models\ExpenseReport;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ExpenseApiController のテスト（store / update / destroy）
+ * ※ batchSave は ExpenseApiControllerBatchSaveTest に分離済み
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [store — POST /api/expenses]
+ *   1. ゲスト → 401
+ *   2. 本人 → 201、DB にレコードが挿入される
+ *   3. 他人のレポートへ追加しようとすると welcome へリダイレクト（AuthorizationException）
+ *   4. SUBMITTED レポートへの追加は 423
+ *   5. 対象月外の expense_date は 422
+ *   6. trip_type が欠如している場合は 422
+ *
+ * [update — PUT /api/expenses/{expense}]
+ *   7. ゲスト → 401
+ *   8. 本人 → 200、DB が更新される
+ *   9. 他人の expense を更新しようとすると welcome へリダイレクト（AuthorizationException）
+ *  10. SUBMITTED レポートの expense 更新は 423
+ *
+ * [destroy — DELETE /api/expenses/{expense}]
+ *  11. ゲスト → 401
+ *  12. 本人 → 200、DB からレコードが削除される
+ *  13. 他人の expense を削除しようとすると welcome へリダイレクト（AuthorizationException）
+ *  14. SUBMITTED レポートの expense 削除は 423
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 注記: このアプリの例外ハンドラは AuthorizationException を JSON リクエストでも
+ * 常に welcome へリダイレクト（302）する。
+ * 423 は abort() 由来の HttpException なので JSON 形式で返る。
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+class ExpenseApiControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * ユーザーと、そのユーザーの今月の DRAFT レポートを生成する。
+     *
+     * @return array{0: User, 1: ExpenseReport}
+     */
+    private function makeUserWithReport(): array
+    {
+        $user = User::factory()->general()->create();
+
+        $report = ExpenseReport::create([
+            'user_id'              => $user->id,
+            'employee_code'        => str_pad((string)$user->id, 4, '0', STR_PAD_LEFT),
+            'employee_family_name' => 'テスト',
+            'employee_first_name'  => null,
+            'year'                 => now()->year,
+            'month'                => now()->month,
+            'status'               => ExpenseReportStatus::DRAFT,
+            'total_amount'         => 0,
+        ]);
+
+        return [$user, $report];
+    }
+
+    /**
+     * 指定レポートに紐づく Expense を1件生成する。
+     */
+    private function makeExpense(ExpenseReport $report, array $override = []): Expense
+    {
+        return Expense::create(array_merge([
+            'expense_report_id' => $report->id,
+            'expense_date'      => now()->startOfMonth()->toDateString(),
+            'seq'               => 100,
+            'station_from'      => '梅田',
+            'station_to'        => '心斎橋',
+            'cost'              => 240,
+            'trip_type'         => 'round_trip',
+            'category'          => 'regular',
+        ], $override));
+    }
+
+    /** store リクエストの最小有効ペイロードを返す。 */
+    private function storePayload(ExpenseReport $report, array $override = []): array
+    {
+        return array_merge([
+            'expense_report_id' => $report->id,
+            'expense_date'      => now()->startOfMonth()->toDateString(),
+            'seq'               => 100,
+            'station_from'      => '梅田',
+            'station_to'        => '心斎橋',
+            'cost'              => 240,
+            'trip_type'         => 'round_trip',
+            'category'          => 'regular',
+        ], $override);
+    }
+
+    // =========================================================================
+    // 1〜6. store（POST /api/expenses）
+    // =========================================================================
+
+    /**
+     * シナリオ 1: 未認証ユーザーは 401
+     */
+    public function test_store_guest_returns_401(): void
+    {
+        $this->postJson(route('api.expenses.store'), [])->assertUnauthorized();
+    }
+
+    /**
+     * シナリオ 2: 本人は expense を新規作成できる → 201、DB にレコードが挿入される
+     *
+     * - レスポンスの id を使って assertDatabaseHas でレコードの存在と値を確認
+     */
+    public function test_store_owner_can_create_expense(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $resp = $this->actingAs($user)
+            ->postJson(route('api.expenses.store'), $this->storePayload($report, [
+                'station_from' => '天王寺',
+                'station_to'   => '難波',
+                'cost'         => 180,
+            ]));
+
+        $resp->assertCreated();
+
+        $this->assertDatabaseHas('expenses', [
+            'expense_report_id' => $report->id,
+            'station_from'      => '天王寺',
+            'station_to'        => '難波',
+            'cost'              => 180,
+            'trip_type'         => 'round_trip',
+        ]);
+    }
+
+    /**
+     * シナリオ 3: 他人のレポートへ expense を追加しようとすると welcome へリダイレクト
+     *
+     * - ExpenseReportPolicy::update が失敗 → AuthorizationException
+     * - カスタム例外ハンドラにより JSON リクエストでも 302 になる
+     */
+    public function test_store_other_users_report_redirects_to_welcome(): void
+    {
+        [, $report] = $this->makeUserWithReport();
+        $attacker = User::factory()->general()->create();
+
+        $this->actingAs($attacker)
+            ->postJson(route('api.expenses.store'), $this->storePayload($report))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 4: SUBMITTED レポートへの追加は 423
+     *
+     * - abortIfLocked が検出して 423 を返す
+     */
+    public function test_store_into_submitted_report_returns_423(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $report->update(['status' => ExpenseReportStatus::SUBMITTED]);
+
+        $this->actingAs($user)
+            ->postJson(route('api.expenses.store'), $this->storePayload($report))
+            ->assertStatus(423);
+    }
+
+    /**
+     * シナリオ 5: 対象月外の expense_date は 422
+     *
+     * - コントローラの月内チェック（abort_unless）で弾かれる
+     */
+    public function test_store_with_out_of_month_date_returns_422(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $nextMonth = now()->addMonth()->startOfMonth()->toDateString();
+
+        $this->actingAs($user)
+            ->postJson(route('api.expenses.store'), $this->storePayload($report, [
+                'expense_date' => $nextMonth,
+            ]))
+            ->assertUnprocessable();
+    }
+
+    /**
+     * シナリオ 6: trip_type が欠如している場合は 422（バリデーション）
+     */
+    public function test_store_without_trip_type_returns_422(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $payload = $this->storePayload($report);
+        unset($payload['trip_type']);
+
+        $this->actingAs($user)
+            ->postJson(route('api.expenses.store'), $payload)
+            ->assertUnprocessable();
+    }
+
+    // =========================================================================
+    // 7〜10. update（PUT /api/expenses/{expense}）
+    // =========================================================================
+
+    /**
+     * シナリオ 7: 未認証ユーザーは 401
+     */
+    public function test_update_guest_returns_401(): void
+    {
+        $this->putJson(route('api.expenses.update', 1), [])->assertUnauthorized();
+    }
+
+    /**
+     * シナリオ 8: 本人は expense を更新できる → 200、DB が更新される
+     *
+     * - station_from / cost / trip_type / note / seq の各フィールドを確認
+     */
+    public function test_update_owner_can_update_expense(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report);
+
+        $this->actingAs($user)
+            ->putJson(route('api.expenses.update', $expense), [
+                'station_from' => '新大阪',
+                'station_to'   => '三ノ宮',
+                'cost'         => 680,
+                'trip_type'    => 'one_way',
+                'note'         => '出張',
+                'seq'          => 512,
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('expenses', [
+            'id'           => $expense->id,
+            'station_from' => '新大阪',
+            'station_to'   => '三ノ宮',
+            'cost'         => 680,
+            'trip_type'    => 'one_way',
+            'note'         => '出張',
+            'seq'          => 512,
+        ]);
+    }
+
+    /**
+     * シナリオ 9: 他人の expense を更新しようとすると welcome へリダイレクト
+     *
+     * - ExpensePolicy::update → canManage が false → AuthorizationException
+     * - カスタム例外ハンドラにより JSON リクエストでも 302 になる
+     */
+    public function test_update_other_users_expense_redirects_to_welcome(): void
+    {
+        [, $report] = $this->makeUserWithReport();
+        $expense  = $this->makeExpense($report);
+        $attacker = User::factory()->general()->create();
+
+        $this->actingAs($attacker)
+            ->putJson(route('api.expenses.update', $expense), [
+                'cost'      => 9999,
+                'trip_type' => 'one_way',
+            ])
+            ->assertRedirect(route('welcome'));
+
+        // 値は変化していない
+        $this->assertDatabaseHas('expenses', ['id' => $expense->id, 'cost' => $expense->cost]);
+    }
+
+    /**
+     * シナリオ 10: SUBMITTED レポートの expense を更新しようとすると 423
+     */
+    public function test_update_expense_in_submitted_report_returns_423(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report);
+        $report->update(['status' => ExpenseReportStatus::SUBMITTED]);
+
+        $this->actingAs($user)
+            ->putJson(route('api.expenses.update', $expense), [
+                'cost'      => 9999,
+                'trip_type' => 'one_way',
+            ])
+            ->assertStatus(423);
+
+        $this->assertDatabaseHas('expenses', ['id' => $expense->id, 'cost' => $expense->cost]);
+    }
+
+    // =========================================================================
+    // 11〜14. destroy（DELETE /api/expenses/{expense}）
+    // =========================================================================
+
+    /**
+     * シナリオ 11: 未認証ユーザーは 401
+     */
+    public function test_destroy_guest_returns_401(): void
+    {
+        $this->deleteJson(route('api.expenses.destroy', 1))->assertUnauthorized();
+    }
+
+    /**
+     * シナリオ 12: 本人は expense を削除できる → 200、DB からレコードが消える
+     */
+    public function test_destroy_owner_can_delete_expense(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report);
+
+        $this->actingAs($user)
+            ->deleteJson(route('api.expenses.destroy', $expense))
+            ->assertOk()
+            ->assertJson(['ok' => true]);
+
+        $this->assertDatabaseMissing('expenses', ['id' => $expense->id]);
+    }
+
+    /**
+     * シナリオ 13: 他人の expense を削除しようとすると welcome へリダイレクト
+     *
+     * - ExpensePolicy::delete → canManage が false → AuthorizationException
+     * - カスタム例外ハンドラにより JSON リクエストでも 302 になる
+     * - DB のレコードは削除されていない
+     */
+    public function test_destroy_other_users_expense_redirects_to_welcome(): void
+    {
+        [, $report] = $this->makeUserWithReport();
+        $expense  = $this->makeExpense($report);
+        $attacker = User::factory()->general()->create();
+
+        $this->actingAs($attacker)
+            ->deleteJson(route('api.expenses.destroy', $expense))
+            ->assertRedirect(route('welcome'));
+
+        $this->assertDatabaseHas('expenses', ['id' => $expense->id]);
+    }
+
+    /**
+     * シナリオ 14: SUBMITTED レポートの expense を削除しようとすると 423
+     *
+     * - abortIfLocked が検出して 423 を返す
+     * - DB のレコードは削除されていない
+     */
+    public function test_destroy_expense_in_submitted_report_returns_423(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $expense = $this->makeExpense($report);
+        $report->update(['status' => ExpenseReportStatus::SUBMITTED]);
+
+        $this->actingAs($user)
+            ->deleteJson(route('api.expenses.destroy', $expense))
+            ->assertStatus(423);
+
+        $this->assertDatabaseHas('expenses', ['id' => $expense->id]);
+    }
+}

--- a/tests/Feature/ExpenseEditControllerTest.php
+++ b/tests/Feature/ExpenseEditControllerTest.php
@@ -1,0 +1,443 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ExpenseReportStatus;
+use App\Models\Department;
+use App\Models\District;
+use App\Models\ExpenseReport;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ExpenseEditController のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [selfEdit — GET /expenses/edit]
+ *   1. ゲスト → ログインページへリダイレクト
+ *   2. 本人（当月レポートあり）→ 200、expenses.edit ビュー、hasReport=true
+ *   3. 本人（レポートなし月）→ 200、expenses.edit ビュー、hasReport=false
+ *
+ * [adminEdit — GET /expenses/{user}/edit]
+ *   4. ゲスト → ログインページへリダイレクト
+ *   5. general ユーザーが他ユーザーの画面を見ようとすると welcome へリダイレクト
+ *   6. admin がスコープ内のユーザーを閲覧できる → 200
+ *
+ * [submit — PUT /expenses/reports/{report}/submit]
+ *   7. 本人が DRAFT レポートを提出できる → status=SUBMITTED、submitted_at に値が入る
+ *   8. 他人のレポートを提出しようとすると welcome へリダイレクト
+ *   9. 提出後は本人の編集画面へリダイレクトされる
+ *
+ * [unsubmit — PATCH /expenses/{report}/unsubmit]
+ *  10. admin が SUBMITTED を DRAFT に戻せる → status=DRAFT、submitted_at=null
+ *  11. DRAFT 状態では unsubmit できない（バックへリダイレクト + エラーメッセージ）
+ *  12. general ユーザーは unsubmit できない → welcome へリダイレクト
+ *
+ * [generateMonthly — POST /expenses/generate-monthly]
+ *  13. admin → Artisan コマンドが呼ばれ back with toast
+ *  14. general ユーザー → welcome へリダイレクト
+ *
+ * [cleanupEmpty — POST /expenses/cleanup-empty]
+ *  15. admin → Artisan コマンドが呼ばれ back with toast
+ *  16. general ユーザー → welcome へリダイレクト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 注記: AuthorizationException はカスタム例外ハンドラにより welcome へリダイレクト（302）
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+class ExpenseEditControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * ユーザーと指定年月の DRAFT レポートを生成する。
+     *
+     * @return array{0: User, 1: ExpenseReport}
+     */
+    private function makeUserWithReport(int $year = 0, int $month = 0): array
+    {
+        $user = User::factory()->general()->create();
+
+        $y = $year ?: now()->year;
+        $m = $month ?: now()->month;
+
+        $report = ExpenseReport::create([
+            'user_id'              => $user->id,
+            'employee_code'        => str_pad((string)$user->id, 4, '0', STR_PAD_LEFT),
+            'employee_family_name' => 'テスト',
+            'employee_first_name'  => null,
+            'year'                 => $y,
+            'month'                => $m,
+            'status'               => ExpenseReportStatus::DRAFT,
+            'total_amount'         => 0,
+        ]);
+
+        return [$user, $report];
+    }
+
+    /**
+     * admin ユーザーとスコープ（District + Department + UserManagementScope）を生成する。
+     *
+     * @return array{0: User, 1: UserManagementScope, 2: District, 3: Department}
+     */
+    private function makeAdmin(): array
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $admin = User::factory()->admin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $scope = UserManagementScope::factory()->create([
+            'user_id'       => $admin->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$admin, $scope, $district, $department];
+    }
+
+    /**
+     * admin のスコープ内に属するユーザーを生成する。
+     */
+    private function makeUserInScope(District $district, Department $department): User
+    {
+        return User::factory()->general()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+    }
+
+    // =========================================================================
+    // 1〜3. selfEdit（GET /expenses/edit）
+    // =========================================================================
+
+    /**
+     * シナリオ 1: ゲストはログインページへリダイレクト
+     */
+    public function test_self_edit_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('expenses.edit'))
+             ->assertRedirect(route('login'));
+    }
+
+    /**
+     * シナリオ 2: 本人（当月レポートあり）→ 200、expenses.edit ビュー、hasReport=true
+     *
+     * - CalendarResolver / RouteDeclarationService は空データで動作する（モック不要）
+     * - ビューに渡る hasReport が true であることを確認
+     */
+    public function test_self_edit_shows_expense_sheet_when_report_exists(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $this->actingAs($user)
+             ->get(route('expenses.edit', ['year' => now()->year, 'month' => now()->month]))
+             ->assertOk()
+             ->assertViewIs('expenses.edit')
+             ->assertViewHas('hasReport', true)
+             ->assertViewHas('report', fn ($r) => $r->id === $report->id);
+    }
+
+    /**
+     * シナリオ 3: 本人（レポートなし月）→ 200、hasReport=false で空シート表示
+     *
+     * - レポートが存在しない月でも 404 にならず画面が表示される
+     */
+    public function test_self_edit_shows_empty_sheet_when_no_report(): void
+    {
+        $user = User::factory()->general()->create();
+
+        // レポートを作らずにアクセス
+        $this->actingAs($user)
+             ->get(route('expenses.edit', ['year' => now()->year, 'month' => now()->month]))
+             ->assertOk()
+             ->assertViewIs('expenses.edit')
+             ->assertViewHas('hasReport', false);
+    }
+
+    // =========================================================================
+    // 4〜6. adminEdit（GET /expenses/{user}/edit）
+    // =========================================================================
+
+    /**
+     * シナリオ 4: ゲストはログインページへリダイレクト
+     */
+    public function test_admin_edit_guest_is_redirected_to_login(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->get(route('expenses.admin.edit', ['user' => $user->employee_code]))
+             ->assertRedirect(route('login'));
+    }
+
+    /**
+     * シナリオ 5: general ユーザーが他ユーザーの画面を見ようとすると welcome へリダイレクト
+     *
+     * - UserPolicy::view が失敗 → AuthorizationException → welcome redirect
+     */
+    public function test_admin_edit_general_user_cannot_view_others(): void
+    {
+        $viewer = User::factory()->general()->create();
+        $target = User::factory()->general()->create();
+
+        $this->actingAs($viewer)
+             ->get(route('expenses.admin.edit', ['user' => $target->employee_code]))
+             ->assertRedirect(route('welcome'));
+    }
+
+    /**
+     * シナリオ 6: admin がスコープ内のユーザーの編集画面を閲覧できる → 200
+     *
+     * - UserPolicy::isScopedAdminFor が CurrentScopeService 経由でスコープを確認
+     * - selected_scope_id をセッションにセットすることで認証が通る
+     * - Blade が $report->employee_code を参照するため、レポートを事前に作成する
+     */
+    public function test_admin_edit_admin_can_view_scoped_users_expenses(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+        $target = $this->makeUserInScope($district, $department);
+
+        // Blade の $report->employee_code 参照を満たすためレポートを作成
+        ExpenseReport::create([
+            'user_id'              => $target->id,
+            'employee_code'        => str_pad((string)$target->id, 4, '0', STR_PAD_LEFT),
+            'employee_family_name' => 'テスト',
+            'employee_first_name'  => null,
+            'year'                 => now()->year,
+            'month'                => now()->month,
+            'status'               => ExpenseReportStatus::DRAFT,
+            'total_amount'         => 0,
+        ]);
+
+        $this->actingAs($admin)
+             ->withSession(['selected_scope_id' => $scope->id])
+             ->get(route('expenses.admin.edit', ['user' => $target->employee_code]))
+             ->assertOk()
+             ->assertViewIs('expenses.edit');
+    }
+
+    // =========================================================================
+    // 7〜9. submit（PUT /expenses/reports/{report}/submit）
+    // =========================================================================
+
+    /**
+     * シナリオ 7: 本人が DRAFT レポートを提出すると SUBMITTED になり submitted_at が記録される
+     *
+     * - status が SUBMITTED に変わる
+     * - submitted_at に NULL 以外の値が入る
+     */
+    public function test_submit_changes_status_to_submitted(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $this->actingAs($user)
+             ->put(route('expenses.submit', $report))
+             ->assertRedirect();
+
+        $report->refresh();
+        $this->assertSame(ExpenseReportStatus::SUBMITTED, $report->status);
+        $this->assertNotNull($report->submitted_at);
+    }
+
+    /**
+     * シナリオ 8: 他人のレポートを提出しようとすると welcome へリダイレクト
+     *
+     * - ExpenseReportPolicy::submit が失敗 → AuthorizationException
+     * - DB の status は変化しない
+     */
+    public function test_submit_other_users_report_redirects_to_welcome(): void
+    {
+        [$owner, $report] = $this->makeUserWithReport();
+        $attacker = User::factory()->general()->create();
+
+        $this->actingAs($attacker)
+             ->put(route('expenses.submit', $report))
+             ->assertRedirect(route('welcome'));
+
+        $this->assertSame(ExpenseReportStatus::DRAFT, $report->fresh()->status);
+    }
+
+    /**
+     * シナリオ 9: 提出後は本人の編集画面（当該年月）へリダイレクトされる
+     *
+     * - リダイレクト先に year / month が含まれることを確認
+     */
+    public function test_submit_redirects_to_expenses_edit_with_year_month(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+
+        $this->actingAs($user)
+             ->put(route('expenses.submit', $report))
+             ->assertRedirect(
+                 route('expenses.edit', ['year' => $report->year, 'month' => $report->month])
+             );
+    }
+
+    // =========================================================================
+    // 10〜12. unsubmit（PATCH /expenses/{report}/unsubmit）
+    // =========================================================================
+
+    /**
+     * シナリオ 10: admin が SUBMITTED レポートを DRAFT に差し戻せる
+     *
+     * - status が DRAFT に戻る
+     * - submitted_at が null になる
+     */
+    public function test_unsubmit_admin_can_return_submitted_report_to_draft(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+        $target = $this->makeUserInScope($district, $department);
+
+        $report = ExpenseReport::create([
+            'user_id'              => $target->id,
+            'employee_code'        => str_pad((string)$target->id, 4, '0', STR_PAD_LEFT),
+            'employee_family_name' => 'テスト',
+            'employee_first_name'  => null,
+            'year'                 => now()->year,
+            'month'                => now()->month,
+            'status'               => ExpenseReportStatus::SUBMITTED,
+            'submitted_at'         => now(),
+            'total_amount'         => 0,
+        ]);
+
+        $this->actingAs($admin)
+             ->withSession(['selected_scope_id' => $scope->id])
+             ->patch(route('expenses.unsubmit', $report))
+             ->assertRedirect();
+
+        $report->refresh();
+        $this->assertSame(ExpenseReportStatus::DRAFT, $report->status);
+        $this->assertNull($report->submitted_at);
+    }
+
+    /**
+     * シナリオ 11: DRAFT 状態のレポートは unsubmit できない → back with toast_errors
+     *
+     * - コントローラの status チェックに引っかかり、back() にエラーが返る
+     */
+    public function test_unsubmit_draft_report_returns_error(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+        $target = $this->makeUserInScope($district, $department);
+
+        $report = ExpenseReport::create([
+            'user_id'              => $target->id,
+            'employee_code'        => str_pad((string)$target->id, 4, '0', STR_PAD_LEFT),
+            'employee_family_name' => 'テスト',
+            'employee_first_name'  => null,
+            'year'                 => now()->year,
+            'month'                => now()->month,
+            'status'               => ExpenseReportStatus::DRAFT,
+            'total_amount'         => 0,
+        ]);
+
+        $this->actingAs($admin)
+             ->withSession(['selected_scope_id' => $scope->id])
+             ->patch(route('expenses.unsubmit', $report))
+             ->assertRedirect();
+
+        // ステータスは変わっていない
+        $this->assertSame(ExpenseReportStatus::DRAFT, $report->fresh()->status);
+    }
+
+    /**
+     * シナリオ 12: general ユーザーは unsubmit できない → welcome へリダイレクト
+     *
+     * - ExpenseReportPolicy::unsubmit は isScopedAdminFor のみ許可
+     */
+    public function test_unsubmit_general_user_is_redirected_to_welcome(): void
+    {
+        [$user, $report] = $this->makeUserWithReport();
+        $report->update(['status' => ExpenseReportStatus::SUBMITTED, 'submitted_at' => now()]);
+
+        $this->actingAs($user)
+             ->patch(route('expenses.unsubmit', $report))
+             ->assertRedirect(route('welcome'));
+
+        $this->assertSame(ExpenseReportStatus::SUBMITTED, $report->fresh()->status);
+    }
+
+    // =========================================================================
+    // 13〜14. generateMonthly（POST /expenses/generate-monthly）
+    // =========================================================================
+
+    /**
+     * シナリオ 13: admin は generateMonthly を実行でき、back with toast が返る
+     *
+     * - welcome へリダイレクトされず、コントローラが back() を返すことを確認
+     * - Artisan::fake() は Laravel 12 のカスタム Kernel では未対応のため使用しない
+     */
+    public function test_generate_monthly_admin_can_execute(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+             ->withSession(['selected_scope_id' => $scope->id])
+             ->post(route('expenses.generateMonthly'), [
+                 'year'  => now()->year,
+                 'month' => now()->month,
+             ])
+             ->assertRedirect();
+    }
+
+    /**
+     * シナリオ 14: general ユーザーは generateMonthly を実行できない → welcome へリダイレクト
+     *
+     * - ExpenseReportPolicy::manage（admin のみ許可）で弾かれる
+     */
+    public function test_generate_monthly_general_user_is_redirected_to_welcome(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+             ->post(route('expenses.generateMonthly'), [
+                 'year'  => now()->year,
+                 'month' => now()->month,
+             ])
+             ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // 15〜16. cleanupEmpty（POST /expenses/cleanup-empty）
+    // =========================================================================
+
+    /**
+     * シナリオ 15: admin は cleanupEmpty を実行でき、back with toast が返る
+     */
+    public function test_cleanup_empty_admin_can_execute(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $this->actingAs($admin)
+             ->withSession(['selected_scope_id' => $scope->id])
+             ->post(route('expenses.cleanupEmpty'), [
+                 'year'  => now()->year,
+                 'month' => now()->month,
+             ])
+             ->assertRedirect();
+    }
+
+    /**
+     * シナリオ 16: general ユーザーは cleanupEmpty を実行できない → welcome へリダイレクト
+     */
+    public function test_cleanup_empty_general_user_is_redirected_to_welcome(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+             ->post(route('expenses.cleanupEmpty'))
+             ->assertRedirect(route('welcome'));
+    }
+}


### PR DESCRIPTION
GitHub PR Description

## 背景

経費編集画面のSaveボタンを押すと、JSが行ごとに1件ずつHTTPリクエストを
`for await` で直列送信していた。1ヶ月分40行あれば40往復となり、
本番環境では保存時の遅延が体感できるレベルで発生していた。

---

## 変更内容

### 変更前

Saveボタン押下
└─ 既存行ごとにループ → PUT  /api/expenses/{id}   （N回、直列）
└─ 新規行ごとにループ → POST /api/expenses         （M回、直列）
合計: N + M 往復



### 変更後

Saveボタン押下
└─ PUT /api/expenses/batch  （1回）
body: { report_id, updates: [...], creates: [...] }
└─ DB::transaction { UPDATE × N件, INSERT × M件 }
合計: 1往復



---

## 実装内容

| レイヤー | 変更内容 |
|---|---|
| **FormRequest** | `BatchSaveExpenseRequest` を新規作成。`updates[*]` / `creates[*]` の配列バリデーションを定義 |
| **Controller** | `ExpenseApiController::batchSave()` を追加。所有権チェック・ロックチェック・月内日付チェックを行ったのち、単一の `DB::transaction()` で一括処理 |
| **ルート** | `PUT /api/expenses/batch` を `PUT /api/expenses/{expense}` より**前**に定義。文字列 `batch` がルートパラメータとして捕捉されるのを防ぐため順序が重要 |
| **JS** | `expenses.js` のSaveハンドラにある2つの `for await` ループを削除し、1回の `fetch()` で全データを送信するよう置き換え |

### 既存のセキュリティチェックは維持
- `authorize('update', $report)` — 本人のレポートのみ操作可
- `abortIfLocked()` — SUBMITTED / APPROVED / PAID 状態は 423 を返す
- `updates[*].id` が全て対象レポートに属するかをDBで一括検証（他ユーザーのIDの混入を防止）
- `creates[*].expense_date` が全てレポートの年月内であるかを検証

---

## テスト項目
- [ ] 既存行のみのSave（新規行なし）
- [ ] 新規行のみのSave（Add cell → Save）
- [ ] 既存行・新規行が混在した状態でのSave
- [ ] 提出済み（SUBMITTED）レポートで423が返りトーストが表示されること
- [ ] ブラウザのDevTools Networkタブで、リクエストがN回→1回になっていること