### PR TITLE
Teacher Master List

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -74,6 +74,61 @@ class AdminController extends Controller
         return view('admin.dashboard', compact('users', 'word', 'fields'));
     }
 
+    public function masterList(): View
+    {
+        $this->authorize('viewAny', User::class);
+
+        $today = today()->toDateString();
+
+        $rows = $this->scopeService->targetUserQuery()
+            ->with([
+                'employmentTerms' => fn ($q) => $q
+                    ->orderByRaw('CASE WHEN start_date <= ? AND (end_date IS NULL OR end_date >= ?) THEN 0 ELSE 1 END', [$today, $today])
+                    ->orderByDesc('start_date'),
+                'restPatternAssignments' => fn ($q) => $q
+                    ->with('pattern')
+                    ->orderByRaw('CASE WHEN start_date <= ? AND (end_date IS NULL OR end_date >= ?) THEN 0 ELSE 1 END', [$today, $today])
+                    ->orderByDesc('start_date'),
+            ])
+            ->orderBy('employee_code')
+            ->get()
+            ->map(function (User $user) use ($today) {
+                $term = $user->employmentTerms->first(
+                    fn ($row) => $row->start_date?->toDateString() <= $today
+                        && (is_null($row->end_date) || $row->end_date->toDateString() >= $today)
+                ) ?? $user->employmentTerms->first();
+
+                $restAssignment = $user->restPatternAssignments->first(
+                    fn ($row) => $row->start_date?->toDateString() <= $today
+                        && (is_null($row->end_date) || $row->end_date->toDateString() >= $today)
+                ) ?? $user->restPatternAssignments->first();
+
+                return [
+                    'profile_url' => route('admin.user.profile', $user),
+                    'employee_code' => $user->employee_code,
+                    'family_name' => $user->family_name,
+                    'first_name' => $user->first_name,
+                    'nick_name' => $user->middle_name,
+                    'email' => $user->email,
+                    'phone_number' => $user->phone_number,
+                    'address' => $user->address,
+                    'user_note' => $user->note,
+                    'employment_start_date' => $term?->start_date?->format('Y-m-d'),
+                    'employment_end_date' => $term?->end_date?->format('Y-m-d'),
+                    'employment_type_code' => $term?->type_code,
+                    'employment_note' => $term?->note,
+                    'rest_pattern_name' => $restAssignment?->pattern?->name,
+                ];
+            })
+            ->values();
+
+        $summary = [
+            'count' => $rows->count(),
+        ];
+
+        return view('user.master_list', compact('rows', 'summary'));
+    }
+
     /**
      * ダッシュボード・検索共通のユーザークエリ構築
      * 検索ワード・対象フィールド・ソート順を受け取り [users, word, fields] を返す

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -82,6 +82,8 @@ class AdminController extends Controller
 
         $rows = $this->scopeService->targetUserQuery()
             ->with([
+                'district',
+                'department',
                 'employmentTerms' => fn ($q) => $q
                     ->orderByRaw('CASE WHEN start_date <= ? AND (end_date IS NULL OR end_date >= ?) THEN 0 ELSE 1 END', [$today, $today])
                     ->orderByDesc('start_date'),
@@ -118,6 +120,10 @@ class AdminController extends Controller
                     'employment_type_code' => $term?->type_code,
                     'employment_note' => $term?->note,
                     'rest_pattern_name' => $restAssignment?->pattern?->name,
+                    'district_name' => $user->district?->name,
+                    'department_name' => $user->department?->name,
+                    'created_at' => $user->created_at?->format('Y-m-d H:i'),
+                    'updated_at' => $user->updated_at?->format('Y-m-d H:i'),
                 ];
             })
             ->values();

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -74,13 +74,46 @@ class AdminController extends Controller
         return view('admin.dashboard', compact('users', 'word', 'fields'));
     }
 
-    public function masterList(): View
+    public function masterList(Request $request): View
     {
         $this->authorize('viewAny', User::class);
 
-        $today = today()->toDateString();
+        $todayDate = today();
+        $today = $todayDate->toDateString();
+        $search = trim((string) $request->query('search', ''));
+        $statuses = collect((array) $request->query('statuses', ['active']))
+            ->intersect(['active', 'terminated'])
+            ->values();
 
-        $rows = $this->scopeService->targetUserQuery()
+        if ($statuses->isEmpty()) {
+            $statuses = collect(['active']);
+        }
+
+        $query = $this->scopeService->targetUserQuery()
+            ->when(filled($search), function (Builder $q) use ($search) {
+                $q->where(function (Builder $w) use ($search) {
+                    $w->whereLikeInsensitive('employee_code', $search)
+                        ->orWhereLikeInsensitive('first_name', $search)
+                        ->orWhereLikeInsensitive('family_name', $search)
+                        ->orWhereLikeInsensitive('phone_number', $search)
+                        ->orWhereHas('employmentTerms', fn (Builder $term) => $term->whereLikeInsensitive('type_code', $search))
+                        ->orWhereHas('restPatternAssignments.pattern', fn (Builder $pattern) => $pattern
+                            ->whereLikeInsensitive('name', $search)
+                            ->orWhereLikeInsensitive('code', $search));
+                });
+            })
+            ->where(function (Builder $q) use ($statuses, $today, $todayDate) {
+                if ($statuses->contains('active')) {
+                    $q->whereHas('employmentTerms', fn (Builder $term) => $term->currentAt($today));
+                }
+
+                if ($statuses->contains('terminated')) {
+                    $method = $statuses->contains('active') ? 'orWhere' : 'where';
+                    $q->{$method}(fn (Builder $terminated) => $terminated->terminated($todayDate));
+                }
+            });
+
+        $rows = $query
             ->with([
                 'district',
                 'department',
@@ -132,7 +165,7 @@ class AdminController extends Controller
             'count' => $rows->count(),
         ];
 
-        return view('user.master_list', compact('rows', 'summary'));
+        return view('user.master_list', compact('rows', 'summary', 'search', 'statuses'));
     }
 
     /**

--- a/app/Models/EmploymentTerm.php
+++ b/app/Models/EmploymentTerm.php
@@ -31,7 +31,10 @@ class EmploymentTerm extends Model
     /** 今日の日付で有効な雇用期間を取得するスコープ */
     public function scopeCurrentAt(Builder $q, $date = null): Builder
     {
-        $d = ($date ?? today())->toDateString();
+        $d = $date instanceof \Carbon\CarbonInterface
+            ? $date->toDateString()
+            : ($date ?? today()->toDateString());
+
         return $q->where('start_date', '<=', $d)
             ->where(function ($qq) use ($d) {
                 $qq->whereNull('end_date')->orWhere('end_date', '>=', $d);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -162,6 +162,11 @@ class User extends Authenticatable
         return $this->hasMany(EmploymentTerm::class);
     }
 
+    public function restPatternAssignments()
+    {
+        return $this->hasMany(UserRestPattern::class);
+    }
+
     /** 最新の雇用期間を1件だけ取得（N+1 を避けるための hasOne + latestOfMany） */
     public function latestEmploymentTerm()
     {

--- a/public/css/masterList.css
+++ b/public/css/masterList.css
@@ -1,0 +1,56 @@
+.page-wrap {
+    max-width: 1320px;
+    margin: 20px auto;
+    padding: 0 16px;
+}
+
+@media (min-width: 992px) {
+    .page-wrap {
+        padding: 0;
+    }
+}
+
+.header-box {
+    background: #f8f9fa;
+    padding: 12px 16px;
+    border-radius: 8px;
+    border: 1px solid #78a3fa;
+}
+
+.header-box .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    font-size: 14px;
+}
+
+.master-list-page .muted {
+    color: #6c757d;
+}
+
+#masterListSheet {
+    width: 100%;
+    height: auto;
+}
+
+h1 {
+    margin-bottom: 1.5rem;
+}
+
+.jspreadsheet tbody td {
+    font-size: 0.95rem;
+}
+
+#masterListSheet a {
+    text-decoration: none !important;
+}
+
+#masterListSheet .btn.btn-sm.btn-outline-primary {
+    padding: 2px 8px;
+    line-height: 0.9;
+}
+
+#masterListSheet td,
+#masterListSheet .jss td {
+    color: #000000 !important;
+}

--- a/public/css/masterList.css
+++ b/public/css/masterList.css
@@ -28,6 +28,13 @@
     color: #6c757d;
 }
 
+.master-search {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 12px 16px;
+}
+
 #masterListSheet {
     width: 100%;
     height: auto;

--- a/public/js/masterList.js
+++ b/public/js/masterList.js
@@ -51,6 +51,10 @@ document.addEventListener('DOMContentLoaded', function () {
         r.rest_pattern_name ?? '',
         r.employment_note ?? '',
         r.user_note ?? '',
+        r.district_name ?? '',
+        r.department_name ?? '',
+        r.created_at ?? '',
+        r.updated_at ?? '',
     ]));
 
     const scrollWrapper = document.createElement('div');
@@ -76,6 +80,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 { title: 'Rest Pattern', width: 160, readOnly: true },
                 { title: 'Employment Note', width: 240, readOnly: true },
                 { title: 'User Note', width: 260, readOnly: true },
+                { title: 'District', width: 160, readOnly: true },
+                { title: 'Department', width: 160, readOnly: true },
+                { title: 'Created At', width: 150, readOnly: true },
+                { title: 'Last Updated', width: 150, readOnly: true },
             ],
             allowInsertRow: false,
             allowManualInsertRow: false,

--- a/public/js/masterList.js
+++ b/public/js/masterList.js
@@ -1,0 +1,93 @@
+// === Ctrl+S / Cmd+S block ===
+(function () {
+    function blockSave(e) {
+        const isSaveKey =
+            (e.key && (e.key === 's' || e.key === 'S')) ||
+            (e.code && e.code === 'KeyS');
+
+        if ((e.ctrlKey || e.metaKey) && isSaveKey) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            return false;
+        }
+    }
+
+    window.addEventListener('keydown', blockSave, { capture: true });
+    window.addEventListener('keypress', blockSave, { capture: true });
+    document.addEventListener('keydown', blockSave, { capture: true });
+    document.addEventListener('keypress', blockSave, { capture: true });
+})();
+
+document.addEventListener('DOMContentLoaded', function () {
+    const dataEl = document.getElementById('masterListData');
+    const el = document.getElementById('masterListSheet');
+    if (!dataEl || !el) return;
+
+    let rows = [];
+    try {
+        rows = JSON.parse(dataEl.textContent || '[]');
+    } catch (e) {
+        console.error('Failed to parse masterListData JSON', e);
+        rows = [];
+    }
+
+    function detailsBtn(url) {
+        if (!url) return '';
+        return `<a href="${url}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary">Details</a>`;
+    }
+
+    const matrix = rows.map(r => ([
+        detailsBtn(r.profile_url),
+        r.employee_code ?? '',
+        r.family_name ?? '',
+        r.first_name ?? '',
+        r.nick_name ?? '',
+        r.email ?? '',
+        r.phone_number ?? '',
+        r.address ?? '',
+        r.employment_start_date ?? '',
+        r.employment_end_date ?? '',
+        r.employment_type_code ?? '',
+        r.rest_pattern_name ?? '',
+        r.employment_note ?? '',
+        r.user_note ?? '',
+    ]));
+
+    const scrollWrapper = document.createElement('div');
+    scrollWrapper.style.cssText = 'width:100%;overflow-x:auto;-webkit-overflow-scrolling:touch;';
+    el.parentNode.insertBefore(scrollWrapper, el);
+    scrollWrapper.appendChild(el);
+
+    jspreadsheet(el, {
+        worksheets: [{
+            data: matrix,
+            columns: [
+                { title: 'Details', width: 90, readOnly: true, type: 'html' },
+                { title: 'Employee Code', width: 130, readOnly: true },
+                { title: 'Family Name', width: 140, readOnly: true },
+                { title: 'First Name', width: 140, readOnly: true },
+                { title: 'Nick Name', width: 140, readOnly: true },
+                { title: 'Email', width: 240, readOnly: true },
+                { title: 'Phone Number', width: 150, readOnly: true },
+                { title: 'Address', width: 260, readOnly: true },
+                { title: 'Start Date', width: 120, readOnly: true },
+                { title: 'End Date', width: 120, readOnly: true },
+                { title: 'Type Code', width: 120, readOnly: true },
+                { title: 'Rest Pattern', width: 160, readOnly: true },
+                { title: 'Employment Note', width: 240, readOnly: true },
+                { title: 'User Note', width: 260, readOnly: true },
+            ],
+            allowInsertRow: false,
+            allowManualInsertRow: false,
+            allowDeleteRow: false,
+            allowInsertColumn: false,
+            allowDeleteColumn: false,
+            allowRenameColumn: false,
+            allowComments: false,
+            allowSaving: false,
+            freezeColumns: 2,
+            tableOverflow: false,
+            tableHeight: '560px',
+        }],
+    });
+});

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -4,9 +4,14 @@
 <div class="container">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1 class="mb-0">管理者ダッシュボード</h1>
-        <a href="{{ route('register.showForm') }}" class="btn btn-sm btn-outline-secondary">
-            Register
-        </a>
+        <div class="d-flex align-items-center gap-2">
+            <a href="{{ route('user.master_list') }}" class="btn btn-sm btn-outline-primary">
+                Master List
+            </a>
+            <a href="{{ route('register.showForm') }}" class="btn btn-sm btn-outline-secondary">
+                Register
+            </a>
+        </div>
     </div>
     <p class="text-center text-muted mb-4">ここでは管理者向けの情報を表示します。</p>
 

--- a/resources/views/user/master_list.blade.php
+++ b/resources/views/user/master_list.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.app')
+
+@section('title', 'Teacher Master List')
+
+@push('styles')
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsuites/dist/jsuites.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5/dist/jspreadsheet.min.css">
+<link rel="stylesheet" href="{{ asset('css/masterList.css') }}?v={{ filemtime(public_path('css/masterList.css')) }}">
+@endpush
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jsuites/dist/jsuites.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5/dist/index.min.js"></script>
+<script src="{{ asset('js/masterList.js') }}?v={{ filemtime(public_path('js/masterList.js')) }}"></script>
+@endpush
+
+@section('content')
+<div class="page-wrap master-list-page">
+  <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+    <h1 class="mb-0">Teacher Master List</h1>
+
+    <a href="{{ route('admin.dashboard') }}" class="btn btn-sm btn-outline-secondary">
+      Dashboard
+    </a>
+  </div>
+
+  <div class="header-box mb-4">
+    <div class="meta w-100">
+      <div>Total Teachers: <strong>{{ number_format($summary['count'] ?? 0) }}</strong></div>
+      <div class="muted">Current employment/rest pattern is shown first when available.</div>
+    </div>
+  </div>
+
+  <div id="masterListSheet"></div>
+
+  <script id="masterListData" type="application/json">
+    @json($rows)
+  </script>
+</div>
+@endsection

--- a/resources/views/user/master_list.blade.php
+++ b/resources/views/user/master_list.blade.php
@@ -24,6 +24,50 @@
     </a>
   </div>
 
+  <form method="GET" action="{{ route('user.master_list') }}" class="master-search mb-3" id="masterSearchForm">
+    <div class="row g-3 align-items-end">
+      <div class="col-lg-6">
+        <label for="masterSearch" class="form-label">Search</label>
+        <input type="text"
+          id="masterSearch"
+          name="search"
+          value="{{ $search ?? '' }}"
+          class="form-control form-control-sm"
+          placeholder="Employee Code / First Name / Last Name / Phone / Type Code / Rest Pattern">
+      </div>
+
+      <div class="col-lg-4">
+        <label class="form-label d-block">Status</label>
+        <div class="d-flex flex-wrap gap-3">
+          <div class="form-check">
+            <input class="form-check-input master-status-check"
+              type="checkbox"
+              id="status-active"
+              name="statuses[]"
+              value="active"
+              {{ $statuses->contains('active') ? 'checked' : '' }}>
+            <label class="form-check-label" for="status-active">在籍者</label>
+          </div>
+
+          <div class="form-check">
+            <input class="form-check-input master-status-check"
+              type="checkbox"
+              id="status-terminated"
+              name="statuses[]"
+              value="terminated"
+              {{ $statuses->contains('terminated') ? 'checked' : '' }}>
+            <label class="form-check-label" for="status-terminated">退職者</label>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-2 d-flex gap-2">
+        <button type="submit" class="btn btn-sm btn-primary">Search</button>
+        <a href="{{ route('user.master_list') }}" class="btn btn-sm btn-outline-secondary">Clear</a>
+      </div>
+    </div>
+  </form>
+
   <div class="header-box mb-4">
     <div class="meta w-100">
       <div>Total Teachers: <strong>{{ number_format($summary['count'] ?? 0) }}</strong></div>
@@ -37,4 +81,18 @@
     @json($rows)
   </script>
 </div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const boxes = document.querySelectorAll('.master-status-check');
+    boxes.forEach(box => {
+      box.addEventListener('change', () => {
+        const checked = Array.from(boxes).filter(b => b.checked);
+        if (checked.length === 0) {
+          box.checked = true;
+        }
+      });
+    });
+  });
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,6 +105,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/admin/register', [AdminController::class, 'showForm'])->name('register.showForm');
     Route::post('/admin/register', [AdminController::class, 'register'])->name('register.submit');
     Route::get('/admin/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
+    Route::get('/user/master-list', [AdminController::class, 'masterList'])->name('user.master_list');
 });
 
 //プロファイル関連


### PR DESCRIPTION
## Teacher Master List 追加概要

### 実装内容

管理者ダッシュボードから遷移できる `Teacher Master List` 画面を追加しました。

追加した主な内容は以下です。

- dashboard 右上に `Master List` ボタンを追加
- 管理者用ルート `/user/master-list` を追加
- `resources/views/user/master_list.blade.php` を新規作成
- `public/js/masterList.js` を新規作成
- `public/css/masterList.css` を新規作成
- `User` モデルに `restPatternAssignments()` リレーションを追加
- `AdminController` に `masterList()` メソッドを追加

---

## 追加目的

既存の管理者ダッシュボードは検索・個別確認に向いていますが、全体の教職員情報を横断的に確認するには一覧性が不足していました。

そのため、以下の情報を一画面で確認できる master list を追加しました。

- 基本ユーザー情報
- 雇用条件
- 休日パターン
- 所属 District / Department
- 作成日・最終更新日

これにより、登録情報の確認、雇用条件の確認、所属管理、マスタデータの棚卸しがしやすくなります。

---

## 技術概要

### 1. ルート追加

`routes/web.php` に管理者向けルートを追加しました。

```php
Route::get('/user/master-list', [AdminController::class, 'masterList'])
    ->name('user.master_list');
```

既存の admin / super_admin 用 middleware group 内に追加しているため、管理者権限のあるユーザーのみアクセスできます。

---

### 2. Dashboard への導線追加

`resources/views/admin/dashboard.blade.php` の右上ボタン群に `Master List` を追加しました。

```blade
<a href="{{ route('user.master_list') }}" class="btn btn-sm btn-outline-primary">
    Master List
</a>
```

既存の `Register` ボタンと同じエリアに配置し、管理系操作への導線として自然に使えるようにしています。

---

### 3. Controller 側のデータ生成

`AdminController::masterList()` で一覧表示用データを生成しています。

取得対象は既存の管理スコープに合わせています。

```php
$this->scopeService->targetUserQuery()
```

これにより、管理者が現在選択している district / department の範囲内のユーザーだけが表示されます。

読み込んでいる関連データは以下です。

```php
->with([
    'district',
    'department',
    'employmentTerms',
    'restPatternAssignments',
])
```

雇用条件と休日パターンは、今日有効なものを優先して表示しています。現在有効なデータがない場合は、最新の履歴を fallback として表示します。

---

### 4. User モデルのリレーション追加

`User` モデルに `user_rest_patterns` への relation を追加しました。

```php
public function restPatternAssignments()
{
    return $this->hasMany(UserRestPattern::class);
}
```

これにより、ユーザーごとの休日パターン履歴を Eloquent 経由で扱えるようになっています。

---

### 5. Blade / JS / CSS の構成

`expenses/report.blade.php` と同じ方向性で、Blade 側ではデータを JSON として埋め込み、表示ロジックは JS に分離しています。

```blade
<script id="masterListData" type="application/json">
    @json($rows)
</script>
```

`public/js/masterList.js` では jSpreadsheet を使って読み取り専用テーブルを作成しています。

主な設定:

```js
allowInsertRow: false,
allowDeleteRow: false,
allowInsertColumn: false,
allowDeleteColumn: false,
allowSaving: false,
freezeColumns: 2,
tableHeight: '560px',
```

マスタ一覧として使うため、編集・行追加・削除は無効化しています。

---

## 表示項目

現在の Teacher Master List では以下を表示しています。

- Details
- Employee Code
- Family Name
- First Name
- Nick Name
- Email
- Phone Number
- Address
- Start Date
- End Date
- Type Code
- Rest Pattern
- Employment Note
- User Note
- District
- Department
- Created At
- Last Updated

`middle_name` は仕様に合わせて `Nick Name` として表示しています。

---

## 変更理由

### Master List ボタン

管理者が dashboard から直接一覧画面へ移動できるようにするためです。既存の登録導線と近い場所に配置することで、管理系操作をまとめています。

### 新規 Blade 作成

既存 dashboard のユーザー一覧とは用途が異なるため、別画面として作成しました。

dashboard は検索・個別操作向き、master list は一覧確認・棚卸し向きです。

### jSpreadsheet 採用

既存の `expenses/report.blade.php` と同じ UI 技術を使うことで、見た目・操作感・保守方法を揃えています。

### District / Department 追加

管理スコープが導入されているため、ユーザーがどの district / department に所属しているかを一覧上でも確認できるようにしました。

### Created At / Last Updated 追加

マスタ情報の作成・更新タイミングを確認できるようにするためです。登録漏れや古い情報の確認に役立ちます。

---

## 検証内容

以下を確認済みです。

```bash
node --check public/js/masterList.js
```

```bash
php -l app/Http/Controllers/AdminController.php
```

```bash
php -l app/Models/User.php
```

```bash
php -l routes/web.php
```

```bash
php artisan route:list --name=user.master_list
```

```bash
php artisan view:cache
php artisan view:clear
```