### PR TITLE
lessonの編集画面を追加

### DIFF
--- a/app/Http/Controllers/LessonEditController.php
+++ b/app/Http/Controllers/LessonEditController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Lesson;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LessonEditController extends Controller
+{
+    private const PER_PAGE_OPTIONS = [60, 120, 180];
+
+    public function index(Request $request)
+    {
+        $this->authorize('viewAny', Lesson::class);
+
+        $search = trim((string) $request->query('q', ''));
+        $perPage = (int) $request->query('per_page', 60);
+        if (! in_array($perPage, self::PER_PAGE_OPTIONS, true)) {
+            $perPage = 60;
+        }
+
+        $lessons = Lesson::query()
+            ->when($search !== '', function ($query) use ($search) {
+                $query->where(function ($query) use ($search) {
+                    $query->whereLikeInsensitive('lesson_name', $search)
+                        ->orWhereLikeInsensitive('lesson_code', $search)
+                        ->orWhereLikeInsensitive('note', $search)
+                        ->orWhereLikeInsensitive('ps_unique_lesson_code', $search)
+                        ->orWhereLikeInsensitive('fm_lesson_code', $search);
+
+                    if (ctype_digit($search)) {
+                        $query->orWhere('id', (int) $search);
+                    }
+                });
+            })
+            ->orderBy('id')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        return view('data.lesson_edit', [
+            'lessons' => $lessons,
+            'search' => $search,
+            'perPage' => $perPage,
+            'perPageOptions' => self::PER_PAGE_OPTIONS,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $this->authorize('create', Lesson::class);
+
+        Lesson::create($this->validatedLessonData($request));
+
+        return redirect()
+            ->route('data.lessons.index')
+            ->with('toast', 'Lesson created.');
+    }
+
+    public function update(Request $request, Lesson $lesson)
+    {
+        $this->authorize('update', $lesson);
+
+        $lesson->update($this->validatedLessonData($request));
+
+        return back()->with('toast', "Lesson #{$lesson->id} updated.");
+    }
+
+    public function destroy(Lesson $lesson)
+    {
+        $this->authorize('delete', $lesson);
+
+        if ($lesson->scheduleDetails()->exists() || DB::table('event_details')->where('lesson_id', $lesson->id)->exists()) {
+            return back()->with('toast_errors', ["Lesson #{$lesson->id} is used by schedules and cannot be deleted."]);
+        }
+
+        $lessonId = $lesson->id;
+        $lesson->delete();
+
+        return back()->with('toast', "Lesson #{$lessonId} deleted.");
+    }
+
+    private function validatedLessonData(Request $request): array
+    {
+        $data = $request->validate([
+            'lesson_name' => ['nullable', 'string', 'max:255'],
+            'lesson_code' => ['nullable', 'string', 'max:255'],
+            'note' => ['nullable', 'string', 'max:255'],
+            'lesson_minute' => ['nullable', 'integer', 'min:0', 'max:65535'],
+            'lesson_type' => ['nullable', 'string', 'max:255'],
+            'ps_unique_lesson_code' => ['nullable', 'string', 'max:255'],
+            'fm_lesson_code' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        foreach ($data as $key => $value) {
+            if (is_string($value)) {
+                $value = trim($value);
+                $data[$key] = $value === '' ? null : $value;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/resources/views/data/data_list.blade.php
+++ b/resources/views/data/data_list.blade.php
@@ -11,9 +11,9 @@
         <a href="{{ route('schools.search') }}" class="list-group-item list-group-item-action">
             School Search
         </a>
-        <span class="list-group-item text-muted">
+        <a href="{{ route('data.lessons.index') }}" class="list-group-item list-group-item-action">
             Lesson
-        </span>
+        </a>
         <a href="{{ route('data.calendar_pattern') }}" class="list-group-item list-group-item-action">
             Calendar Pattern
         </a>

--- a/resources/views/data/lesson_edit.blade.php
+++ b/resources/views/data/lesson_edit.blade.php
@@ -1,0 +1,183 @@
+@extends('layouts.app')
+
+@section('content')
+@php($oldForm = old('_lesson_form'))
+
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+    <div>
+        <h2 class="mb-0">Lesson</h2>
+        <div class="text-muted small">{{ number_format($lessons->total()) }} lessons</div>
+    </div>
+    <div class="d-flex gap-2">
+        <a href="{{ route('csv.lessons.show') }}" class="btn btn-sm btn-outline-primary">
+            <i class="fas fa-file-csv me-1"></i>CSV
+        </a>
+        <a href="{{ route('data.list') }}" class="btn btn-sm btn-outline-secondary">&larr; Data</a>
+    </div>
+</div>
+
+<form method="GET" action="{{ route('data.lessons.index') }}" class="row g-2 align-items-end mb-3">
+    <div class="col-12 col-md-7 col-lg-6">
+        <label for="lesson-search" class="form-label small mb-1">Search</label>
+        <input
+            id="lesson-search"
+            type="search"
+            name="q"
+            value="{{ $search }}"
+            class="form-control"
+            placeholder="ID / name / code / note / PS / FM">
+    </div>
+    <div class="col-6 col-md-2">
+        <label for="lesson-per-page" class="form-label small mb-1">Per page</label>
+        <select id="lesson-per-page" name="per_page" class="form-select">
+            @foreach($perPageOptions as $option)
+                <option value="{{ $option }}" @selected($perPage === $option)>{{ $option }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="col-6 col-md-auto">
+        <button type="submit" class="btn btn-primary w-100">
+            <i class="fas fa-magnifying-glass me-1"></i>Search
+        </button>
+    </div>
+    @if($search !== '')
+        <div class="col-12 col-md-auto">
+            <a href="{{ route('data.lessons.index', ['per_page' => $perPage]) }}" class="btn btn-outline-secondary">
+                Clear
+            </a>
+        </div>
+    @endif
+</form>
+
+<div class="card mb-4">
+    <div class="card-header bg-white">
+        <strong>New Lesson</strong>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-sm table-bordered align-middle mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 5rem;">ID</th>
+                        <th style="min-width: 13.2rem;">Lesson name</th>
+                        <th style="min-width: 8rem;">Code</th>
+                        <th style="min-width: 5rem;">Minute</th>
+                        <th style="min-width: 28.8rem;">PS unique code</th>
+                        <th style="min-width: 9.3rem;">FM code</th>
+                        <th style="min-width: 9.7rem;">Note</th>
+                        <th style="width: 10rem;">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <input type="text" value="New" class="form-control form-control-sm bg-light text-muted" readonly>
+                        </td>
+                        <td>
+                            <input form="lesson-create-form" type="text" name="lesson_name" value="{{ $oldForm === 'create' ? old('lesson_name') : '' }}" class="form-control form-control-sm" maxlength="255">
+                        </td>
+                        <td>
+                            <input form="lesson-create-form" type="text" name="lesson_code" value="{{ $oldForm === 'create' ? old('lesson_code') : '' }}" class="form-control form-control-sm" maxlength="255">
+                        </td>
+                        <td>
+                            <input form="lesson-create-form" type="number" name="lesson_minute" value="{{ $oldForm === 'create' ? old('lesson_minute') : '' }}" class="form-control form-control-sm" min="0" max="65535">
+                        </td>
+                        <td>
+                            <input form="lesson-create-form" type="text" name="ps_unique_lesson_code" value="{{ $oldForm === 'create' ? old('ps_unique_lesson_code') : '' }}" class="form-control form-control-sm" maxlength="255">
+                        </td>
+                        <td>
+                            <input form="lesson-create-form" type="text" name="fm_lesson_code" value="{{ $oldForm === 'create' ? old('fm_lesson_code') : '' }}" class="form-control form-control-sm" maxlength="255">
+                        </td>
+                        <td>
+                            <input form="lesson-create-form" type="text" name="note" value="{{ $oldForm === 'create' ? old('note') : '' }}" class="form-control form-control-sm" maxlength="255">
+                        </td>
+                        <td>
+                            <form id="lesson-create-form" method="POST" action="{{ route('data.lessons.store') }}">
+                                @csrf
+                                <input type="hidden" name="_lesson_form" value="create">
+                            </form>
+                            <button form="lesson-create-form" type="submit" class="btn btn-sm btn-success" title="Create">
+                                <i class="fas fa-plus"></i>
+                            </button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-sm table-bordered align-middle">
+        <thead class="table-light">
+            <tr>
+                <th style="width: 5rem;">ID</th>
+                <th style="min-width: 13.2rem;">Lesson name</th>
+                <th style="min-width: 8rem;">Code</th>
+                <th style="min-width: 5rem;">Minute</th>
+                <th style="min-width: 28.8rem;">PS unique code</th>
+                <th style="min-width: 9.3rem;">FM code</th>
+                <th style="min-width: 9.7rem;">Note</th>
+                <th style="width: 10rem;">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($lessons as $lesson)
+                @php($formId = 'lesson-update-' . $lesson->id)
+                @php($isOldRow = $oldForm === $formId)
+                <tr>
+                    <td class="text-muted">#{{ $lesson->id }}</td>
+                    <td>
+                        <input form="{{ $formId }}" type="text" name="lesson_name" value="{{ $isOldRow ? old('lesson_name') : $lesson->lesson_name }}" class="form-control form-control-sm" maxlength="255">
+                    </td>
+                    <td>
+                        <input form="{{ $formId }}" type="text" name="lesson_code" value="{{ $isOldRow ? old('lesson_code') : $lesson->lesson_code }}" class="form-control form-control-sm" maxlength="255">
+                    </td>
+                    <td>
+                        <input form="{{ $formId }}" type="number" name="lesson_minute" value="{{ $isOldRow ? old('lesson_minute') : $lesson->lesson_minute }}" class="form-control form-control-sm" min="0" max="65535">
+                    </td>
+                    <td>
+                        <input form="{{ $formId }}" type="text" name="ps_unique_lesson_code" value="{{ $isOldRow ? old('ps_unique_lesson_code') : $lesson->ps_unique_lesson_code }}" class="form-control form-control-sm bg-light" maxlength="255" readonly>
+                    </td>
+                    <td>
+                        <input form="{{ $formId }}" type="text" name="fm_lesson_code" value="{{ $isOldRow ? old('fm_lesson_code') : $lesson->fm_lesson_code }}" class="form-control form-control-sm" maxlength="255">
+                    </td>
+                    <td>
+                        <input form="{{ $formId }}" type="text" name="note" value="{{ $isOldRow ? old('note') : $lesson->note }}" class="form-control form-control-sm" maxlength="255">
+                    </td>
+                    <td>
+                        <div class="d-flex gap-1">
+                            <form id="{{ $formId }}" method="POST" action="{{ route('data.lessons.update', $lesson) }}">
+                                @csrf
+                                @method('PUT')
+                                <input type="hidden" name="_lesson_form" value="{{ $formId }}">
+                            </form>
+                            <button form="{{ $formId }}" type="submit" class="btn btn-sm btn-primary" title="Update">
+                                <i class="fas fa-floppy-disk"></i>
+                            </button>
+                            <form method="POST" action="{{ route('data.lessons.destroy', $lesson) }}" onsubmit="return confirm('Delete lesson #{{ $lesson->id }}? Used lessons will be blocked.');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="8" class="text-center text-muted py-4">No lessons found.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+    <div class="text-muted small">
+        Showing {{ $lessons->firstItem() ?? 0 }}-{{ $lessons->lastItem() ?? 0 }} of {{ $lessons->total() }}
+    </div>
+    {{ $lessons->links() }}
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -396,6 +396,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
 // ---------------------------------------------------------------------------------------------------------▼ Data関連ルート
 use App\Http\Controllers\CalendarPatternEditorController;
 use App\Http\Controllers\DistrictDepartmentController;
+use App\Http\Controllers\LessonEditController;
 
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/data', function () {
@@ -404,6 +405,12 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
 
     // Calendar Pattern Editor page
     Route::get('/data/calendar-pattern', [CalendarPatternEditorController::class, 'index'])->name('data.calendar_pattern');
+
+    // Lesson edit page
+    Route::get('/data/lesson_edit', [LessonEditController::class, 'index'])->name('data.lessons.index');
+    Route::post('/data/lesson_edit', [LessonEditController::class, 'store'])->name('data.lessons.store');
+    Route::put('/data/lesson_edit/{lesson}', [LessonEditController::class, 'update'])->name('data.lessons.update');
+    Route::delete('/data/lesson_edit/{lesson}', [LessonEditController::class, 'destroy'])->name('data.lessons.destroy');
 
     // Events API (mini-calendar)
     Route::get('/api/calendar-pattern/events', [CalendarPatternEditorController::class, 'events'])->name('api.cpe.events');

--- a/tests/Feature/LessonEditControllerTest.php
+++ b/tests/Feature/LessonEditControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Lesson;
+use App\Models\ScheduleDetail;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LessonEditControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_searchable_paginated_lesson_list(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        Lesson::factory()->count(35)->create();
+        Lesson::factory()->create([
+            'lesson_name' => 'Target Conversation',
+            'lesson_code' => 'TARGET01',
+            'lesson_minute' => 45,
+            'lesson_type' => 'Adults',
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('data.lessons.index', ['q' => 'target', 'per_page' => 60]))
+            ->assertOk()
+            ->assertSee('Target Conversation')
+            ->assertSee('TARGET01')
+            ->assertSee('60');
+    }
+
+    public function test_admin_can_create_update_and_delete_lesson(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->post(route('data.lessons.store'), [
+                'lesson_name' => 'New Lesson',
+                'lesson_code' => 'NEW01',
+                'lesson_minute' => 30,
+                'lesson_type' => 'Kids',
+                'note' => 'Starter',
+                'ps_unique_lesson_code' => 'PS-NEW',
+                'fm_lesson_code' => 'FM-NEW',
+            ])
+            ->assertRedirect(route('data.lessons.index'));
+
+        $lesson = Lesson::where('lesson_code', 'NEW01')->firstOrFail();
+
+        $this->assertDatabaseHas('lessons', [
+            'id' => $lesson->id,
+            'lesson_name' => 'New Lesson',
+            'lesson_minute' => 30,
+        ]);
+
+        $this->actingAs($admin)
+            ->put(route('data.lessons.update', $lesson), [
+                'lesson_name' => 'Updated Lesson',
+                'lesson_code' => 'UPD01',
+                'lesson_minute' => 45,
+                'lesson_type' => 'Adults',
+                'note' => 'Updated note',
+                'ps_unique_lesson_code' => 'PS-UPD',
+                'fm_lesson_code' => 'FM-UPD',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('lessons', [
+            'id' => $lesson->id,
+            'lesson_name' => 'Updated Lesson',
+            'lesson_code' => 'UPD01',
+            'lesson_minute' => 45,
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('data.lessons.destroy', $lesson))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('lessons', [
+            'id' => $lesson->id,
+        ]);
+    }
+
+    public function test_admin_cannot_delete_lesson_used_by_schedule_details(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $lesson = Lesson::factory()->create();
+        ScheduleDetail::factory()->create([
+            'lesson_id' => $lesson->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('data.lessons.destroy', $lesson))
+            ->assertRedirect()
+            ->assertSessionHas('toast_errors');
+
+        $this->assertDatabaseHas('lessons', [
+            'id' => $lesson->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## 実装・技術概要

Lesson情報を管理画面から閲覧・検索・作成・更新・削除できるようにしました。

`data_list` の `Lesson` から `/data/lesson_edit` に遷移し、Lesson一覧を表示します。Lesson件数が多いため、一覧は `paginate()` を使い、表示件数は `60 / 120 / 180` から選択できます。検索は `lesson_name`, `lesson_code`, `note`, `ps_unique_lesson_code`, `fm_lesson_code`, `id` を対象にしています。

編集画面では、上部に新規作成用の1行フォーム、下部に既存Lessonの一覧編集フォームを配置しています。新規作成フォームは既存行と同じ列構成に揃え、操作列だけ `Create` ボタンにしています。既存行では保存・削除ボタンを表示します。

`PS unique code` は既存行では `readonly` にし、誤編集を防いでいます。一方、新規作成時には入力できるようにしています。

削除時は、スケジュール明細やイベント明細で使用中のLessonを削除できないようにガードを入れています。

## 追加・修正ファイル

### `routes/web.php`

Lesson管理用のルートを追加しました。

追加したルート:

```php
GET    /data/lesson_edit
POST   /data/lesson_edit
PUT    /data/lesson_edit/{lesson}
DELETE /data/lesson_edit/{lesson}
```

すべて既存のData管理系ルートと同じく、`auth` と `role:admin|super_admin` 配下に置いています。

### `app/Http/Controllers/LessonEditController.php`

Lesson管理画面用のControllerを追加しました。

役割:

- Lesson一覧表示
- 検索
- Pagination
- 新規作成
- 更新
- 削除
- バリデーション
- 使用中Lessonの削除防止

検索は既存プロジェクトの `whereLikeInsensitive` マクロを使い、大文字小文字を吸収する形にしています。

削除時は以下を確認しています。

- `schedule_details` で使われていないか
- `event_details` で使われていないか

使用中の場合は削除せず、エラートーストを返します。

### `resources/views/data/data_list.blade.php`

Data一覧画面の `Lesson` をリンク化しました。

変更前は無効なテキスト表示でしたが、現在は `data.lessons.index` に遷移するリンクになっています。

### `resources/views/data/lesson_edit.blade.php`

Lesson管理画面を実装しました。

主な内容:

- 検索フォーム
- 表示件数切替 `60 / 120 / 180`
- 新規作成フォーム
- 既存Lesson一覧
- 各行の更新ボタン
- 各行の削除ボタン
- Pagination表示

列構成:

- ID
- Lesson name
- Code
- Minute
- PS unique code
- FM code
- Note
- Actions

新規作成行も既存編集行と同じ列幅・並びに揃えています。

既存Lessonの `PS unique code` は `readonly` にしています。新規作成時のみ入力可能です。

### `tests/Feature/LessonEditControllerTest.php`

Lesson管理機能のFeatureテストを追加しました。

テスト内容:

- 管理者がLesson一覧を検索・ページネーション付きで表示できること
- Lessonを作成・更新・削除できること
- スケジュール明細で使用中のLessonは削除できないこと

確認済み:

```bash
php artisan test tests/Feature/LessonEditControllerTest.php
```

結果:

```text
3 passed (14 assertions)
```

## 動作確認

以下を実行済みです。

```bash
php artisan view:cache
php artisan test tests/Feature/LessonEditControllerTest.php
```

`view:cache` でBladeテンプレートの構文問題がないことを確認し、FeatureテストでCRUDと削除ガードを確認しています。