### PR TITLE
地区部署切替後の旧URLによる403を防止

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -23,15 +23,13 @@ class CalendarController extends Controller
         $viewer = Auth::user();
         $canViewAnyUser = $viewer->can('viewAny', User::class);
         $viewUser = $user ?? ($canViewAnyUser ? null : $viewer);
-        $this->authorize('view', $user ?? $viewer);
 
         // スコープが切り替わった後に古いユーザーのURLが残っている場合はリセット
-        if ($canViewAnyUser && $viewUser !== null) {
-            $currentDid = $this->scopeService->currentDistrictId();
-            if ($currentDid !== null && $viewUser->district_id !== $currentDid) {
-                return redirect()->route('calendar.index');
-            }
+        if ($canViewAnyUser && $viewUser !== null && ! $viewer->can('view', $viewUser)) {
+            return redirect()->route('calendar.index', $request->only('month'));
         }
+
+        $this->authorize('view', $user ?? $viewer);
 
         // 管理者だけにセレクト用リストを渡す（district/department で直接絞り込み）
         $userOptions = $canViewAnyUser

--- a/app/Http/Controllers/ExpenseEditController.php
+++ b/app/Http/Controllers/ExpenseEditController.php
@@ -28,6 +28,11 @@ class ExpenseEditController extends Controller
      */
     public function adminEdit(User $user, Request $req)
     {
+        $viewer = $req->user();
+        if ($viewer->can('viewAny', User::class) && ! $viewer->can('view', $user)) {
+            return redirect()->route('expenses.admin.report', $req->only(['year', 'month']));
+        }
+
         $this->authorize('view', $user);
         return $this->renderFor($user, $req);
     }

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -32,8 +32,7 @@ use Tests\TestCase;
  *   9. /leave は表示できる → 200
  *
  * [スコープ分離]
- *  10. admin が /calendar/{スコープ外ユーザー} にアクセスすると welcome へリダイレクト
- *      （UserPolicy::view → isScopedAdminFor が false → AuthorizationException → 302）
+ *  10. admin が /calendar/{スコープ外ユーザー} にアクセスするとユーザー指定なしの /calendar へリダイレクト
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * テストのセットアップ方針
@@ -58,9 +57,8 @@ use Tests\TestCase;
  * - /calendar（ユーザー未指定）は 'auth' のみ。general ユーザーも自分自身のカレンダーを閲覧可能。
  *   コントローラーが $canViewAnyUser = false の場合は $viewUser = $viewer（自分）に固定する。
  *
- * - admin が /calendar/{スコープ外ユーザー} にアクセスすると
- *   UserPolicy::view → isScopedAdminFor が false → AuthorizationException
- *   → Handler.php が redirect()->route('welcome') を返す（302）
+ * - admin が /calendar/{スコープ外ユーザー} にアクセスすると、スコープ切替後の古いURLとして扱い
+ *   ユーザー指定をクリアした /calendar へリダイレクトする。
  */
 class CalendarControllerTest extends TestCase
 {
@@ -255,10 +253,10 @@ class CalendarControllerTest extends TestCase
     // =========================================================================
 
     /**
-     * シナリオ 10: admin がスコープ外ユーザーの /calendar/{user} にアクセスすると welcome へリダイレクト
+     * シナリオ 10: admin がスコープ外ユーザーの /calendar/{user} にアクセスすると /calendar へリダイレクト
      *
      * - UserPolicy::view → isScopedAdminFor が false（別 district のユーザーは targetUserIds に含まれない）
-     * - AuthorizationException → Handler.php が redirect()->route('welcome') を返す（302）
+     * - スコープ切替後の古いURLとして扱い、ユーザー選択をクリアする
      */
     public function test_admin_cannot_view_calendar_for_user_outside_scope(): void
     {
@@ -273,8 +271,8 @@ class CalendarControllerTest extends TestCase
 
         $this->actingAs($admin)
             ->withSession(['selected_scope_id' => $scope->id])
-            ->get(route('calendar.index.user', $outsideUser))
-            ->assertRedirect(route('welcome'));
+            ->get(route('calendar.index.user', ['user' => $outsideUser, 'month' => '2026-05']))
+            ->assertRedirect(route('calendar.index', ['month' => '2026-05']));
     }
 
 

--- a/tests/Feature/ExpenseEditControllerTest.php
+++ b/tests/Feature/ExpenseEditControllerTest.php
@@ -27,6 +27,7 @@ use Tests\TestCase;
  *   4. ゲスト → ログインページへリダイレクト
  *   5. general ユーザーが他ユーザーの画面を見ようとすると welcome へリダイレクト
  *   6. admin がスコープ内のユーザーを閲覧できる → 200
+ *   6-2. admin がスコープ外ユーザーの編集URLを踏むと経費一覧へリダイレクト
  *
  * [submit — PUT /expenses/reports/{report}/submit]
  *   7. 本人が DRAFT レポートを提出できる → status=SUBMITTED、submitted_at に値が入る
@@ -226,6 +227,30 @@ class ExpenseEditControllerTest extends TestCase
              ->get(route('expenses.admin.edit', ['user' => $target->employee_code]))
              ->assertOk()
              ->assertViewIs('expenses.edit');
+    }
+
+    /**
+     * シナリオ 6-2: スコープ外ユーザーの古い編集URLは、年月を保ったまま経費一覧へ戻す
+     */
+    public function test_admin_edit_outside_scope_redirects_to_report(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $otherDistrict   = District::factory()->create();
+        $otherDepartment = Department::factory()->create();
+        $outsideUser = User::factory()->general()->create([
+            'district_id'   => $otherDistrict->id,
+            'department_id' => $otherDepartment->id,
+        ]);
+
+        $this->actingAs($admin)
+             ->withSession(['selected_scope_id' => $scope->id])
+             ->get(route('expenses.admin.edit', [
+                 'user' => $outsideUser->employee_code,
+                 'year' => 2026,
+                 'month' => 5,
+             ]))
+             ->assertRedirect(route('expenses.admin.report', ['year' => 2026, 'month' => 5]));
     }
 
     // =========================================================================


### PR DESCRIPTION
## 概要

地区部署スコープを切り替えた後、旧スコープのユーザーを含むURLへ戻った場合に403になる問題を修正しました。

## 変更内容

- `/calendar/{user}` でスコープ外ユーザーが指定された場合、403にせず `/calendar` へリダイレクト
- カレンダーの `month` クエリは維持
- `/expenses/{user}/edit` でスコープ外ユーザーが指定された場合、403にせず `/expenses/report` へリダイレクト
- 経費画面の `year` / `month` クエリは維持
- 関連Feature testを更新
