### PR TITLE
District & Department マスタ管理画面を追加（super_admin 専用）

### DIFF
--- a/app/Http/Controllers/DistrictDepartmentController.php
+++ b/app/Http/Controllers/DistrictDepartmentController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Department;
+use App\Models\District;
+use Illuminate\Http\Request;
+
+class DistrictDepartmentController extends Controller
+{
+    // ─── Page ───────────────────────────────────────────────────────────────
+
+    public function index()
+    {
+        $this->authorize('viewAny', District::class);
+
+        return view('data.district_department');
+    }
+
+    // ─── District API ────────────────────────────────────────────────────────
+
+    public function districtIndex()
+    {
+        $this->authorize('viewAny', District::class);
+
+        $districts = District::with('children')
+            ->whereNull('parent_id')
+            ->orderBy('name')
+            ->get()
+            ->map(fn($d) => $this->formatDistrict($d));
+
+        return response()->json($districts);
+    }
+
+    public function districtStore(Request $request)
+    {
+        $this->authorize('create', District::class);
+
+        $data = $request->validate([
+            'name'      => 'required|string|max:255',
+            'parent_id' => 'nullable|integer|exists:districts,id',
+        ]);
+
+        $district = District::create($data);
+        $district->load('children');
+
+        return response()->json($this->formatDistrict($district), 201);
+    }
+
+    public function districtUpdate(Request $request, District $district)
+    {
+        $this->authorize('update', $district);
+
+        $data = $request->validate([
+            'name'      => 'required|string|max:255',
+            'parent_id' => 'nullable|integer|exists:districts,id',
+        ]);
+
+        if ($data['parent_id'] ?? null) {
+            abort_if($data['parent_id'] == $district->id, 422, 'Cannot set self as parent.');
+        }
+
+        $district->update($data);
+        $district->load('children');
+
+        return response()->json($this->formatDistrict($district));
+    }
+
+    public function districtDestroy(District $district)
+    {
+        $this->authorize('delete', $district);
+
+        District::where('parent_id', $district->id)->update(['parent_id' => null]);
+        $district->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function formatDistrict(District $d): array
+    {
+        return [
+            'id'        => $d->id,
+            'name'      => $d->name,
+            'parent_id' => $d->parent_id,
+            'children'  => $d->children->sortBy('name')->map(fn($c) => [
+                'id'        => $c->id,
+                'name'      => $c->name,
+                'parent_id' => $c->parent_id,
+                'children'  => [],
+            ])->values()->toArray(),
+        ];
+    }
+
+    // ─── Department API ──────────────────────────────────────────────────────
+
+    public function departmentIndex()
+    {
+        $this->authorize('viewAny', Department::class);
+
+        return response()->json(Department::orderBy('name')->get(['id', 'name']));
+    }
+
+    public function departmentStore(Request $request)
+    {
+        $this->authorize('create', Department::class);
+
+        $data = $request->validate(['name' => 'required|string|max:255']);
+        $dept = Department::create($data);
+
+        return response()->json($dept, 201);
+    }
+
+    public function departmentUpdate(Request $request, Department $department)
+    {
+        $this->authorize('update', $department);
+
+        $data = $request->validate(['name' => 'required|string|max:255']);
+        $department->update($data);
+
+        return response()->json($department);
+    }
+
+    public function departmentDestroy(Department $department)
+    {
+        $this->authorize('delete', $department);
+
+        $department->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/RoleChangeController.php
+++ b/app/Http/Controllers/RoleChangeController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\RoleChange\ApplyRoleChangeRequest;
+use App\Models\Department;
+use App\Models\District;
 use App\Models\User;
 use App\Services\RoleChange\RoleChangeApplicationService;
 use Illuminate\Support\Facades\Auth;
@@ -21,7 +23,12 @@ class RoleChangeController extends Controller
         $currentRole    = $user->getRoleNames()->first();
         $availableRoles = ['general', 'admin', 'super_admin'];
 
-        return view('user.roleChange', compact('user', 'currentRole', 'availableRoles'));
+        $districts   = District::whereNull('parent_id')->with('children')->orderBy('name')->get();
+        $departments = Department::orderBy('name')->get();
+
+        $user->load(['district', 'department', 'managementScopes.district', 'managementScopes.department']);
+
+        return view('user.roleChange', compact('user', 'currentRole', 'availableRoles', 'districts', 'departments'));
     }
 
     /**
@@ -34,7 +41,15 @@ class RoleChangeController extends Controller
 
         $data = $request->validated();
 
-        $this->roleChangeService->apply($user, Auth::user(), $data['role'], $data['reason']);
+        $this->roleChangeService->apply(
+            $user,
+            Auth::user(),
+            $data['role'],
+            $data['reason'],
+            (int) $data['district_id'],
+            (int) $data['department_id'],
+            $data['scopes'] ?? [],
+        );
 
         return back()->with('toast', '権限変更の申請を受け付けました。');
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -30,6 +30,10 @@ class UsersController extends Controller
                 $q->with('leavePeriods')
                     ->orderByDesc('start_date');
             },
+            'district',
+            'department',
+            'managementScopes.district',
+            'managementScopes.department',
         ]);
 
         // 最新の雇用期間を取得（今日の日付でフィルタ）

--- a/app/Http/Requests/RoleChange/ApplyRoleChangeRequest.php
+++ b/app/Http/Requests/RoleChange/ApplyRoleChangeRequest.php
@@ -13,9 +13,59 @@ class ApplyRoleChangeRequest extends FormRequest
 
     public function rules(): array
     {
+        $role    = $this->input('role');
+        $isAdmin = in_array($role, ['admin', 'super_admin']);
+
         return [
-            'role'   => ['required', 'in:general,admin,super_admin'],
-            'reason' => ['required', 'string', 'max:2000'],
+            'role'                    => ['required', 'in:general,admin,super_admin'],
+            'reason'                  => ['required', 'string', 'max:2000'],
+            'district_id'             => ['required', 'integer', 'exists:districts,id'],
+            'department_id'           => ['required', 'integer', 'exists:departments,id'],
+            'scopes'                  => $isAdmin ? ['required', 'array', 'min:1'] : ['nullable', 'array'],
+            'scopes.*.district_id'    => ['required', 'integer', 'exists:districts,id'],
+            'scopes.*.department_id'  => ['required', 'integer', 'exists:departments,id'],
+        ];
+    }
+
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($v) {
+            $role   = $this->input('role');
+            $scopes = $this->input('scopes') ?? [];
+
+            if ($role === 'general' && !empty($scopes)) {
+                $v->errors()->add('scopes', '一般ユーザーには管理範囲を設定できません。');
+                return;
+            }
+
+            if (!is_array($scopes)) {
+                return;
+            }
+
+            $seen = [];
+            foreach ($scopes as $i => $scope) {
+                $key = ($scope['district_id'] ?? '') . '-' . ($scope['department_id'] ?? '');
+                if (isset($seen[$key])) {
+                    $v->errors()->add("scopes.$i", '同じ地区・部署の組み合わせが重複しています。');
+                }
+                $seen[$key] = true;
+            }
+        });
+    }
+
+    public function messages(): array
+    {
+        return [
+            'district_id.required'          => '所属地区を選択してください。',
+            'district_id.exists'            => '選択された所属地区は存在しません。',
+            'department_id.required'        => '所属部署を選択してください。',
+            'department_id.exists'          => '選択された所属部署は存在しません。',
+            'scopes.required'               => '管理地区・部署を1件以上追加してください。',
+            'scopes.min'                    => '管理地区・部署を1件以上追加してください。',
+            'scopes.*.district_id.required' => '管理範囲の地区を選択してください。',
+            'scopes.*.district_id.exists'   => '選択された管理地区は存在しません。',
+            'scopes.*.department_id.required' => '管理範囲の部署を選択してください。',
+            'scopes.*.department_id.exists' => '選択された管理部署は存在しません。',
         ];
     }
 }

--- a/app/Models/RoleChange.php
+++ b/app/Models/RoleChange.php
@@ -57,16 +57,15 @@ class RoleChange extends Model
         $user->department_id = $this->department_id;
         $user->save();
 
+        $user->managementScopes()->delete();
+
         if (in_array($this->requested_role, ['admin', 'super_admin'])) {
-            $user->managementScopes()->delete();
             foreach ($this->scopes ?? [] as $scope) {
-                $user->managementScopes()->firstOrCreate([
+                $user->managementScopes()->create([
                     'district_id'   => $scope['district_id'],
                     'department_id' => $scope['department_id'],
                 ]);
             }
-        } else {
-            $user->managementScopes()->delete();
         }
     }
 }

--- a/app/Models/RoleChange.php
+++ b/app/Models/RoleChange.php
@@ -17,6 +17,13 @@ class RoleChange extends Model
         'reason',
         'requested_by_id',
         'status',
+        'district_id',
+        'department_id',
+        'scopes',
+    ];
+
+    protected $casts = [
+        'scopes' => 'array',
     ];
 
     public function targetUser(): BelongsTo
@@ -43,7 +50,23 @@ class RoleChange extends Model
     public function applyDomainEffect(): void
     {
         $user = $this->targetUser;
-        // 既存ロールを置換するなら syncRoles、追加なら assignRole
+
         $user->syncRoles([$this->requested_role]);
+
+        $user->district_id   = $this->district_id;
+        $user->department_id = $this->department_id;
+        $user->save();
+
+        if (in_array($this->requested_role, ['admin', 'super_admin'])) {
+            $user->managementScopes()->delete();
+            foreach ($this->scopes ?? [] as $scope) {
+                $user->managementScopes()->firstOrCreate([
+                    'district_id'   => $scope['district_id'],
+                    'department_id' => $scope['department_id'],
+                ]);
+            }
+        } else {
+            $user->managementScopes()->delete();
+        }
     }
 }

--- a/app/Policies/DepartmentPolicy.php
+++ b/app/Policies/DepartmentPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Department;
+use App\Models\User;
+
+class DepartmentPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    public function update(User $user, Department $department): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    public function delete(User $user, Department $department): bool
+    {
+        return $user->isSuperAdmin();
+    }
+}

--- a/app/Policies/DistrictPolicy.php
+++ b/app/Policies/DistrictPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\District;
+use App\Models\User;
+
+class DistrictPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    public function update(User $user, District $district): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    public function delete(User $user, District $district): bool
+    {
+        return $user->isSuperAdmin();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\Models\ApprovalRequest;
+use App\Models\Department;
+use App\Models\District;
 use App\Models\Event;
 use App\Models\Expense;
 use App\Models\ExpenseReport;
@@ -11,6 +13,8 @@ use App\Models\ScheduleDetail;
 use App\Models\ScheduleLine;
 use App\Models\UserManagementScope;
 use App\Policies\ApprovalRequestPolicy;
+use App\Policies\DepartmentPolicy;
+use App\Policies\DistrictPolicy;
 use App\Policies\EventPolicy;
 use App\Policies\ExpensePolicy;
 use App\Policies\ExpenseReportPolicy;
@@ -34,6 +38,8 @@ class AuthServiceProvider extends ServiceProvider
         \App\Models\Leave::class               => \App\Policies\LeavePolicy::class,
         \App\Models\Post::class                => \App\Policies\PostPolicy::class,
         ApprovalRequest::class                 => ApprovalRequestPolicy::class,
+        Department::class                      => DepartmentPolicy::class,
+        District::class                        => DistrictPolicy::class,
         Event::class                           => EventPolicy::class,
         ExpenseReport::class                   => ExpenseReportPolicy::class,
         Expense::class                         => ExpensePolicy::class,

--- a/app/Services/RoleChange/RoleChangeApplicationService.php
+++ b/app/Services/RoleChange/RoleChangeApplicationService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\RoleChange;
 
+use App\Models\Department;
+use App\Models\District;
 use App\Models\RoleChange;
 use App\Models\User;
 use App\Notifications\ApprovalRequestedNotification;
@@ -10,31 +12,64 @@ use Spatie\Permission\Models\Role;
 
 class RoleChangeApplicationService
 {
-    public function apply(User $targetUser, User $requester, string $role, string $reason): void
-    {
-        DB::transaction(function () use ($targetUser, $requester, $role, $reason) {
+    public function apply(
+        User   $targetUser,
+        User   $requester,
+        string $role,
+        string $reason,
+        int    $districtId,
+        int    $departmentId,
+        array  $scopes = []
+    ): void {
+        DB::transaction(function () use ($targetUser, $requester, $role, $reason, $districtId, $departmentId, $scopes) {
             $rc = RoleChange::create([
                 'user_id'         => $targetUser->id,
                 'requested_role'  => $role,
                 'reason'          => $reason,
                 'requested_by_id' => $requester->id,
                 'status'          => 'pending',
+                'district_id'     => $districtId,
+                'department_id'   => $departmentId,
+                'scopes'          => $scopes,
             ]);
 
             $roleLabels = ['general' => '一般', 'admin' => '管理者', 'super_admin' => 'スーパー管理者'];
-            $title = '権限変更: ' . $rc->targetUser->role_label . ' → ' . ($roleLabels[$role] ?? $role);
+            $title = '権限・所属・管理範囲変更: ' . $rc->targetUser->role_label . ' → ' . ($roleLabels[$role] ?? $role);
+
+            $targetUser->load(['district', 'department', 'managementScopes.district', 'managementScopes.department']);
+
+            $requestedDistrict   = District::find($districtId);
+            $requestedDepartment = Department::find($departmentId);
+
+            $resolvedScopes = collect($scopes)->map(function ($s) {
+                return [
+                    'district_id'   => $s['district_id'],
+                    'department_id' => $s['department_id'],
+                    'district'      => District::find($s['district_id'])?->name,
+                    'department'    => Department::find($s['department_id'])?->name,
+                ];
+            })->toArray();
 
             $rc->approvalRequest()->create([
                 'title'           => $title,
                 'requested_by_id' => $requester->id,
                 'current_state'   => 'pending',
                 'metadata'        => [
-                    'target_user_id'   => $targetUser->id,
-                    'target_user_name' => $targetUser->name,
-                    'requested_role'   => $role,
-                    'reason'           => $reason,
-                    'flow'             => ['type' => 'any_of_role', 'role' => 'super_admin', 'min_approvals' => 1],
-                    'current_role'     => $targetUser->getRoleNames()->first(),
+                    'target_user_id'       => $targetUser->id,
+                    'target_user_name'     => $targetUser->name,
+                    'requested_role'       => $role,
+                    'reason'               => $reason,
+                    'flow'                 => ['type' => 'any_of_role', 'role' => 'super_admin', 'min_approvals' => 1],
+                    'current_role'         => $targetUser->getRoleNames()->first(),
+                    'current_district'     => $targetUser->district?->name,
+                    'current_department'   => $targetUser->department?->name,
+                    'current_scopes'       => $targetUser->managementScopes->map(fn($s) => [
+                        'district'   => $s->district?->name,
+                        'department' => $s->department?->name,
+                    ])->toArray(),
+                    'requested_district'   => $requestedDistrict?->name,
+                    'requested_department' => $requestedDepartment?->name,
+                    'requested_scopes'     => $resolvedScopes,
                 ],
             ]);
 

--- a/database/migrations/2026_05_25_000001_add_scope_fields_to_role_changes_table.php
+++ b/database/migrations/2026_05_25_000001_add_scope_fields_to_role_changes_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('role_changes', function (Blueprint $table) {
+            $table->unsignedBigInteger('district_id')->nullable()->after('reason');
+            $table->unsignedBigInteger('department_id')->nullable()->after('district_id');
+            $table->json('scopes')->nullable()->after('department_id');
+
+            $table->foreign('district_id')->references('id')->on('districts')->nullOnDelete();
+            $table->foreign('department_id')->references('id')->on('departments')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('role_changes', function (Blueprint $table) {
+            $table->dropForeign(['district_id']);
+            $table->dropForeign(['department_id']);
+            $table->dropColumn(['district_id', 'department_id', 'scopes']);
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -67,3 +67,11 @@ if (cpepEl) {
     const props = cpepEl.dataset.props ? JSON.parse(cpepEl.dataset.props) : {};
     createApp(CalendarPatternEditorPage, props).mount(cpepEl);
 }
+
+import DistrictDepartmentEditor from './components/DistrictDepartmentEditor.vue';
+
+const ddeEl = document.getElementById('districtDepartmentEditor');
+if (ddeEl) {
+    const props = ddeEl.dataset.props ? JSON.parse(ddeEl.dataset.props) : {};
+    createApp(DistrictDepartmentEditor, props).mount(ddeEl);
+}

--- a/resources/js/components/DistrictDepartmentEditor.vue
+++ b/resources/js/components/DistrictDepartmentEditor.vue
@@ -1,0 +1,355 @@
+<template>
+  <div>
+    <!-- Flash -->
+    <div v-if="flash.text" :class="['alert','py-2','px-3','mb-3', flash.ok ? 'alert-success' : 'alert-danger']">
+      {{ flash.text }}
+    </div>
+
+    <div class="row g-4">
+      <!-- ── Districts ─────────────────────────────────────────── -->
+      <div class="col-lg-7">
+        <div class="card h-100">
+          <div class="card-header d-flex align-items-center justify-content-between py-2">
+            <span class="fw-semibold">Districts</span>
+            <button class="btn btn-sm btn-primary" @click="openDistrictModal(null)">+ Add</button>
+          </div>
+          <div class="card-body p-0">
+            <div v-if="districtLoading" class="p-3 text-muted small">Loading…</div>
+            <div v-else-if="districts.length === 0" class="p-3 text-muted small">No districts yet.</div>
+            <table v-else class="table table-sm table-hover mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th>Name</th>
+                  <th>Sub-districts</th>
+                  <th style="width:100px"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <template v-for="d in districts" :key="d.id">
+                  <!-- Parent row -->
+                  <tr>
+                    <td class="fw-semibold">{{ d.name }}</td>
+                    <td class="text-muted small">
+                      <span v-for="(c, i) in d.children" :key="c.id">
+                        {{ c.name }}<span v-if="i < d.children.length - 1">、</span>
+                      </span>
+                      <span v-if="d.children.length === 0">—</span>
+                    </td>
+                    <td class="text-end">
+                      <button class="btn btn-xs btn-outline-secondary me-1" @click="openDistrictModal(d)">Edit</button>
+                      <button class="btn btn-xs btn-outline-danger" @click="deleteDistrict(d)">Del</button>
+                    </td>
+                  </tr>
+                  <!-- Child rows -->
+                  <tr v-for="c in d.children" :key="'c'+c.id" class="table-secondary">
+                    <td class="ps-4 text-muted small">↳ {{ c.name }}</td>
+                    <td></td>
+                    <td class="text-end">
+                      <button class="btn btn-xs btn-outline-secondary me-1" @click="openDistrictModal(c)">Edit</button>
+                      <button class="btn btn-xs btn-outline-danger" @click="deleteDistrict(c)">Del</button>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Departments ───────────────────────────────────────── -->
+      <div class="col-lg-5">
+        <div class="card h-100">
+          <div class="card-header d-flex align-items-center justify-content-between py-2">
+            <span class="fw-semibold">Departments</span>
+            <button class="btn btn-sm btn-primary" @click="openDeptModal(null)">+ Add</button>
+          </div>
+          <div class="card-body p-0">
+            <div v-if="deptLoading" class="p-3 text-muted small">Loading…</div>
+            <div v-else-if="departments.length === 0" class="p-3 text-muted small">No departments yet.</div>
+            <table v-else class="table table-sm table-hover mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th>Name</th>
+                  <th style="width:100px"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="dept in departments" :key="dept.id">
+                  <td>{{ dept.name }}</td>
+                  <td class="text-end">
+                    <button class="btn btn-xs btn-outline-secondary me-1" @click="openDeptModal(dept)">Edit</button>
+                    <button class="btn btn-xs btn-outline-danger" @click="deleteDept(dept)">Del</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── District Modal ─────────────────────────────────────── -->
+    <div class="modal fade" id="districtModal" tabindex="-1" ref="districtModalEl">
+      <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+          <div class="modal-header py-2">
+            <h6 class="modal-title mb-0">{{ districtForm.id ? 'Edit District' : 'Add District' }}</h6>
+            <button type="button" class="btn-close btn-sm" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label class="form-label small">Name <span class="text-danger">*</span></label>
+              <input v-model="districtForm.name" type="text" class="form-control form-control-sm"
+                     :class="{'is-invalid': districtErrors.name}" @keyup.enter="saveDistrict" />
+              <div class="invalid-feedback">{{ districtErrors.name }}</div>
+            </div>
+            <div class="mb-1">
+              <label class="form-label small">Parent District</label>
+              <select v-model="districtForm.parent_id" class="form-select form-select-sm">
+                <option :value="null">— None (top-level) —</option>
+                <option v-for="d in parentOptions" :key="d.id" :value="d.id">{{ d.name }}</option>
+              </select>
+            </div>
+          </div>
+          <div class="modal-footer py-2">
+            <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-sm btn-primary" :disabled="districtSaving" @click="saveDistrict">
+              {{ districtSaving ? 'Saving…' : 'Save' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Department Modal ───────────────────────────────────── -->
+    <div class="modal fade" id="deptModal" tabindex="-1" ref="deptModalEl">
+      <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+          <div class="modal-header py-2">
+            <h6 class="modal-title mb-0">{{ deptForm.id ? 'Edit Department' : 'Add Department' }}</h6>
+            <button type="button" class="btn-close btn-sm" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-1">
+              <label class="form-label small">Name <span class="text-danger">*</span></label>
+              <input v-model="deptForm.name" type="text" class="form-control form-control-sm"
+                     :class="{'is-invalid': deptErrors.name}" @keyup.enter="saveDept" />
+              <div class="invalid-feedback">{{ deptErrors.name }}</div>
+            </div>
+          </div>
+          <div class="modal-footer py-2">
+            <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-sm btn-primary" :disabled="deptSaving" @click="saveDept">
+              {{ deptSaving ? 'Saving…' : 'Save' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+const csrfToken = () => document.querySelector('meta[name="csrf-token"]')?.content ?? '';
+
+axios.defaults.headers.common['X-CSRF-TOKEN'] = csrfToken();
+
+export default {
+  name: 'DistrictDepartmentEditor',
+
+  props: {
+    districtUrl:  { type: String, required: true },
+    departmentUrl: { type: String, required: true },
+  },
+
+  data() {
+    return {
+      districts:       [],
+      departments:     [],
+      districtLoading: true,
+      deptLoading:     true,
+      flash:           { text: '', ok: true },
+
+      // District modal
+      districtForm:   { id: null, name: '', parent_id: null },
+      districtErrors: {},
+      districtSaving: false,
+      districtModal:  null,
+
+      // Department modal
+      deptForm:   { id: null, name: '' },
+      deptErrors: {},
+      deptSaving: false,
+      deptModal:  null,
+    };
+  },
+
+  computed: {
+    parentOptions() {
+      const editingId = this.districtForm.id;
+      // Flat list of top-level districts (cannot pick self or own children as parent)
+      const forbidden = new Set([editingId]);
+      const childrenOfEditing = (this.districts.find(d => d.id === editingId)?.children ?? []).map(c => c.id);
+      childrenOfEditing.forEach(id => forbidden.add(id));
+
+      return this.districts.filter(d => !forbidden.has(d.id));
+    },
+
+    allDistrictsFlat() {
+      const flat = [];
+      this.districts.forEach(d => {
+        flat.push(d);
+        d.children.forEach(c => flat.push(c));
+      });
+      return flat;
+    },
+  },
+
+  mounted() {
+    this.districtModal = new window.bootstrap.Modal(this.$refs.districtModalEl);
+    this.deptModal     = new window.bootstrap.Modal(this.$refs.deptModalEl);
+    this.loadDistricts();
+    this.loadDepartments();
+  },
+
+  methods: {
+    // ── Flash ──────────────────────────────────────────────────
+    showFlash(text, ok = true) {
+      this.flash = { text, ok };
+      setTimeout(() => { this.flash.text = ''; }, 3000);
+    },
+
+    // ── Districts ──────────────────────────────────────────────
+    async loadDistricts() {
+      this.districtLoading = true;
+      try {
+        const { data } = await axios.get(this.districtUrl);
+        this.districts = data;
+      } catch {
+        this.showFlash('Failed to load districts.', false);
+      } finally {
+        this.districtLoading = false;
+      }
+    },
+
+    openDistrictModal(district) {
+      this.districtErrors = {};
+      if (district) {
+        this.districtForm = { id: district.id, name: district.name, parent_id: district.parent_id ?? null };
+      } else {
+        this.districtForm = { id: null, name: '', parent_id: null };
+      }
+      this.districtModal.show();
+    },
+
+    async saveDistrict() {
+      this.districtErrors = {};
+      this.districtSaving = true;
+      const { id, name, parent_id } = this.districtForm;
+      try {
+        if (id) {
+          await axios.put(`${this.districtUrl}/${id}`, { name, parent_id });
+        } else {
+          await axios.post(this.districtUrl, { name, parent_id });
+        }
+        this.districtModal.hide();
+        await this.loadDistricts();
+        this.showFlash(id ? 'District updated.' : 'District added.');
+      } catch (err) {
+        if (err.response?.status === 422) {
+          const errs = err.response.data.errors ?? {};
+          this.districtErrors = Object.fromEntries(
+            Object.entries(errs).map(([k, v]) => [k, v[0]])
+          );
+        } else {
+          this.showFlash(err.response?.data?.message ?? 'Error saving district.', false);
+        }
+      } finally {
+        this.districtSaving = false;
+      }
+    },
+
+    async deleteDistrict(district) {
+      if (!confirm(`Delete "${district.name}"? Sub-districts will become top-level.`)) return;
+      try {
+        await axios.delete(`${this.districtUrl}/${district.id}`);
+        await this.loadDistricts();
+        this.showFlash('District deleted.');
+      } catch {
+        this.showFlash('Failed to delete district.', false);
+      }
+    },
+
+    // ── Departments ────────────────────────────────────────────
+    async loadDepartments() {
+      this.deptLoading = true;
+      try {
+        const { data } = await axios.get(this.departmentUrl);
+        this.departments = data;
+      } catch {
+        this.showFlash('Failed to load departments.', false);
+      } finally {
+        this.deptLoading = false;
+      }
+    },
+
+    openDeptModal(dept) {
+      this.deptErrors = {};
+      if (dept) {
+        this.deptForm = { id: dept.id, name: dept.name };
+      } else {
+        this.deptForm = { id: null, name: '' };
+      }
+      this.deptModal.show();
+    },
+
+    async saveDept() {
+      this.deptErrors = {};
+      this.deptSaving = true;
+      const { id, name } = this.deptForm;
+      try {
+        if (id) {
+          await axios.put(`${this.departmentUrl}/${id}`, { name });
+        } else {
+          await axios.post(this.departmentUrl, { name });
+        }
+        this.deptModal.hide();
+        await this.loadDepartments();
+        this.showFlash(id ? 'Department updated.' : 'Department added.');
+      } catch (err) {
+        if (err.response?.status === 422) {
+          const errs = err.response.data.errors ?? {};
+          this.deptErrors = Object.fromEntries(
+            Object.entries(errs).map(([k, v]) => [k, v[0]])
+          );
+        } else {
+          this.showFlash(err.response?.data?.message ?? 'Error saving department.', false);
+        }
+      } finally {
+        this.deptSaving = false;
+      }
+    },
+
+    async deleteDept(dept) {
+      if (!confirm(`Delete "${dept.name}"?`)) return;
+      try {
+        await axios.delete(`${this.departmentUrl}/${dept.id}`);
+        await this.loadDepartments();
+        this.showFlash('Department deleted.');
+      } catch {
+        this.showFlash('Failed to delete department.', false);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.btn-xs {
+  padding: 0.1rem 0.45rem;
+  font-size: 0.75rem;
+  border-radius: 0.2rem;
+}
+</style>

--- a/resources/views/approvals/show.blade.php
+++ b/resources/views/approvals/show.blade.php
@@ -6,11 +6,10 @@
 
     <div class="card mt-3">
         <div class="card-body">
-            {{-- 承認リクエストの概要 --}}
             @php
-            $meta = $approvalRequest->metadata ?? [];
+            $meta       = $approvalRequest->metadata ?? [];
             $approvable = $approvalRequest->approvable;
-            $isLeave = $approvable instanceof \App\Models\Leave;
+            $isLeave    = $approvable instanceof \App\Models\Leave;
             @endphp
 
             <table class="table table-bordered">
@@ -36,7 +35,7 @@
                 </tr>
 
                 @if($isLeave)
-                {{-- ★ 有給/特別休暇申請の場合の表示 --}}
+                {{-- 有給/特別休暇申請の場合 --}}
                 <tr>
                     <th>申請種別</th>
                     <td>
@@ -51,13 +50,11 @@
                         {{ $kindLabel ?? '-' }}
                     </td>
                 </tr>
-                @if($meta['kind'] === 'special' || ($approvable->kind ?? null) === 'special')
-                {{-- ★ 特別休暇の場合の追加情報 --}}
+                @if(($meta['kind'] ?? null) === 'special' || ($approvable->kind ?? null) === 'special')
                 <tr>
                     <th>特別休暇の種類</th>
                     <td>{{ $meta['special_type'] ?? $approvable->special_type ?? '-' }}</td>
                 </tr>
-                {{-- ★ 特別休暇の証明添付（ある場合） --}}
                 <tr>
                     <th>添付</th>
                     <td>
@@ -74,38 +71,85 @@
                     </td>
                 </tr>
                 @endif
-
-                <th>対象日</th>
-                <td>
-                    {{-- ★ 期間（特別休暇） or 日, 日, 日（有給） --}}
-                    {{ $dateSummary ?? ($meta['date'] ?? optional($approvable->start_date)->format('Y-m-d') ?? '-') }}
-                </td>
-
+                <tr>
+                    <th>対象日</th>
+                    <td>{{ $dateSummary ?? ($meta['date'] ?? optional($approvable->start_date)->format('Y-m-d') ?? '-') }}</td>
+                </tr>
                 <tr>
                     <th>理由</th>
-                    <td>
-                        {{ $meta['reason'] ?? ($isLeave ? ($approvable->reason ?? '-') : '-') }}
-                    </td>
+                    <td>{{ $meta['reason'] ?? ($approvable->reason ?? '-') }}</td>
                 </tr>
 
                 @else
-                {{-- 変更後ロール（ロール変更リクエストの場合など） --}}
+                {{-- 権限変更申請の場合 --}}
                 <tr>
                     <th>対象ユーザー</th>
+                    <td>{{ $meta['target_user_name'] ?? '不明' }}</td>
+                </tr>
+                <tr>
+                    <th>権限</th>
                     <td>
-                        {{-- metadata からユーザー名を表示 --}}
-                        @if($isLeave)
-                        {{ optional($approvable->user)->name ?? ('ID:' . ($meta['user_id'] ?? '不明')) }}
-                        @else
-                        {{ $meta['target_user_name'] ?? '不明' }}
-                        @endif
+                        @php
+                        $roleLabels = ['general' => '一般', 'admin' => '管理者', 'super_admin' => 'スーパー管理者'];
+                        @endphp
+                        {{ $roleLabels[$meta['current_role'] ?? ''] ?? ($meta['current_role'] ?? '—') }}
+                        →
+                        <strong>{{ $roleLabels[$meta['requested_role'] ?? ''] ?? ($meta['requested_role'] ?? '—') }}</strong>
                     </td>
                 </tr>
                 <tr>
-                    <th>変更後ロール</th>
+                    <th>所属地区</th>
                     <td>
-                        {{ $meta['requested_role'] ?? '-' }}
+                        {{ $meta['current_district'] ?? '—' }}
+                        →
+                        <strong>{{ $meta['requested_district'] ?? '—' }}</strong>
                     </td>
+                </tr>
+                <tr>
+                    <th>所属部署</th>
+                    <td>
+                        {{ $meta['current_department'] ?? '—' }}
+                        →
+                        <strong>{{ $meta['requested_department'] ?? '—' }}</strong>
+                    </td>
+                </tr>
+                <tr>
+                    <th>管理範囲</th>
+                    <td>
+                        <div class="d-flex gap-4">
+                            <div>
+                                <div class="text-muted small mb-1">現在</div>
+                                @php $currentScopes = $meta['current_scopes'] ?? []; @endphp
+                                @if(empty($currentScopes))
+                                    <span class="text-muted">—</span>
+                                @else
+                                    <ul class="mb-0 ps-3">
+                                        @foreach($currentScopes as $s)
+                                        <li>{{ $s['district'] ?? '—' }} ／ {{ $s['department'] ?? '—' }}</li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                            </div>
+                            <div class="text-muted align-self-center">→</div>
+                            <div>
+                                <div class="text-muted small mb-1">変更後</div>
+                                @php $requestedScopes = $meta['requested_scopes'] ?? []; @endphp
+                                @if(empty($requestedScopes))
+                                    <span class="text-muted">—</span>
+                                @else
+                                    <ul class="mb-0 ps-3">
+                                        @foreach($requestedScopes as $s)
+                                        <li><strong>{{ $s['district'] ?? '—' }} ／ {{ $s['department'] ?? '—' }}</strong></li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <th>申請理由</th>
+                    <td>{{ $meta['reason'] ?? '—' }}</td>
                 </tr>
                 @endif
             </table>

--- a/resources/views/data/data_list.blade.php
+++ b/resources/views/data/data_list.blade.php
@@ -17,9 +17,11 @@
         <a href="{{ route('data.calendar_pattern') }}" class="list-group-item list-group-item-action">
             Calendar Pattern
         </a>
-        <span class="list-group-item text-muted">
+        @can('viewAny', \App\Models\District::class)
+        <a href="{{ route('data.district_department') }}" class="list-group-item list-group-item-action">
             District &amp; Department
-        </span>
+        </a>
+        @endcan
     </div>
 </div>
 @endsection

--- a/resources/views/data/district_department.blade.php
+++ b/resources/views/data/district_department.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">District &amp; Department</h2>
+  <a href="{{ route('data.list') }}" class="btn btn-sm btn-outline-secondary">&larr; Data</a>
+</div>
+
+@php
+$props = [
+    'districtUrl'   => route('api.district.index'),
+    'departmentUrl' => route('api.department.index'),
+];
+@endphp
+<div id="districtDepartmentEditor" data-props='@json($props)'></div>
+@endsection

--- a/resources/views/user/profile/role.blade.php
+++ b/resources/views/user/profile/role.blade.php
@@ -14,6 +14,34 @@
                         <th>権限</th>
                         <td>{{ $user->role_label }}</td>
                     </tr>
+                    <tr>
+                        <th>所属地区</th>
+                        <td>{{ $user->district?->name ?? '—' }}</td>
+                    </tr>
+                    <tr>
+                        <th>所属部署</th>
+                        <td>{{ $user->department?->name ?? '—' }}</td>
+                    </tr>
+                    @if($user->isAdmin())
+                    <tr>
+                        <th>管理範囲</th>
+                        <td>
+                            @if($user->managementScopes->isEmpty())
+                                <span class="text-muted">—</span>
+                            @else
+                                <ul class="mb-0 ps-3">
+                                    @foreach($user->managementScopes as $scope)
+                                    <li>
+                                        {{ $scope->district?->name ?? '—' }}
+                                        ／
+                                        {{ $scope->department?->name ?? '—' }}
+                                    </li>
+                                    @endforeach
+                                </ul>
+                            @endif
+                        </td>
+                    </tr>
+                    @endif
                 </table>
                 <div class="mt-3">
                     <a href="{{ route('admin.user.roleChange', $user) }}" class="btn btn-secondary btn-block">権限を編集</a>

--- a/resources/views/user/roleChange.blade.php
+++ b/resources/views/user/roleChange.blade.php
@@ -9,7 +9,7 @@
             {{-- 本人情報 --}}
             <table class="table table-bordered">
                 <colgroup>
-                    <col style="width:140px;"> <!-- ← 好きな幅に -->
+                    <col style="width:140px;">
                     <col>
                 </colgroup>
                 <tr>
@@ -24,26 +24,124 @@
                     <th>現在の権限</th>
                     <td>{{ $user->role_label }}</td>
                 </tr>
+                <tr>
+                    <th>現在の所属地区</th>
+                    <td>{{ $user->district?->name ?? '—' }}</td>
+                </tr>
+                <tr>
+                    <th>現在の所属部署</th>
+                    <td>{{ $user->department?->name ?? '—' }}</td>
+                </tr>
+                @if($user->isAdmin())
+                <tr>
+                    <th>現在の管理範囲</th>
+                    <td>
+                        @if($user->managementScopes->isEmpty())
+                            <span class="text-muted">—</span>
+                        @else
+                            @foreach($user->managementScopes as $scope)
+                                {{ $scope->district?->name ?? '—' }} ／ {{ $scope->department?->name ?? '—' }}<br>
+                            @endforeach
+                        @endif
+                    </td>
+                </tr>
+                @endif
             </table>
 
             {{-- 申請フォーム --}}
-            <form action="{{ route('roleChange.apply', $user) }}" method="POST"> {{--  --}}
+            @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+            @endif
+
+            <form action="{{ route('roleChange.apply', $user) }}" method="POST">
                 @csrf
 
+                {{-- 変更後の権限 --}}
                 <div class="mb-3">
-                    <label for="role" class="form-label">変更後の権限</label>
+                    <label for="role" class="form-label">変更後の権限 <span class="text-danger">*</span></label>
                     <select name="role" id="role" class="form-select" required>
-                        @foreach ($availableRoles as $role)
-                        <option value="{{ $role }}" {{ $currentRole === $role ? 'selected' : '' }}>
-                            {{ $user->map[$role] ?? $role }}
+                        @foreach ($availableRoles as $r)
+                        @php
+                            $labels = ['general' => '一般', 'admin' => '管理者', 'super_admin' => 'スーパー管理者'];
+                        @endphp
+                        <option value="{{ $r }}" {{ old('role', $currentRole) === $r ? 'selected' : '' }}>
+                            {{ $labels[$r] ?? $r }}
                         </option>
                         @endforeach
                     </select>
                 </div>
 
+                {{-- 所属地区（read-only） --}}
                 <div class="mb-3">
-                    <label for="reason" class="form-label">申請理由</label>
-                    <input type="text" name="reason" id="reason" class="form-control" required>
+                    <label class="form-label">所属地区</label>
+                    <input type="hidden" name="district_id" value="{{ $user->district_id }}">
+                    <p class="form-control-plaintext border rounded px-3 py-2 bg-light mb-0">
+                        {{ $user->district?->name ?? '—' }}
+                    </p>
+                </div>
+
+                {{-- 所属部署（read-only） --}}
+                <div class="mb-3">
+                    <label class="form-label">所属部署</label>
+                    <input type="hidden" name="department_id" value="{{ $user->department_id }}">
+                    <p class="form-control-plaintext border rounded px-3 py-2 bg-light mb-0">
+                        {{ $user->department?->name ?? '—' }}
+                    </p>
+                </div>
+
+                {{-- 管理範囲（admin / super_admin のみ） --}}
+                <div id="scopesSection" class="mb-3" style="display:none;">
+                    <label class="form-label">管理範囲 <span class="text-danger">*</span></label>
+                    <div class="mb-1 text-muted small">地区と部署の組み合わせを1件以上追加してください。</div>
+                    @error('scopes')<div class="text-danger small mb-2">{{ $message }}</div>@enderror
+
+                    <div id="scopeRows">
+                        {{-- 既存エラー時の再描画 --}}
+                        @if(old('scopes'))
+                            @foreach(old('scopes') as $i => $scope)
+                            <div class="scope-row d-flex gap-2 mb-2">
+                                <select name="scopes[{{ $i }}][district_id]" class="form-select @error('scopes.'.$i) is-invalid @enderror">
+                                    <option value="">— 地区 —</option>
+                                    @foreach ($districts as $district)
+                                        <option value="{{ $district->id }}" {{ ($scope['district_id'] ?? '') == $district->id ? 'selected' : '' }}>
+                                            {{ $district->name }}
+                                        </option>
+                                        @foreach ($district->children as $child)
+                                        <option value="{{ $child->id }}" {{ ($scope['district_id'] ?? '') == $child->id ? 'selected' : '' }}>
+                                            　↳ {{ $child->name }}
+                                        </option>
+                                        @endforeach
+                                    @endforeach
+                                </select>
+                                <select name="scopes[{{ $i }}][department_id]" class="form-select">
+                                    <option value="">— 部署 —</option>
+                                    @foreach ($departments as $dept)
+                                    <option value="{{ $dept->id }}" {{ ($scope['department_id'] ?? '') == $dept->id ? 'selected' : '' }}>
+                                        {{ $dept->name }}
+                                    </option>
+                                    @endforeach
+                                </select>
+                                <button type="button" class="btn btn-outline-danger btn-sm scope-remove" style="white-space:nowrap;">削除</button>
+                            </div>
+                            @endforeach
+                        @endif
+                    </div>
+
+                    <button type="button" id="addScope" class="btn btn-outline-secondary btn-sm mt-1">+ 管理範囲を追加</button>
+                </div>
+
+                {{-- 申請理由 --}}
+                <div class="mb-3">
+                    <label for="reason" class="form-label">申請理由 <span class="text-danger">*</span></label>
+                    <textarea name="reason" id="reason" class="form-control @error('reason') is-invalid @enderror"
+                              rows="3" required>{{ old('reason') }}</textarea>
+                    @error('reason')<div class="invalid-feedback">{{ $message }}</div>@enderror
                 </div>
 
                 <button type="submit" class="btn btn-primary">申請する</button>
@@ -51,4 +149,106 @@
         </div>
     </div>
 </div>
+
+@php
+$districtsData = $districts->map(function ($d) {
+    return [
+        'id'       => $d->id,
+        'name'     => $d->name,
+        'children' => $d->children->map(function ($c) {
+            return ['id' => $c->id, 'name' => $c->name];
+        })->values(),
+    ];
+})->values();
+$departmentsData = $departments->map(function ($d) {
+    return ['id' => $d->id, 'name' => $d->name];
+})->values();
+$existingScopesData = $user->managementScopes->map(function ($s) {
+    return ['district_id' => $s->district_id, 'department_id' => $s->department_id];
+})->values();
+@endphp
+
+<script>
+(function () {
+    const roleSelect    = document.getElementById('role');
+    const scopesSection = document.getElementById('scopesSection');
+    const scopeRows     = document.getElementById('scopeRows');
+    const addScopeBtn   = document.getElementById('addScope');
+
+    const districtsJson    = @json($districtsData);
+    const departmentsJson  = @json($departmentsData);
+    const existingScopes   = @json($existingScopesData);
+    const hasOldInput      = {{ old('scopes') ? 'true' : 'false' }};
+
+    let rowIndex = {{ old('scopes') ? count(old('scopes')) : 0 }};
+
+    function buildDistrictOptions(selectedId) {
+        let html = '<option value="">— 地区 —</option>';
+        districtsJson.forEach(d => {
+            const sel = d.id == selectedId ? ' selected' : '';
+            html += `<option value="${d.id}"${sel}>${d.name}</option>`;
+            d.children.forEach(c => {
+                const csel = c.id == selectedId ? ' selected' : '';
+                html += `<option value="${c.id}"${csel}>　↳ ${c.name}</option>`;
+            });
+        });
+        return html;
+    }
+
+    function buildDepartmentOptions(selectedId) {
+        let html = '<option value="">— 部署 —</option>';
+        departmentsJson.forEach(d => {
+            const sel = d.id == selectedId ? ' selected' : '';
+            html += `<option value="${d.id}"${sel}>${d.name}</option>`;
+        });
+        return html;
+    }
+
+    function addRow(districtId, departmentId) {
+        const i   = rowIndex++;
+        const row = document.createElement('div');
+        row.className = 'scope-row d-flex gap-2 mb-2';
+        row.innerHTML = `
+            <select name="scopes[${i}][district_id]" class="form-select">
+                ${buildDistrictOptions(districtId)}
+            </select>
+            <select name="scopes[${i}][department_id]" class="form-select">
+                ${buildDepartmentOptions(departmentId)}
+            </select>
+            <button type="button" class="btn btn-outline-danger btn-sm scope-remove" style="white-space:nowrap;">削除</button>
+        `;
+        scopeRows.appendChild(row);
+    }
+
+    function toggleScopes() {
+        const isAdmin = ['admin', 'super_admin'].includes(roleSelect.value);
+        scopesSection.style.display = isAdmin ? '' : 'none';
+        if (!isAdmin) {
+            scopeRows.innerHTML = '';
+            rowIndex = 0;
+        } else if (scopeRows.children.length === 0) {
+            // バリデーションエラー後は old() の行が Blade で描画済みなので追加しない
+            if (!hasOldInput && existingScopes.length > 0) {
+                existingScopes.forEach(s => addRow(s.district_id, s.department_id));
+            } else if (!hasOldInput) {
+                addRow('', '');
+            }
+        }
+    }
+
+    addScopeBtn.addEventListener('click', () => addRow('', ''));
+
+    scopeRows.addEventListener('click', function (e) {
+        if (e.target.classList.contains('scope-remove')) {
+            e.target.closest('.scope-row').remove();
+        }
+    });
+
+    roleSelect.addEventListener('change', toggleScopes);
+
+    // 初期表示
+    toggleScopes();
+    // old() でエラー時に行が既にある場合は追加しない（Bladeで描画済み）
+})();
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -395,6 +395,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
 
 // ---------------------------------------------------------------------------------------------------------▼ Data関連ルート
 use App\Http\Controllers\CalendarPatternEditorController;
+use App\Http\Controllers\DistrictDepartmentController;
 
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/data', function () {
@@ -430,6 +431,22 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::delete('/api/calendar-pattern/closure/{closure}', [CalendarPatternEditorController::class, 'closureDestroy'])->name('api.cpe.closure.destroy');
 });
 // ---------------------------------------------------------------------------------------------------------▲ Data関連ルート
+
+// ---------------------------------------------------------------------------------------------------------▼ District & Department (super_admin only)
+Route::middleware(['auth', 'role:super_admin'])->group(function () {
+    Route::get('/data/district-department', [DistrictDepartmentController::class, 'index'])->name('data.district_department');
+
+    Route::get('/api/district',               [DistrictDepartmentController::class, 'districtIndex'])->name('api.district.index');
+    Route::post('/api/district',              [DistrictDepartmentController::class, 'districtStore'])->name('api.district.store');
+    Route::put('/api/district/{district}',    [DistrictDepartmentController::class, 'districtUpdate'])->name('api.district.update');
+    Route::delete('/api/district/{district}', [DistrictDepartmentController::class, 'districtDestroy'])->name('api.district.destroy');
+
+    Route::get('/api/department',                [DistrictDepartmentController::class, 'departmentIndex'])->name('api.department.index');
+    Route::post('/api/department',               [DistrictDepartmentController::class, 'departmentStore'])->name('api.department.store');
+    Route::put('/api/department/{department}',   [DistrictDepartmentController::class, 'departmentUpdate'])->name('api.department.update');
+    Route::delete('/api/department/{department}',[DistrictDepartmentController::class, 'departmentDestroy'])->name('api.department.destroy');
+});
+// ---------------------------------------------------------------------------------------------------------▲ District & Department
 
 // ---------------------------------------------------------------------------------------------------------▼ CSV関連ルート
 use App\Http\Controllers\CsvController;

--- a/tests/Feature/DistrictDepartmentControllerTest.php
+++ b/tests/Feature/DistrictDepartmentControllerTest.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * DistrictDepartmentController のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [ゲスト]
+ *   1. ページへの未認証アクセスはログインへリダイレクト
+ *   2. District API（GET）への未認証アクセスはログインへリダイレクト
+ *   3. Department API（GET）への未認証アクセスはログインへリダイレクト
+ *
+ * [権限: general ユーザー]
+ *   4. ページは welcome へリダイレクト（role ミドルウェアが UnauthorizedException → Handler が welcome へ誘導）
+ *   5. District API（GET）は welcome へリダイレクト
+ *   6. Department API（GET）は welcome へリダイレクト
+ *
+ * [権限: admin ユーザー（super_admin ではない）]
+ *   7. ページは welcome へリダイレクト
+ *   8. District API（GET）は welcome へリダイレクト
+ *   9. District API（POST）は welcome へリダイレクト
+ *  10. District API（PUT）は welcome へリダイレクト
+ *  11. District API（DELETE）は welcome へリダイレクト
+ *  12. Department API（GET）は welcome へリダイレクト
+ *  13. Department API（POST）は welcome へリダイレクト
+ *  14. Department API（PUT）は welcome へリダイレクト
+ *  15. Department API（DELETE）は welcome へリダイレクト
+ *
+ * [権限: super_admin（正常系）]
+ *  16. ページを表示できる（200）
+ *  17. District 一覧を取得できる（JSON）
+ *  18. District を作成できる（201 + DB確認）
+ *  19. District を更新できる（200 + DB確認）
+ *  20. District を削除できる（204 + DB確認、子は parent_id が null に）
+ *  21. District を親付きで作成できる
+ *  22. Department 一覧を取得できる（JSON）
+ *  23. Department を作成できる（201 + DB確認）
+ *  24. Department を更新できる（200 + DB確認）
+ *  25. Department を削除できる（204 + DB確認）
+ *
+ * [バリデーション]
+ *  26. District 作成時 name が空だと 422
+ *  27. District 更新時 name が空だと 422
+ *  28. Department 作成時 name が空だと 422
+ *
+ * [data_list ページ]
+ *  29. super_admin は District & Department リンクが表示される
+ *  30. admin はリンクが表示されない
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+class DistrictDepartmentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    private function makeSuperAdmin(): User
+    {
+        return User::factory()->superAdmin()->create();
+    }
+
+    private function makeAdmin(): User
+    {
+        return User::factory()->admin()->create();
+    }
+
+    private function makeGeneral(): User
+    {
+        return User::factory()->general()->create();
+    }
+
+    // =========================================================================
+    // ゲスト
+    // =========================================================================
+
+    public function test_guest_redirected_from_page(): void
+    {
+        $this->get(route('data.district_department'))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_guest_redirected_from_district_api(): void
+    {
+        $this->getJson(route('api.district.index'))
+            ->assertStatus(401);
+    }
+
+    public function test_guest_redirected_from_department_api(): void
+    {
+        $this->getJson(route('api.department.index'))
+            ->assertStatus(401);
+    }
+
+    // =========================================================================
+    // general ユーザー
+    // =========================================================================
+
+    public function test_general_cannot_view_page(): void
+    {
+        $this->actingAs($this->makeGeneral())
+            ->get(route('data.district_department'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_general_cannot_access_district_api(): void
+    {
+        $this->actingAs($this->makeGeneral())
+            ->getJson(route('api.district.index'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_general_cannot_access_department_api(): void
+    {
+        $this->actingAs($this->makeGeneral())
+            ->getJson(route('api.department.index'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // admin ユーザー（super_admin ではない）
+    // =========================================================================
+
+    public function test_admin_cannot_view_page(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->get(route('data.district_department'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_list_districts(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->getJson(route('api.district.index'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_create_district(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->postJson(route('api.district.store'), ['name' => 'Test'])
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_update_district(): void
+    {
+        $district = District::factory()->create();
+
+        $this->actingAs($this->makeAdmin())
+            ->putJson(route('api.district.update', $district), ['name' => 'New'])
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_delete_district(): void
+    {
+        $district = District::factory()->create();
+
+        $this->actingAs($this->makeAdmin())
+            ->deleteJson(route('api.district.destroy', $district))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_list_departments(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->getJson(route('api.department.index'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_create_department(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->postJson(route('api.department.store'), ['name' => 'Test'])
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_update_department(): void
+    {
+        $dept = Department::factory()->create();
+
+        $this->actingAs($this->makeAdmin())
+            ->putJson(route('api.department.update', $dept), ['name' => 'New'])
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_admin_cannot_delete_department(): void
+    {
+        $dept = Department::factory()->create();
+
+        $this->actingAs($this->makeAdmin())
+            ->deleteJson(route('api.department.destroy', $dept))
+            ->assertRedirect(route('welcome'));
+    }
+
+    // =========================================================================
+    // super_admin（正常系）
+    // =========================================================================
+
+    public function test_super_admin_can_view_page(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->get(route('data.district_department'))
+            ->assertOk();
+    }
+
+    public function test_super_admin_can_list_districts(): void
+    {
+        District::factory()->count(3)->create();
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->getJson(route('api.district.index'))
+            ->assertOk()
+            ->assertJsonStructure([['id', 'name', 'parent_id', 'children']]);
+    }
+
+    public function test_super_admin_can_create_district(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->postJson(route('api.district.store'), ['name' => 'New District'])
+            ->assertStatus(201)
+            ->assertJsonFragment(['name' => 'New District']);
+
+        $this->assertDatabaseHas('districts', ['name' => 'New District']);
+    }
+
+    public function test_super_admin_can_create_district_with_parent(): void
+    {
+        $parent = District::factory()->create(['name' => 'Parent']);
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->postJson(route('api.district.store'), ['name' => 'Child', 'parent_id' => $parent->id])
+            ->assertStatus(201)
+            ->assertJsonFragment(['name' => 'Child', 'parent_id' => $parent->id]);
+
+        $this->assertDatabaseHas('districts', ['name' => 'Child', 'parent_id' => $parent->id]);
+    }
+
+    public function test_super_admin_can_update_district(): void
+    {
+        $district = District::factory()->create(['name' => 'Old']);
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->putJson(route('api.district.update', $district), ['name' => 'Updated', 'parent_id' => null])
+            ->assertOk()
+            ->assertJsonFragment(['name' => 'Updated']);
+
+        $this->assertDatabaseHas('districts', ['id' => $district->id, 'name' => 'Updated']);
+    }
+
+    public function test_super_admin_can_delete_district_and_children_become_top_level(): void
+    {
+        $parent = District::factory()->create(['name' => 'Parent']);
+        $child  = District::factory()->create(['name' => 'Child', 'parent_id' => $parent->id]);
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->deleteJson(route('api.district.destroy', $parent))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('districts', ['id' => $parent->id]);
+        $this->assertDatabaseHas('districts', ['id' => $child->id, 'parent_id' => null]);
+    }
+
+    public function test_super_admin_can_list_departments(): void
+    {
+        Department::factory()->count(3)->create();
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->getJson(route('api.department.index'))
+            ->assertOk()
+            ->assertJsonStructure([['id', 'name']]);
+    }
+
+    public function test_super_admin_can_create_department(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->postJson(route('api.department.store'), ['name' => 'New Dept'])
+            ->assertStatus(201)
+            ->assertJsonFragment(['name' => 'New Dept']);
+
+        $this->assertDatabaseHas('departments', ['name' => 'New Dept']);
+    }
+
+    public function test_super_admin_can_update_department(): void
+    {
+        $dept = Department::factory()->create(['name' => 'Old']);
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->putJson(route('api.department.update', $dept), ['name' => 'Updated'])
+            ->assertOk()
+            ->assertJsonFragment(['name' => 'Updated']);
+
+        $this->assertDatabaseHas('departments', ['id' => $dept->id, 'name' => 'Updated']);
+    }
+
+    public function test_super_admin_can_delete_department(): void
+    {
+        $dept = Department::factory()->create();
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->deleteJson(route('api.department.destroy', $dept))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('departments', ['id' => $dept->id]);
+    }
+
+    // =========================================================================
+    // バリデーション
+    // =========================================================================
+
+    public function test_district_store_requires_name(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->postJson(route('api.district.store'), ['name' => ''])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name']);
+    }
+
+    public function test_district_update_requires_name(): void
+    {
+        $district = District::factory()->create();
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->putJson(route('api.district.update', $district), ['name' => ''])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name']);
+    }
+
+    public function test_department_store_requires_name(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->postJson(route('api.department.store'), ['name' => ''])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name']);
+    }
+
+    // =========================================================================
+    // data_list ページの表示制御
+    // =========================================================================
+
+    public function test_super_admin_sees_district_department_link_on_data_list(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->get(route('data.list'))
+            ->assertOk()
+            ->assertSee(route('data.district_department'));
+    }
+
+    public function test_admin_does_not_see_district_department_link_on_data_list(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->get(route('data.list'))
+            ->assertOk()
+            ->assertDontSee(route('data.district_department'));
+    }
+}

--- a/tests/Feature/RoleChangeTest.php
+++ b/tests/Feature/RoleChangeTest.php
@@ -1,0 +1,412 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\RoleChange;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * 権限変更申請フロー のテスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [🔴 applyDomainEffect() — 承認後の反映ロジック]
+ *   1. general 承認後: district_id / department_id が更新される
+ *   2. general 承認後: user_management_scopes が全削除される
+ *   3. admin 承認後: district_id / department_id が更新される
+ *   4. admin 承認後: user_management_scopes が申請内容で完全同期される
+ *   5. admin 承認後: 申請に含まれない旧スコープは削除される
+ *   6. admin → general 降格後: 既存スコープが全削除される
+ *
+ * [🟠 バリデーション — HTTP POST]
+ *   7.  district_id 未送信 → 422
+ *   8.  department_id 未送信 → 422
+ *   9.  general + scopes あり → 422（一般ユーザーに管理範囲は不可）
+ *  10.  admin + scopes なし → 422（管理範囲は1件以上必須）
+ *  11.  admin + 重複 scopes → 422
+ *  12.  admin + 存在しない district_id の scope → 422
+ *  13.  general 正常申請 → RoleChange / ApprovalRequest が生成され users・ロールは変わらない
+ *  14.  admin 正常申請 → RoleChange に scopes が保存され users・ロールは変わらない
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+class RoleChangeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /** actor (super_admin) がターゲットを管理できるようスコープをセットアップ */
+    private function setUpActorAndTarget(): array
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $actor = User::factory()->superAdmin()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+        UserManagementScope::factory()->create([
+            'user_id'       => $actor->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        // ターゲットが同一地区・部署に属することで policy を通過させる
+        $target = User::factory()->general()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return [$actor, $target, $district, $department];
+    }
+
+    /** RoleChange を直接生成し applyDomainEffect() を呼ぶ（HTTP を介さない） */
+    private function buildAndApply(
+        User    $target,
+        string  $role,
+        ?int    $districtId,
+        ?int    $departmentId,
+        array   $scopes = []
+    ): RoleChange {
+        $requester = User::factory()->superAdmin()->create();
+        $rc = RoleChange::create([
+            'user_id'         => $target->id,
+            'requested_role'  => $role,
+            'reason'          => 'test',
+            'requested_by_id' => $requester->id,
+            'status'          => 'pending',
+            'district_id'     => $districtId,
+            'department_id'   => $departmentId,
+            'scopes'          => $scopes,
+        ]);
+        $rc->applyDomainEffect();
+        return $rc;
+    }
+
+    // =========================================================================
+    // 🔴 applyDomainEffect() — 承認後の反映ロジック
+    // =========================================================================
+
+    /** 1. general 承認後: 所属地区・部署が更新される */
+    public function test_general_approval_updates_belonging(): void
+    {
+        $oldDistrict   = District::factory()->create();
+        $newDistrict   = District::factory()->create();
+        $oldDepartment = Department::factory()->create();
+        $newDepartment = Department::factory()->create();
+
+        $target = User::factory()->admin()->create([
+            'district_id'   => $oldDistrict->id,
+            'department_id' => $oldDepartment->id,
+        ]);
+
+        $this->buildAndApply($target, 'general', $newDistrict->id, $newDepartment->id);
+
+        $this->assertDatabaseHas('users', [
+            'id'            => $target->id,
+            'district_id'   => $newDistrict->id,
+            'department_id' => $newDepartment->id,
+        ]);
+        $this->assertTrue($target->fresh()->hasRole('general'));
+    }
+
+    /** 2. general 承認後: user_management_scopes が全削除される */
+    public function test_general_approval_deletes_all_management_scopes(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $target = User::factory()->admin()->create();
+        UserManagementScope::factory()->count(3)->create([
+            'user_id'       => $target->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $this->buildAndApply($target, 'general', $district->id, $department->id);
+
+        $this->assertDatabaseMissing('user_management_scopes', ['user_id' => $target->id]);
+    }
+
+    /** 3. admin 承認後: 所属地区・部署が更新される */
+    public function test_admin_approval_updates_belonging(): void
+    {
+        $oldDistrict   = District::factory()->create();
+        $newDistrict   = District::factory()->create();
+        $oldDepartment = Department::factory()->create();
+        $newDepartment = Department::factory()->create();
+
+        $target = User::factory()->general()->create([
+            'district_id'   => $oldDistrict->id,
+            'department_id' => $oldDepartment->id,
+        ]);
+
+        $this->buildAndApply($target, 'admin', $newDistrict->id, $newDepartment->id, [
+            ['district_id' => $newDistrict->id, 'department_id' => $newDepartment->id],
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'id'            => $target->id,
+            'district_id'   => $newDistrict->id,
+            'department_id' => $newDepartment->id,
+        ]);
+        $this->assertTrue($target->fresh()->hasRole('admin'));
+    }
+
+    /** 4. admin 承認後: user_management_scopes が申請内容で完全同期される */
+    public function test_admin_approval_syncs_management_scopes(): void
+    {
+        $d1 = District::factory()->create();
+        $d2 = District::factory()->create();
+        $p  = Department::factory()->create();
+
+        $target = User::factory()->general()->create();
+
+        $this->buildAndApply($target, 'admin', $d1->id, $p->id, [
+            ['district_id' => $d1->id, 'department_id' => $p->id],
+            ['district_id' => $d2->id, 'department_id' => $p->id],
+        ]);
+
+        $this->assertCount(2, $target->fresh()->managementScopes);
+        $this->assertDatabaseHas('user_management_scopes', [
+            'user_id' => $target->id, 'district_id' => $d1->id, 'department_id' => $p->id,
+        ]);
+        $this->assertDatabaseHas('user_management_scopes', [
+            'user_id' => $target->id, 'district_id' => $d2->id, 'department_id' => $p->id,
+        ]);
+    }
+
+    /** 5. admin 承認後: 申請に含まれない旧スコープは削除される */
+    public function test_admin_approval_removes_old_scopes_not_in_request(): void
+    {
+        $oldDistrict = District::factory()->create();
+        $newDistrict = District::factory()->create();
+        $dept        = Department::factory()->create();
+
+        $target = User::factory()->admin()->create();
+        UserManagementScope::factory()->create([
+            'user_id'       => $target->id,
+            'district_id'   => $oldDistrict->id,
+            'department_id' => $dept->id,
+        ]);
+
+        $this->buildAndApply($target, 'admin', $newDistrict->id, $dept->id, [
+            ['district_id' => $newDistrict->id, 'department_id' => $dept->id],
+        ]);
+
+        $this->assertDatabaseMissing('user_management_scopes', [
+            'user_id' => $target->id, 'district_id' => $oldDistrict->id,
+        ]);
+        $this->assertDatabaseHas('user_management_scopes', [
+            'user_id' => $target->id, 'district_id' => $newDistrict->id,
+        ]);
+    }
+
+    /** 6. admin → general 降格後: 既存スコープが全削除される */
+    public function test_demotion_from_admin_to_general_clears_scopes(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $target = User::factory()->admin()->create();
+        UserManagementScope::factory()->count(2)->create([
+            'user_id'       => $target->id,
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $this->buildAndApply($target, 'general', $district->id, $department->id);
+
+        $this->assertDatabaseMissing('user_management_scopes', ['user_id' => $target->id]);
+        $this->assertTrue($target->fresh()->hasRole('general'));
+    }
+
+    // =========================================================================
+    // 🟠 バリデーション — HTTP POST
+    // =========================================================================
+
+    /** 7. district_id 未送信 → 422 */
+    public function test_district_id_is_required(): void
+    {
+        [$actor, $target] = $this->setUpActorAndTarget();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'general',
+                'reason'        => 'test',
+                'department_id' => Department::factory()->create()->id,
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['district_id']);
+    }
+
+    /** 8. department_id 未送信 → 422 */
+    public function test_department_id_is_required(): void
+    {
+        [$actor, $target] = $this->setUpActorAndTarget();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'        => 'general',
+                'reason'      => 'test',
+                'district_id' => District::factory()->create()->id,
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['department_id']);
+    }
+
+    /** 9. general + scopes あり → 422（一般ユーザーに管理範囲は不可） */
+    public function test_general_role_rejects_scopes(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'general',
+                'reason'        => 'test',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+                'scopes'        => [
+                    ['district_id' => $district->id, 'department_id' => $department->id],
+                ],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['scopes']);
+    }
+
+    /** 10. admin + scopes なし → 422（管理範囲は1件以上必須） */
+    public function test_admin_role_requires_at_least_one_scope(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'admin',
+                'reason'        => 'test',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['scopes']);
+    }
+
+    /** 11. admin + 重複 scopes → 422 */
+    public function test_duplicate_scopes_are_rejected(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'admin',
+                'reason'        => 'test',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+                'scopes'        => [
+                    ['district_id' => $district->id, 'department_id' => $department->id],
+                    ['district_id' => $district->id, 'department_id' => $department->id],
+                ],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['scopes.1']);
+    }
+
+    /** 12. admin + 存在しない district_id の scope → 422 */
+    public function test_nonexistent_district_in_scope_is_rejected(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'admin',
+                'reason'        => 'test',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+                'scopes'        => [
+                    ['district_id' => 99999, 'department_id' => $department->id],
+                ],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['scopes.0.district_id']);
+    }
+
+    /** 13. general 正常申請 → RoleChange / ApprovalRequest 生成・users とロールは変わらない */
+    public function test_general_apply_creates_workflow_without_changing_user(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+        $originalRole = $target->getRoleNames()->first();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'general',
+                'reason'        => '異動のため',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+            ])
+            ->assertRedirect();
+
+        // RoleChange が生成されている
+        $this->assertDatabaseHas('role_changes', [
+            'user_id'        => $target->id,
+            'requested_role' => 'general',
+            'status'         => 'pending',
+            'district_id'    => $district->id,
+            'department_id'  => $department->id,
+        ]);
+
+        // ApprovalRequest も生成されている
+        $rc = RoleChange::where('user_id', $target->id)->latest()->first();
+        $this->assertNotNull($rc->approvalRequest);
+        $this->assertSame('pending', $rc->approvalRequest->current_state);
+
+        // 承認前は users / ロールが変わっていない
+        $fresh = $target->fresh();
+        $this->assertSame($originalRole, $fresh->getRoleNames()->first());
+    }
+
+    /** 14. admin 正常申請 → RoleChange に scopes 保存・users とロールは変わらない */
+    public function test_admin_apply_persists_scopes_without_changing_user(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+        $originalRole        = $target->getRoleNames()->first();
+        $originalDistrictId  = $target->district_id;
+        $originalDepartmentId = $target->department_id;
+
+        $d2 = District::factory()->create();
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'admin',
+                'reason'        => '管理者に昇格',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+                'scopes'        => [
+                    ['district_id' => $district->id, 'department_id' => $department->id],
+                    ['district_id' => $d2->id,       'department_id' => $department->id],
+                ],
+            ])
+            ->assertRedirect();
+
+        $rc = RoleChange::where('user_id', $target->id)->latest()->first();
+
+        // scopes が JSON で保存されている
+        $this->assertCount(2, $rc->scopes);
+        $this->assertSame($district->id, $rc->scopes[0]['district_id']);
+        $this->assertSame($d2->id,       $rc->scopes[1]['district_id']);
+
+        // 承認前は users / ロール / スコープテーブルが変わっていない
+        $fresh = $target->fresh();
+        $this->assertSame($originalRole,         $fresh->getRoleNames()->first());
+        $this->assertSame($originalDistrictId,   $fresh->district_id);
+        $this->assertSame($originalDepartmentId, $fresh->department_id);
+        $this->assertDatabaseMissing('user_management_scopes', ['user_id' => $target->id]);
+    }
+}

--- a/tests/Feature/RoleChangeTest.php
+++ b/tests/Feature/RoleChangeTest.php
@@ -122,17 +122,21 @@ class RoleChangeTest extends TestCase
     /** 2. general 承認後: user_management_scopes が全削除される */
     public function test_general_approval_deletes_all_management_scopes(): void
     {
-        $district   = District::factory()->create();
-        $department = Department::factory()->create();
+        $district    = District::factory()->create();
+        $department1 = Department::factory()->create();
+        $department2 = Department::factory()->create();
+        $department3 = Department::factory()->create();
 
         $target = User::factory()->admin()->create();
-        UserManagementScope::factory()->count(3)->create([
-            'user_id'       => $target->id,
-            'district_id'   => $district->id,
-            'department_id' => $department->id,
-        ]);
+        foreach ([$department1, $department2, $department3] as $dept) {
+            UserManagementScope::factory()->create([
+                'user_id'       => $target->id,
+                'district_id'   => $district->id,
+                'department_id' => $dept->id,
+            ]);
+        }
 
-        $this->buildAndApply($target, 'general', $district->id, $department->id);
+        $this->buildAndApply($target, 'general', $district->id, $department1->id);
 
         $this->assertDatabaseMissing('user_management_scopes', ['user_id' => $target->id]);
     }
@@ -214,17 +218,20 @@ class RoleChangeTest extends TestCase
     /** 6. admin → general 降格後: 既存スコープが全削除される */
     public function test_demotion_from_admin_to_general_clears_scopes(): void
     {
-        $district   = District::factory()->create();
-        $department = Department::factory()->create();
+        $district    = District::factory()->create();
+        $department1 = Department::factory()->create();
+        $department2 = Department::factory()->create();
 
         $target = User::factory()->admin()->create();
-        UserManagementScope::factory()->count(2)->create([
-            'user_id'       => $target->id,
-            'district_id'   => $district->id,
-            'department_id' => $department->id,
-        ]);
+        foreach ([$department1, $department2] as $dept) {
+            UserManagementScope::factory()->create([
+                'user_id'       => $target->id,
+                'district_id'   => $district->id,
+                'department_id' => $dept->id,
+            ]);
+        }
 
-        $this->buildAndApply($target, 'general', $district->id, $department->id);
+        $this->buildAndApply($target, 'general', $district->id, $department1->id);
 
         $this->assertDatabaseMissing('user_management_scopes', ['user_id' => $target->id]);
         $this->assertTrue($target->fresh()->hasRole('general'));


### PR DESCRIPTION
## 概要

`/data` ページから遷移できる **District & Department マスタ管理画面** を新設しました。

地域（District）と部署（Department）の閲覧・追加・編集・削除をインラインで操作できるようにし、アクセスは `super_admin` ロールのみに制限しています。

---

## 実装内容

### Districts（地域）

- 一覧表示
  - 親子構造に対応
  - 親 District → 子 District を `↳` 付きでインデント表示
- 追加・編集
  - 名前
  - 親 District の選択
- 削除
  - 削除対象に子 District が存在する場合、子 District は自動的にトップレベルへ昇格
  - `parent_id` を `null` に更新

### Departments（部署）

- 一覧表示
- 追加
- 編集
- 削除

### Data List ページ

- `/data` ページに `"District & Department"` リンクを追加
- リンクは `super_admin` のみ表示
- 表示制御は `@can` ディレクティブで実施

---

## 技術概要

### 認可：二重防御構造

| レイヤー | 仕組み | 効果 |
|---|---|---|
| ルートミドルウェア | `role:super_admin`（Spatie Permission） | 未認可ロールをルーティング段階で弾き、`welcome` へリダイレクト |
| Policy | `DistrictPolicy` / `DepartmentPolicy` の `isSuperAdmin()` | ミドルウェア回避時のフォールバックとして 403 abort |

---

## 追加・変更ファイル

```text
app/Http/Controllers/DistrictDepartmentController.php
app/Policies/DistrictPolicy.php
app/Policies/DepartmentPolicy.php
app/Providers/AuthServiceProvider.php
routes/web.php
resources/js/components/DistrictDepartmentEditor.vue
resources/views/data/district_department.blade.php
resources/views/data/data_list.blade.php
tests/Feature/DistrictDepartmentControllerTest.php
```

### 各ファイルの役割

| ファイル | 内容 |
|---|---|
| `DistrictDepartmentController.php` | ページ表示 + District / Department CRUD API |
| `DistrictPolicy.php` | District 操作を `super_admin` のみに制限 |
| `DepartmentPolicy.php` | Department 操作を `super_admin` のみに制限 |
| `AuthServiceProvider.php` | District / Department と Policy の紐付けを追加 |
| `routes/web.php` | `role:super_admin` グループにルートを分離 |
| `DistrictDepartmentEditor.vue` | Vue 3 SPA コンポーネント |
| `district_department.blade.php` | Vue マウント用 Blade |
| `data_list.blade.php` | `@can` によるリンク表示制御 |
| `DistrictDepartmentControllerTest.php` | Feature Test 追加 |

---

## Vue コンポーネント

`DistrictDepartmentEditor.vue` を新規作成しました。

### 主な仕様

- Vue 3 Options API
- axios による REST API 呼び出し
- Districts / Departments を 2 カラムレイアウトで並列表示
- Bootstrap 5 モーダルで追加・編集フォームを表示
- サーバーサイドバリデーションエラーをインライン表示
- 操作フィードバックを flash メッセージで表示
- flash メッセージは 3 秒後に自動で非表示

---

## API エンドポイント

### District

| Method | URL | 説明 |
|---|---|---|
| GET | `/api/district` | 親子構造で一覧取得 |
| POST | `/api/district` | 作成 |
| PUT | `/api/district/{district}` | 更新 |
| DELETE | `/api/district/{district}` | 削除。子 District は `parent_id = null` に更新 |

### Department

| Method | URL | 説明 |
|---|---|---|
| GET | `/api/department` | 一覧取得 |
| POST | `/api/department` | 作成 |
| PUT | `/api/department/{department}` | 更新 |
| DELETE | `/api/department/{department}` | 削除 |

---

## テスト

`tests/Feature/DistrictDepartmentControllerTest.php` を追加しました。

### テスト結果

```text
30 tests / 75 assertions
```

### テスト内容

| カテゴリ | 件数 | 内容 |
|---|---:|---|
| ゲスト | 3 | 未認証アクセス時に login へリダイレクト |
| general | 3 | ページ・API へのアクセス時に welcome へリダイレクト |
| admin | 9 | ページ・全 API へのアクセス時に welcome へリダイレクト |
| super_admin 正常系 | 11 | District / Department の CRUD 全操作、District 削除時の子昇格確認 |
| バリデーション | 3 | name 空欄時に 422 |
| 画面表示制御 | 2 | super_admin はリンク表示、admin はリンク非表示 |

---

## 確認ポイント

- `/data` ページに `"District & Department"` リンクが表示されること
- リンクは `super_admin` のみに表示されること
- general / admin では画面・APIへアクセスできないこと
- District を追加・編集・削除できること
- 子 District を持つ親 District を削除した場合、子 District がトップレベルへ昇格すること
- Department を追加・編集・削除できること
- バリデーションエラーが画面上に表示されること
- 操作後に flash メッセージが表示されること
- 既存の `/data` ページの他リンクに影響がないこと

---

## 補足

District / Department は今後のスコープ制御やユーザー・スクール管理の基礎データになるため、操作権限は `super_admin` のみに限定しています。

ルートミドルウェアと Policy の両方で制御することで、画面・API の両面から誤操作や不正アクセスを防ぐ構成にしています。