### PR TITLE
Fix CSV import upsert handling and improve user import performance

### DIFF
--- a/app/Http/Controllers/LessonCsvController.php
+++ b/app/Http/Controllers/LessonCsvController.php
@@ -167,15 +167,11 @@ class LessonCsvController extends Controller
                     'fm_lesson_code'        => $data['fm_lesson_code'] ?? null,
                 ];
 
-                if ($id !== null) {
-                    $lesson = Lesson::find($id);
-                    if ($lesson) {
-                        $lesson->update($payload);
-                        $updated++;
-                    } else {
-                        Lesson::create($payload);
-                        $created++;
-                    }
+                $lesson = $this->findLessonForImport($id, $data);
+
+                if ($lesson) {
+                    $lesson->update($payload);
+                    $updated++;
                 } else {
                     Lesson::create($payload);
                     $created++;
@@ -196,5 +192,32 @@ class LessonCsvController extends Controller
         }
         $trimmed = trim($value);
         return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * id が合わない CSV でも、同一レッスンと判断できるコードがあれば更新対象にする。
+     */
+    private function findLessonForImport(?int $id, array $data): ?Lesson
+    {
+        if ($id !== null) {
+            $lesson = Lesson::find($id);
+            if ($lesson) {
+                return $lesson;
+            }
+        }
+
+        foreach (['ps_unique_lesson_code', 'fm_lesson_code', 'lesson_code'] as $column) {
+            $value = $data[$column] ?? null;
+            if ($value === null) {
+                continue;
+            }
+
+            $lesson = Lesson::where($column, $value)->first();
+            if ($lesson) {
+                return $lesson;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Http/Controllers/UserCsvController.php
+++ b/app/Http/Controllers/UserCsvController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 
 class UserCsvController extends Controller
 {
@@ -169,9 +170,11 @@ class UserCsvController extends Controller
         // マスターデータをキャッシュ（N+1防止）
         $districtMap   = District::pluck('id', 'name')->all();
         $departmentMap = Department::pluck('id', 'name')->all();
-        $roleMap       = Role::where('guard_name', 'web')->pluck('name', 'name')->all();
-        $existingEmails = User::pluck('id', 'email')->all();
-        $existingCodes  = User::pluck('id', 'employee_code')->all();
+        $roleMap = Role::where('guard_name', 'web')->pluck('id', 'name')->all();
+        $targetUsers = $this->loadImportTargetUsers($rows);
+        $existingEmails = array_map(fn(User $user) => $user->id, $targetUsers['email']);
+        $existingCodes = array_map(fn(User $user) => $user->id, $targetUsers['employee_code']);
+        $existingIds = array_map(fn(User $user) => $user->id, $targetUsers['id']);
 
         foreach ($rows as ['row' => $rowNum, 'data' => $data]) {
             $v = Validator::make($data, [
@@ -223,15 +226,17 @@ class UserCsvController extends Controller
                 $validationErrors[] = "{$rowNum}行目: role「{$roleName}」が roles テーブルに存在しません。";
             }
 
+            $targetId = $this->resolveExistingUserId($id, $data, $existingIds, $existingEmails, $existingCodes);
+
             // email 重複チェック（別ユーザー）
             $emailOwner = $existingEmails[$data['email']] ?? null;
-            if ($emailOwner !== null && $emailOwner !== $id) {
+            if ($emailOwner !== null && $emailOwner !== $targetId) {
                 $validationErrors[] = "{$rowNum}行目: email「{$data['email']}」は既に別のユーザーが使用しています。";
             }
 
             // employee_code 重複チェック（別ユーザー）
             $codeOwner = $existingCodes[$data['employee_code']] ?? null;
-            if ($codeOwner !== null && $codeOwner !== $id) {
+            if ($codeOwner !== null && $codeOwner !== $targetId) {
                 $validationErrors[] = "{$rowNum}行目: employee_code「{$data['employee_code']}」は既に別のユーザーが使用しています。";
             }
         }
@@ -246,9 +251,12 @@ class UserCsvController extends Controller
         $employmentProcessed = 0;
 
         DB::transaction(function () use (
-            $rows, $districtMap, $departmentMap,
+            $rows, $districtMap, $departmentMap, $roleMap, &$targetUsers,
             &$created, &$updated, &$employmentProcessed
         ) {
+            $roleRows = [];
+            $employmentRows = [];
+
             foreach ($rows as ['data' => $data]) {
                 $id = (isset($data['id']) && is_numeric($data['id'])) ? (int) $data['id'] : null;
 
@@ -273,7 +281,7 @@ class UserCsvController extends Controller
                     'department_id' => $departmentMap[$data['department_name']],
                 ];
 
-                $user = $id !== null ? User::find($id) : null;
+                $user = $this->findUserForImport($id, $data, $targetUsers);
 
                 if ($user) {
                     $user->update($payload);
@@ -285,24 +293,44 @@ class UserCsvController extends Controller
                     $created++;
                 }
 
-                // role 付与（既存を置き換え）
-                $user->syncRoles([$roleName]);
+                $targetUsers['id'][$user->id] = $user;
+                $targetUsers['email'][$user->email] = $user;
+                $targetUsers['employee_code'][$user->employee_code] = $user;
+
+                $roleRows[$user->id] = [
+                    'role_id' => $roleMap[$roleName],
+                    'model_type' => User::class,
+                    'model_id' => $user->id,
+                ];
 
                 // employment_terms: start_date があれば作成/更新
                 $startDate = $data['employment_start_date'] ?? null;
                 if ($startDate !== null) {
-                    $term = EmploymentTerm::firstOrNew([
+                    $employmentRows[] = [
                         'user_id'    => $user->id,
                         'start_date' => $startDate,
-                    ]);
-                    $term->end_date  = $data['employment_end_date'] ?? null;
-                    $term->type_name = $data['employment_type_name'] ?? null;
-                    $term->type_code = $data['employment_type_code'] ?? null;
-                    $term->note      = $data['employment_note'] ?? null;
-                    $term->save();
+                        'end_date'   => $data['employment_end_date'] ?? null,
+                        'type_name'  => $data['employment_type_name'] ?? null,
+                        'type_code'  => $data['employment_type_code'] ?? null,
+                        'note'       => $data['employment_note'] ?? null,
+                        'updated_at' => now(),
+                    ];
                     $employmentProcessed++;
                 }
             }
+
+            $userIds = array_keys($roleRows);
+            if (!empty($userIds)) {
+                DB::table(config('permission.table_names.model_has_roles'))
+                    ->where('model_type', User::class)
+                    ->whereIn(config('permission.column_names.model_morph_key'), $userIds)
+                    ->delete();
+
+                DB::table(config('permission.table_names.model_has_roles'))->insert(array_values($roleRows));
+                app(PermissionRegistrar::class)->forgetCachedPermissions();
+            }
+
+            $this->saveEmploymentTerms($employmentRows);
         });
 
         return back()->with(
@@ -321,5 +349,104 @@ class UserCsvController extends Controller
         }
         $trimmed = trim($value);
         return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function resolveExistingUserId(?int $id, array $data, array $ids, array $emails, array $codes): ?int
+    {
+        if ($id !== null && isset($ids[$id])) {
+            return $id;
+        }
+
+        return $codes[$data['employee_code']] ?? $emails[$data['email']] ?? null;
+    }
+
+    private function loadImportTargetUsers(array $rows): array
+    {
+        [$ids, $emails, $codes] = $this->collectImportKeys($rows);
+
+        $users = User::query()
+            ->whereIn('id', array_unique($ids))
+            ->orWhereIn('email', array_unique($emails))
+            ->orWhereIn('employee_code', array_unique($codes))
+            ->get();
+
+        return [
+            'id' => $users->keyBy('id')->all(),
+            'email' => $users->keyBy('email')->all(),
+            'employee_code' => $users->keyBy('employee_code')->all(),
+        ];
+    }
+
+    private function collectImportKeys(array $rows): array
+    {
+        $ids = [];
+        $emails = [];
+        $codes = [];
+
+        foreach ($rows as ['data' => $data]) {
+            if (isset($data['id']) && is_numeric($data['id'])) {
+                $ids[] = (int) $data['id'];
+            }
+            if (!empty($data['email'])) {
+                $emails[] = $data['email'];
+            }
+            if (!empty($data['employee_code'])) {
+                $codes[] = $data['employee_code'];
+            }
+        }
+
+        return [
+            array_values(array_unique($ids)),
+            array_values(array_unique($emails)),
+            array_values(array_unique($codes)),
+        ];
+    }
+
+    private function findUserForImport(?int $id, array $data, array $users): ?User
+    {
+        if ($id !== null && isset($users['id'][$id])) {
+            return $users['id'][$id];
+        }
+
+        return $users['employee_code'][$data['employee_code']]
+            ?? $users['email'][$data['email']]
+            ?? null;
+    }
+
+    private function saveEmploymentTerms(array $rows): void
+    {
+        if (empty($rows)) {
+            return;
+        }
+
+        $now = now();
+        $existing = EmploymentTerm::query()
+            ->whereIn('user_id', array_unique(array_column($rows, 'user_id')))
+            ->whereIn('start_date', array_unique(array_column($rows, 'start_date')))
+            ->get()
+            ->keyBy(fn(EmploymentTerm $term) => $term->user_id . '|' . $term->start_date->toDateString());
+
+        $inserts = [];
+        foreach ($rows as $row) {
+            $key = $row['user_id'] . '|' . $row['start_date'];
+            $term = $existing[$key] ?? null;
+
+            if ($term) {
+                $term->update([
+                    'end_date' => $row['end_date'],
+                    'type_name' => $row['type_name'],
+                    'type_code' => $row['type_code'],
+                    'note' => $row['note'],
+                ]);
+                continue;
+            }
+
+            $row['created_at'] = $now;
+            $inserts[] = $row;
+        }
+
+        foreach (array_chunk($inserts, 500) as $chunk) {
+            EmploymentTerm::insert($chunk);
+        }
     }
 }

--- a/database/seeders/LessonSeeder.php
+++ b/database/seeders/LessonSeeder.php
@@ -9,13 +9,31 @@ class LessonSeeder extends Seeder
 {
     public function run(): void
     {
-        DB::table('lessons')->insert([
-            ['id'=>1,'lesson_name'=>'Global',       'lesson_code'=>'BW', 'lesson_minute'=>45,'lesson_type'=>'kids'],
-            ['id'=>2,'lesson_name'=>'Free',         'lesson_code'=>'FTL','lesson_minute'=>40,'lesson_type'=>'Adults'],
-            ['id'=>3,'lesson_name'=>'Mini',         'lesson_code'=>'AK', 'lesson_minute'=>30,'lesson_type'=>'kids'],
-            ['id'=>4,'lesson_name'=>'Break',        'lesson_code'=>'Break','lesson_minute'=>45,'lesson_type'=>'Break'],
-            ['id'=>5,'lesson_name'=>'Envision',     'lesson_code'=>'EV', 'lesson_minute'=>40,'lesson_type'=>'Adults'],
-            ['id'=>6,'lesson_name'=>'Enjoy English','lesson_code'=>'EE', 'lesson_minute'=>40,'lesson_type'=>'Adults'],
+        $now = now();
+
+        DB::table('lessons')->upsert([
+            ['id'=>1,'lesson_name'=>'Global',       'lesson_code'=>'BW', 'lesson_minute'=>45,'lesson_type'=>'kids',   'created_at'=>$now,'updated_at'=>$now],
+            ['id'=>2,'lesson_name'=>'Free',         'lesson_code'=>'FTL','lesson_minute'=>40,'lesson_type'=>'Adults', 'created_at'=>$now,'updated_at'=>$now],
+            ['id'=>3,'lesson_name'=>'Mini',         'lesson_code'=>'AK', 'lesson_minute'=>30,'lesson_type'=>'kids',   'created_at'=>$now,'updated_at'=>$now],
+            ['id'=>4,'lesson_name'=>'Break',        'lesson_code'=>'Break','lesson_minute'=>45,'lesson_type'=>'Break','created_at'=>$now,'updated_at'=>$now],
+            ['id'=>5,'lesson_name'=>'Envision',     'lesson_code'=>'EV', 'lesson_minute'=>40,'lesson_type'=>'Adults', 'created_at'=>$now,'updated_at'=>$now],
+            ['id'=>6,'lesson_name'=>'Enjoy English','lesson_code'=>'EE', 'lesson_minute'=>40,'lesson_type'=>'Adults', 'created_at'=>$now,'updated_at'=>$now],
+        ], ['id'], [
+            'lesson_name',
+            'lesson_code',
+            'lesson_minute',
+            'lesson_type',
+            'updated_at',
         ]);
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement("
+                select setval(
+                    pg_get_serial_sequence('lessons', 'id'),
+                    coalesce((select max(id) from lessons), 1),
+                    (select count(*) > 0 from lessons)
+                )
+            ");
+        }
     }
 }

--- a/resources/views/csv/lesson_csv.blade.php
+++ b/resources/views/csv/lesson_csv.blade.php
@@ -45,7 +45,9 @@
     <div class="card-body">
         <p class="text-muted mb-3">
             CSV ファイルをアップロードして lessons テーブルに登録・更新します。<br>
-            <strong>id</strong> が入力されていればその id のレコードを更新（存在しなければ新規作成）、空の場合は新規作成です。
+            <strong>id</strong> が一致するレコードを更新します。id が空、または一致しない場合は
+            <code>ps_unique_lesson_code</code>、<code>fm_lesson_code</code>、<code>lesson_code</code> の順で既存レコードを探し、
+            見つかれば更新、見つからなければ新規作成します。
         </p>
 
         {{-- カラム仕様 --}}
@@ -62,7 +64,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr><td><code>id</code></td>              <td>任意</td><td>整数</td>          <td>空なら新規作成。指定した場合は update 判定に使用</td></tr>
+                        <tr><td><code>id</code></td>              <td>任意</td><td>整数</td>          <td>一致すれば更新。未一致の場合は各コードで update 判定</td></tr>
                         <tr><td><code>lesson_name</code></td>      <td>任意</td><td>文字列 max:255</td><td>空白は null 保存</td></tr>
                         <tr><td><code>lesson_code</code></td>      <td>任意</td><td>文字列 max:255</td><td>空白は null 保存</td></tr>
                         <tr><td><code>lesson_minute</code></td>    <td>任意</td><td>整数 min:0</td>   <td>30 / 40 / 45 など。空白は null 保存</td></tr>

--- a/resources/views/csv/user_csv.blade.php
+++ b/resources/views/csv/user_csv.blade.php
@@ -46,7 +46,9 @@
     <div class="card-body">
         <p class="text-muted mb-3">
             CSV ファイルをアップロードして users テーブルに登録・更新します。<br>
-            <strong>id</strong> が入力されていてDBに存在する場合は更新、空またはDBに存在しない場合は新規作成です。<br>
+            <strong>id</strong> が一致するレコードを更新します。id が空、または一致しない場合は
+            <code>employee_code</code>、<code>email</code> の順で既存レコードを探し、
+            見つかれば更新、見つからなければ新規作成します。<br>
             <span class="text-danger"><i class="fas fa-lock me-1"></i>password はインポート対象外です。新規作成時は安全な初期パスワードが自動設定されます。</span>
         </p>
 
@@ -64,7 +66,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr><td><code>id</code></td>                      <td>任意</td><td>整数</td>                    <td>空なら新規作成。DBに存在すれば更新</td></tr>
+                        <tr><td><code>id</code></td>                      <td>任意</td><td>整数</td>                    <td>一致すれば更新。未一致の場合は employee_code / email で update 判定</td></tr>
                         <tr><td><code>family_name</code></td>              <td><span class="badge bg-danger">必須</span></td><td>文字列 max:255</td>    <td></td></tr>
                         <tr><td><code>first_name</code></td>               <td><span class="badge bg-danger">必須</span></td><td>文字列 max:255</td>    <td></td></tr>
                         <tr><td><code>middle_name</code></td>              <td>任意</td><td>文字列 max:255</td>    <td>空白は null 保存</td></tr>


### PR DESCRIPTION
## 概要

- `LessonSeeder` を固定IDの `insert` から `upsert` に変更
- PostgreSQL の `lessons` シーケンスを seed 後に最大IDへ補正
- Lesson CSV インポートで、既存データを `id` / `ps_unique_lesson_code` / `fm_lesson_code` / `lesson_code` の順に探して更新するよう修正
- User CSV インポートで、行ごとのDB問い合わせを削減
- User CSV インポートで、`id` / `employee_code` / `email` による既存ユーザー更新に対応
- role の付与処理と employment_terms の保存処理を一括処理寄りに改善
- CSVインポート画面の説明文を実際の更新仕様に合わせて修正

## 背景

LessonSeeder の固定ID insert により、再seed時や PostgreSQL のシーケンスずれで主キー重複が発生する可能性がありました。

また、CSVインポート時に `id` が空、または一致しない場合は既存データではなく新規作成されるため、同じCSVを再読み込みすると重複作成される問題がありました。

User CSV インポートでは、行ごとにユーザー検索・role同期・雇用期間検索が走っていたため、CSV行数やユーザー数が多い場合に処理が重くなっていました。

## 対応内容

- LessonSeeder を再実行しても重複しないよう `upsert` 化
- seed 後に `lessons_id_seq` を `lessons.id` の最大値へ同期
- Lesson CSV の既存レコード判定を自然キーでも行うよう修正
- User CSV の既存ユーザー判定を `employee_code` / `email` でも行うよう修正
- User CSV import 前に対象ユーザーのみを事前取得し、全件取得や行ごとの検索を削減
- role pivot の更新を対象ユーザー単位でまとめて処理
- employment_terms の新規登録をまとめて insert

## 確認内容

- `php -l database/seeders/LessonSeeder.php`
- `php -l app/Http/Controllers/LessonCsvController.php`
- `php -l app/Http/Controllers/UserCsvController.php`
- `php artisan db:seed --class=LessonSeeder`
- `lessons_id_seq` が `lessons.id` の最大値と一致することを確認
- `csv.users.import` ルートが正常に読み込まれることを確認

## Summary

- Fixed `LessonSeeder` to use upsert instead of fixed-id insert
- Reset PostgreSQL `lessons` sequence after lesson seeding to prevent duplicate primary key errors
- Updated Lesson CSV import to update existing records by `id`, `ps_unique_lesson_code`, `fm_lesson_code`, or `lesson_code`
- Improved User CSV import performance by reducing per-row database queries
- Updated User CSV import to resolve existing users by `id`, `employee_code`, or `email`
- Batched role pivot updates and employment term inserts where possible
- Updated CSV import screen descriptions to match the new update behavior

## Why

Repeated seeding or CSV import could create duplicate key errors or unintended duplicate records.  
User CSV import was also slow because it performed repeated database lookups and role sync operations per row.

## Verification

- `php -l database/seeders/LessonSeeder.php`
- `php -l app/Http/Controllers/LessonCsvController.php`
- `php -l app/Http/Controllers/UserCsvController.php`
- `php artisan db:seed --class=LessonSeeder`
- Confirmed `lessons_id_seq` matches current max `lessons.id`
- Confirmed `csv.users.import` route loads