### PR TITLE
Schedule CSV Downloadに期間を設定

### DIFF
--- a/app/Http/Controllers/ScheduleCsvController.php
+++ b/app/Http/Controllers/ScheduleCsvController.php
@@ -19,19 +19,35 @@ class ScheduleCsvController extends Controller
     {
         $this->authorize('viewAny', ScheduleLine::class);
 
-        return view('csv.schedule_csv');
+        $currentFiscalYear = now()->month >= 4 ? now()->year : now()->year - 1;
+        $fiscalYears = range($currentFiscalYear + 1, $currentFiscalYear - 5);
+
+        return view('csv.schedule_csv', [
+            'fiscalYears' => $fiscalYears,
+            'currentFiscalYear' => $currentFiscalYear,
+        ]);
     }
 
     /**
      * スケジュールデータを CSV でエクスポート
      * GET /csv/schedule/export — ScheduleCsvExportService でストリームダウンロード形式に出力
      */
-    public function export(ScheduleCsvExportService $service)
+    public function export(Request $request, ScheduleCsvExportService $service)
     {
         $this->authorize('viewAny', ScheduleLine::class);
 
-        $filename = 'schedules_' . now()->format('Ymd_His') . '.csv';
-        return $service->streamCsv($filename);
+        $validated = $request->validate([
+            'fiscal_year' => ['required', 'integer', 'between:2000,2100'],
+        ], [
+            'fiscal_year.required' => '年度を選択してください。',
+            'fiscal_year.integer' => '年度の指定が不正です。',
+            'fiscal_year.between' => '年度の指定が不正です。',
+        ]);
+
+        $fiscalYear = (int) $validated['fiscal_year'];
+        $filename = 'schedules_' . $fiscalYear . 'fy_' . now()->format('Ymd_His') . '.csv';
+
+        return $service->streamCsv($filename, $fiscalYear);
     }
 
     /**

--- a/app/Services/ScheduleCsv/ScheduleCsvExportService.php
+++ b/app/Services/ScheduleCsv/ScheduleCsvExportService.php
@@ -37,12 +37,15 @@ class ScheduleCsvExportService
         6 => 'Saturday',
     ];
 
-    public function streamCsv(string $filename): StreamedResponse
+    public function streamCsv(string $filename, int $fiscalYear): StreamedResponse
     {
+        $fiscalStart = sprintf('%04d-04-01', $fiscalYear);
+        $fiscalEnd = sprintf('%04d-03-31', $fiscalYear + 1);
+
         // school_name => school_code の逆引きマップ（export 時の SchoolNumName 組み立て用）
         $schoolCodeMap = School::pluck('school_code', 'school_name')->all();
 
-        return response()->streamDownload(function () use ($schoolCodeMap) {
+        return response()->streamDownload(function () use ($schoolCodeMap, $fiscalStart, $fiscalEnd) {
             $fp = fopen('php://output', 'w');
 
             fputcsv($fp, self::HEADERS);
@@ -64,6 +67,8 @@ class ScheduleCsvExportService
                     'di.name as district_name',
                     'dep.name as department_name'
                 )
+                ->whereDate('sl.effective_start', '>=', $fiscalStart)
+                ->whereDate('sl.effective_start', '<=', $fiscalEnd)
                 ->orderBy('u.employee_code')
                 ->orderBy('sl.effective_start')
                 ->orderBy('sl.dow')
@@ -75,6 +80,8 @@ class ScheduleCsvExportService
                 $details = DB::table('schedule_details as sd')
                     ->join('lessons as l', 'sd.lesson_id', '=', 'l.id')
                     ->where('sd.schedule_line_id', $line->line_id)
+                    ->whereDate('sd.effective_start', '>=', $fiscalStart)
+                    ->whereDate('sd.effective_start', '<=', $fiscalEnd)
                     ->select(
                         'l.fm_lesson_code as lesson_code',
                         'sd.start_time as det_start_time',

--- a/resources/views/csv/lesson_csv.blade.php
+++ b/resources/views/csv/lesson_csv.blade.php
@@ -84,12 +84,56 @@
             </p>
         </div>
 
-        {{-- ヘッダー例 --}}
+        {{-- サンプルCSV --}}
         <div class="mb-4">
-            <h6 class="fw-bold">CSVヘッダー例</h6>
-            <pre class="bg-light p-2 rounded small">id,lesson_name,lesson_code,note,lesson_minute,lesson_type,ps_unique_lesson_code,fm_lesson_code,created_at,updated_at
-1,Global,BW,,45,kids,,,
-,NewLesson,NL,,30,Adults,PS001,FM001,</pre>
+            <h6 class="fw-bold">CSVサンプル</h6>
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle small">
+                    <thead class="table-light">
+                        <tr>
+                            <th>id</th>
+                            <th>lesson_name</th>
+                            <th>lesson_code</th>
+                            <th>note</th>
+                            <th>lesson_minute</th>
+                            <th>lesson_type</th>
+                            <th>ps_unique_lesson_code</th>
+                            <th>fm_lesson_code</th>
+                            <th>created_at</th>
+                            <th>updated_at</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>Global</td>
+                            <td>BW</td>
+                            <td class="text-muted">空欄</td>
+                            <td>45</td>
+                            <td>kids</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted">空欄</td>
+                            <td>NewLesson</td>
+                            <td>NL</td>
+                            <td class="text-muted">空欄</td>
+                            <td>30</td>
+                            <td>Adults</td>
+                            <td>PS001</td>
+                            <td>FM001</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p class="text-muted small mb-0">
+                ※ <code>created_at</code> / <code>updated_at</code> はインポート時に無視されます。空欄セルは <code>null</code> として保存されます。
+            </p>
         </div>
 
         {{-- インポートフォーム --}}

--- a/resources/views/csv/schedule_csv.blade.php
+++ b/resources/views/csv/schedule_csv.blade.php
@@ -28,14 +28,34 @@
     </div>
     <div class="card-body">
         <p class="text-muted mb-3">
-            schedule_lines + schedule_details の全件を FileMaker 形式の CSV でダウンロードします。<br>
-            ファイル名：<code>schedules_YYYYmmdd_His.csv</code>　文字コード：UTF-8<br>
+            StartDate が選択年度内の schedule_lines + schedule_details を FileMaker 形式の CSV でダウンロードします。<br>
+            年度は 4月1日〜翌年3月31日 です。例：2026年度 = 2026/04/01〜2027/03/31<br>
+            過去年度に開始したデータは、EndDate が対象年度にはみ出していてもダウンロード対象外です。<br>
+            ファイル名：<code>schedules_YYYYfy_YYYYmmdd_His.csv</code>　文字コード：UTF-8<br>
             同一 schedule_line に複数 detail がある場合、1行目のみ schedule_line 情報を出力し、2行目以降は空白になります（FileMaker 形式）。<br>
             エクスポートした CSV をそのままインポートすることができます。
         </p>
-        <a href="{{ route('csv.schedules.export') }}" class="btn btn-success">
-            <i class="fas fa-download me-1"></i>CSV をダウンロード
-        </a>
+        <form action="{{ route('csv.schedules.export') }}" method="GET" class="row g-3 align-items-end">
+            <div class="col-md-4 col-lg-3">
+                <label for="fiscal_year" class="form-label fw-bold">対象年度</label>
+                <select id="fiscal_year" name="fiscal_year" class="form-select @error('fiscal_year') is-invalid @enderror" required>
+                    <option value="">年度を選択</option>
+                    @foreach ($fiscalYears as $year)
+                        <option value="{{ $year }}" @selected((string) old('fiscal_year', $currentFiscalYear) === (string) $year)>
+                            {{ $year }}年度
+                        </option>
+                    @endforeach
+                </select>
+                @error('fiscal_year')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+            <div class="col-md-auto">
+                <button type="submit" class="btn btn-success">
+                    <i class="fas fa-download me-1"></i>CSV をダウンロード
+                </button>
+            </div>
+        </form>
     </div>
 </div>
 
@@ -93,11 +113,102 @@
         {{-- サンプルCSV --}}
         <div class="mb-4">
             <h6 class="fw-bold">CSVサンプル（FileMaker 形式）</h6>
-            <pre class="bg-light p-2 rounded small" style="overflow-x:auto;">EndDate,EndTime,LineID,StartDate,StartTime,ClassSlots::cClassName,ClassSlots::EndDate,ClassSlots::LineID,ClassSlots::StartDate,ClassSlots::StartTime,Days::DayName,Employees ＭＡＩＮ::EmployeeCode,Schools::SchoolNumName,district_name,department_name
-2027/03/31,21:20,71446,2026/04/13,15:20,AN,2027/03/31,71446,2026/04/13,15:35,Monday,014064,103 - Kusatsu,Kinki,ECC
-,,,,,BX,2027/03/31,71446,2026/04/13,16:40,,,,
-,,,,,CP,2027/03/31,71446,2026/04/13,17:55,,,,
-,,,,,Enjoy Elem B,2027/03/31,71446,2026/04/13,19:10,,,,</pre>
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle small">
+                    <thead class="table-light">
+                        <tr>
+                            <th>EndDate</th>
+                            <th>EndTime</th>
+                            <th>LineID</th>
+                            <th>StartDate</th>
+                            <th>StartTime</th>
+                            <th>ClassSlots::cClassName</th>
+                            <th>ClassSlots::EndDate</th>
+                            <th>ClassSlots::LineID</th>
+                            <th>ClassSlots::StartDate</th>
+                            <th>ClassSlots::StartTime</th>
+                            <th>Days::DayName</th>
+                            <th>Employees ＭＡＩＮ::EmployeeCode</th>
+                            <th>Schools::SchoolNumName</th>
+                            <th>district_name</th>
+                            <th>department_name</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>2027/03/31</td>
+                            <td>21:20</td>
+                            <td>71446</td>
+                            <td>2026/04/13</td>
+                            <td>15:20</td>
+                            <td>AN</td>
+                            <td>2027/03/31</td>
+                            <td>71446</td>
+                            <td>2026/04/13</td>
+                            <td>15:35</td>
+                            <td>Monday</td>
+                            <td>014064</td>
+                            <td>103 - Kusatsu</td>
+                            <td>Kinki</td>
+                            <td>ECC</td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td>BX</td>
+                            <td>2027/03/31</td>
+                            <td>71446</td>
+                            <td>2026/04/13</td>
+                            <td>16:40</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td>CP</td>
+                            <td>2027/03/31</td>
+                            <td>71446</td>
+                            <td>2026/04/13</td>
+                            <td>17:55</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td>Enjoy Elem B</td>
+                            <td>2027/03/31</td>
+                            <td>71446</td>
+                            <td>2026/04/13</td>
+                            <td>19:10</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p class="text-muted small mb-0">
+                ※ 同一 schedule_line に複数 detail がある場合、2行目以降の schedule_line 系カラムは CSV 上では空欄になります。
+            </p>
         </div>
 
         {{-- インポートフォーム --}}

--- a/resources/views/csv/user_csv.blade.php
+++ b/resources/views/csv/user_csv.blade.php
@@ -97,12 +97,83 @@
             </p>
         </div>
 
-        {{-- ヘッダー例 --}}
+        {{-- サンプルCSV --}}
         <div class="mb-4">
-            <h6 class="fw-bold">CSVヘッダー例</h6>
-            <pre class="bg-light p-2 rounded small" style="overflow-x:auto;">id,family_name,first_name,middle_name,name_in_kana,email,gender,note,employee_code,address,phone_number,district_name,department_name,role,employment_start_date,employment_end_date,employment_type_name,employment_type_code,employment_note
-1,山田,太郎,,やまだたろう,taro@example.com,male,,000001,東京都渋谷区1-1,090-1234-5678,東京,営業部,general,2024-04-01,,正社員,SEI,
-,鈴木,花子,,すずきはなこ,hanako@example.com,female,,000002,,,大阪,総務部,admin,2024-04-01,,,,,</pre>
+            <h6 class="fw-bold">CSVサンプル</h6>
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle small">
+                    <thead class="table-light">
+                        <tr>
+                            <th>id</th>
+                            <th>family_name</th>
+                            <th>first_name</th>
+                            <th>middle_name</th>
+                            <th>name_in_kana</th>
+                            <th>email</th>
+                            <th>gender</th>
+                            <th>note</th>
+                            <th>employee_code</th>
+                            <th>address</th>
+                            <th>phone_number</th>
+                            <th>district_name</th>
+                            <th>department_name</th>
+                            <th>role</th>
+                            <th>employment_start_date</th>
+                            <th>employment_end_date</th>
+                            <th>employment_type_name</th>
+                            <th>employment_type_code</th>
+                            <th>employment_note</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>Yamada</td>
+                            <td>Taro</td>
+                            <td class="text-muted">空欄</td>
+                            <td>やまだたろう</td>
+                            <td>taro@example.com</td>
+                            <td>male</td>
+                            <td class="text-muted">空欄</td>
+                            <td>000001</td>
+                            <td>東京都渋谷区1-1</td>
+                            <td>090-1234-5678</td>
+                            <td>Tokyo</td>
+                            <td>Sales</td>
+                            <td>general</td>
+                            <td>2024-04-01</td>
+                            <td class="text-muted">空欄</td>
+                            <td>Full-time</td>
+                            <td>FT</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted">空欄</td>
+                            <td>Suzuki</td>
+                            <td>Hanako</td>
+                            <td class="text-muted">空欄</td>
+                            <td>すずきはなこ</td>
+                            <td>hanako@example.com</td>
+                            <td>female</td>
+                            <td class="text-muted">空欄</td>
+                            <td>000002</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td>Osaka</td>
+                            <td>Admin</td>
+                            <td>admin</td>
+                            <td>2024-04-01</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                            <td class="text-muted">空欄</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p class="text-muted small mb-0">
+                ※ <code>password</code> はインポート・エクスポート対象外です。新規作成時は初期パスワードが自動設定されます。
+            </p>
         </div>
 
         {{-- インポートフォーム --}}


### PR DESCRIPTION
## 実装・技術概要

Schedule CSV Download に年度フィルターを追加しました。

年度は `4月1日〜翌年3月31日` として扱い、CSV Download 時に対象年度の選択を必須にしています。  
抽出条件は **「Schedule の StartDate が選択年度内にあること」** です。

例:

- 2026年度: `2026/04/01〜2027/03/31`
- `2026/04/22〜2027/04/23` のデータは 2026年度に含まれる
- 同データは 2027年度には含まれない
- `2025/04/22〜2027/04/23` のように過去年度開始で EndDate だけはみ出しているデータは対象外

これにより、EndDate の記入ミスや期間の閉じ忘れによって、過去年度の Schedule が後続年度のCSVに混入することを防ぎます。

---

## 変更ファイル

### `app/Http/Controllers/ScheduleCsvController.php`

Schedule CSV画面とエクスポート処理に年度指定を追加しました。

主な変更:

- 現在年度を基準に年度選択リストを生成
- CSV Export 時に `fiscal_year` を必須バリデーション
- 不正な年度指定時はエラー表示
- ダウンロードファイル名に年度を追加

目的:

- CSV Download 時に年度指定を必須化するため
- ユーザーが意図しない全件ダウンロードを行わないようにするため

---

### `app/Services/ScheduleCsv/ScheduleCsvExportService.php`

Schedule CSVの抽出条件を年度指定に対応させました。

主な変更:

- `streamCsv()` に `$fiscalYear` を追加
- 年度開始日・終了日を算出
  - `YYYY-04-01`
  - `YYYY+1-03-31`
- `schedule_lines.effective_start` が年度内のデータのみ出力
- `schedule_details.effective_start` も年度内のデータのみ出力

目的:

- 選択年度に開始したScheduleのみCSV出力するため
- EndDateの入力ミスや過去年度データの残存による混入を防ぐため

---

### `resources/views/csv/schedule_csv.blade.php`

Schedule CSV画面のエクスポートUIと説明を更新しました。

主な変更:

- CSVダウンロードリンクを年度選択フォームに変更
- 対象年度のselectを追加
- 年度定義を画面上に明記
- 過去年度開始データは、EndDateが対象年度にはみ出していても対象外である旨を明記
- CSVサンプルを `pre` 表示からテーブル形式に変更
- FileMaker形式の「2行目以降はschedule_line系カラムが空欄」を見やすく表示

目的:

- ユーザーがDownload条件を誤解しないようにするため
- FileMaker形式CSVの構造を画面上で分かりやすく確認できるようにするため

---

## 訂正理由

当初は「年度期間と有効期間が重なるScheduleを含める」overlap条件で実装していました。

しかし、この条件では以下のようなデータが複数年度に含まれます。

```text
2026/04/22〜2027/04/23