### PR TITLE
Feature/attandance search

### DIFF
--- a/app/Http/Controllers/UserAttendanceSearchController.php
+++ b/app/Http/Controllers/UserAttendanceSearchController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Services\Calendar\CalendarResolver;
+use App\Services\Calendar\EventType;
+use App\Services\Calendar\PlanGroup;
+use App\Services\CurrentScopeService;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class UserAttendanceSearchController extends Controller
+{
+    public function __construct(
+        private CurrentScopeService $scopeService,
+        private CalendarResolver $resolver
+    ) {}
+
+    public function attendance(Request $request): View
+    {
+        $this->authorize('viewAny', User::class);
+
+        $validated = $request->validate([
+            'date' => ['nullable', 'date'],
+            'regular_on' => ['nullable', 'boolean'],
+        ]);
+
+        $date = Carbon::parse($validated['date'] ?? today()->toDateString())->startOfDay();
+        $mode = $request->boolean('regular_on') ? 'regular_on' : 'available';
+        $searched = $request->hasAny(['date', 'regular_on']);
+
+        $results = collect();
+
+        if ($searched) {
+            $users = $this->scopeService->targetUserQuery()
+                ->whereHas('employmentTerms', fn (Builder $term) => $term->currentAt($date->toDateString()))
+                ->with([
+                    'district',
+                    'department',
+                    'employmentTerms' => fn ($q) => $q
+                        ->currentAt($date->toDateString())
+                        ->orderByDesc('start_date'),
+                    'restPatternAssignments' => fn ($q) => $q
+                        ->with('pattern')
+                        ->activeBetween($date->toDateString(), $date->toDateString())
+                        ->orderByDesc('start_date'),
+                ])
+                ->orderBy('employee_code')
+                ->get();
+
+            $results = $users
+                ->map(fn (User $user) => $this->buildRow($user, $date))
+                ->filter(fn (array $row) => $mode === 'regular_on'
+                    ? $row['has_regular_on']
+                    : (! $row['has_on'] && ! $row['has_off']))
+                ->values();
+        }
+
+        return view('user.search.attendance', [
+            'date' => $date->toDateString(),
+            'mode' => $mode,
+            'searched' => $searched,
+            'results' => $results,
+        ]);
+    }
+
+    private function buildRow(User $user, Carbon $date): array
+    {
+        $events = collect($this->resolver->build($user, $date->copy()->startOfDay(), $date->copy()->endOfDay()));
+        $employmentTerm = $user->employmentTerms->first();
+        $restPatternAssignment = $user->restPatternAssignments->first();
+
+        $hasOn = $events->contains(fn (array $event) => $this->eventType($event) === EventType::ON);
+        $hasOff = $events->contains(fn (array $event) => $this->eventType($event) === EventType::OFF);
+        $hasRegularOn = $events->contains(fn (array $event) =>
+            $this->eventType($event) === EventType::ON
+            && $this->planGroup($event) === PlanGroup::REGULAR_PLAN
+        );
+
+        return [
+            'user' => $user,
+            'has_on' => $hasOn,
+            'has_off' => $hasOff,
+            'has_regular_on' => $hasRegularOn,
+            'type_code' => $employmentTerm?->type_code,
+            'rest_pattern' => $restPatternAssignment?->pattern?->name,
+        ];
+    }
+
+    private function eventType(array $event): ?string
+    {
+        return $event['extendedProps']['type'] ?? $event['display'] ?? null;
+    }
+
+    private function planGroup(array $event): ?string
+    {
+        return $event['extendedProps']['plan_group']
+            ?? $event['extendedProps']['plan']
+            ?? null;
+    }
+}

--- a/app/Http/Controllers/UserAttendanceSearchController.php
+++ b/app/Http/Controllers/UserAttendanceSearchController.php
@@ -25,12 +25,13 @@ class UserAttendanceSearchController extends Controller
 
         $validated = $request->validate([
             'date' => ['nullable', 'date'],
+            'mode' => ['nullable', 'in:available,regular_on'],
             'regular_on' => ['nullable', 'boolean'],
         ]);
 
         $date = Carbon::parse($validated['date'] ?? today()->toDateString())->startOfDay();
-        $mode = $request->boolean('regular_on') ? 'regular_on' : 'available';
-        $searched = $request->hasAny(['date', 'regular_on']);
+        $mode = $validated['mode'] ?? ($request->boolean('regular_on') ? 'regular_on' : 'available');
+        $searched = $request->hasAny(['date', 'mode', 'regular_on']);
 
         $results = collect();
 

--- a/app/Services/Calendar/CalendarResolver.php
+++ b/app/Services/Calendar/CalendarResolver.php
@@ -169,6 +169,8 @@ class CalendarResolver
                 // extendedProps の sort_order が無ければ自動補完
                 $arr['extendedProps'] = $arr['extendedProps'] ?? [];
                 $arr['extendedProps']['level'] = $arr['extendedProps']['level'] ?? ($arr['level'] ?? 9);
+                $arr['extendedProps']['type'] = $arr['extendedProps']['type'] ?? ($arr['type'] ?? null);
+                $arr['extendedProps']['plan_group'] = $arr['extendedProps']['plan_group'] ?? ($arr['planGroup'] ?? null);
 
                 $events[] = $arr;
             }

--- a/app/Services/Calendar/CandidateEvent.php
+++ b/app/Services/Calendar/CandidateEvent.php
@@ -29,6 +29,11 @@ class CandidateEvent
 
     public function toArray(): array
     {
+        $extendedProps = $this->extendedProps;
+        $extendedProps['level'] = $extendedProps['level'] ?? $this->level;
+        $extendedProps['type'] = $extendedProps['type'] ?? $this->type;
+        $extendedProps['plan_group'] = $extendedProps['plan_group'] ?? $this->planGroup;
+
         return [
             'title' => $this->title,
             'start' => $this->start,
@@ -36,7 +41,7 @@ class CandidateEvent
             'allDay' => $this->allDay,
             'classNames' => $this->classNames,
             'display' => $this->type, // ←追加（背景塗りつぶしスタイル）provoder側での指定は無効（なぜか不明）。
-            'extendedProps' => $this->extendedProps,
+            'extendedProps' => $extendedProps,
         ];
     }
 }

--- a/resources/views/user/master_list.blade.php
+++ b/resources/views/user/master_list.blade.php
@@ -19,9 +19,14 @@
   <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
     <h1 class="mb-0">Teacher Master List</h1>
 
-    <a href="{{ route('admin.dashboard') }}" class="btn btn-sm btn-outline-secondary">
-      Dashboard
-    </a>
+    <div class="d-flex flex-wrap gap-2">
+      <a href="{{ route('user.search.attendance') }}" class="btn btn-sm btn-outline-primary">
+        Attendance Search
+      </a>
+      <a href="{{ route('admin.dashboard') }}" class="btn btn-sm btn-outline-secondary">
+        Dashboard
+      </a>
+    </div>
   </div>
 
   <form method="GET" action="{{ route('user.master_list') }}" class="master-search mb-3" id="masterSearchForm">

--- a/resources/views/user/search/attendance.blade.php
+++ b/resources/views/user/search/attendance.blade.php
@@ -1,0 +1,181 @@
+@extends('layouts.app')
+
+@section('title', 'Attendance Search')
+
+@section('content')
+<div class="page-wrap">
+  <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+    <h1 class="mb-0">Attendance Search</h1>
+    <a href="{{ route('user.master_list') }}" class="btn btn-sm btn-outline-secondary">Master List</a>
+  </div>
+
+  <form method="GET" action="{{ route('user.search.attendance') }}" class="card mb-3">
+    <div class="card-body">
+      <div class="row g-3 align-items-end">
+        <div class="col-md-3">
+          <label for="attendanceDate" class="form-label">Date</label>
+          <input type="date"
+                 id="attendanceDate"
+                 name="date"
+                 value="{{ old('date', $date) }}"
+                 class="form-control"
+                 required>
+        </div>
+
+        <div class="col-md-6">
+          <div class="form-check">
+            <input class="form-check-input"
+                   type="checkbox"
+                   id="regularOn"
+                   name="regular_on"
+                   value="1"
+                   @checked($mode === 'regular_on')>
+            <label class="form-check-label" for="regularOn">
+              通常出勤する人を探す（未チェック: 残業できる人）
+            </label>
+          </div>
+        </div>
+
+        <div class="col-md-3 d-flex gap-2">
+          <button type="submit" class="btn btn-primary">Search</button>
+          <a href="{{ route('user.search.attendance') }}" class="btn btn-outline-secondary">Clear</a>
+        </div>
+      </div>
+    </div>
+  </form>
+
+  @error('date')
+    <div class="alert alert-danger">{{ $message }}</div>
+  @enderror
+
+  @if($searched)
+    <div class="alert alert-light border mb-3">
+      <div>
+        Date: <strong>{{ $date }}</strong>
+        / Mode:
+        <strong>{{ $mode === 'regular_on' ? '通常出勤する人' : '残業できる人' }}</strong>
+        / Results: <strong>{{ number_format($results->count()) }}</strong>
+      </div>
+      <div class="text-muted small">
+        Calendar Resolver の最終returnで判定しています。
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table table-sm table-hover align-middle">
+        <thead>
+          <tr>
+            <th style="width: 44px;">
+              <input type="checkbox" class="form-check-input" id="selectAllEmails" aria-label="Select all emails">
+            </th>
+            <th>Employee Code</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Phone Number</th>
+            <th>Type Code</th>
+            <th>Rest Pattern</th>
+            <th>District</th>
+            <th>Department</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          @forelse($results as $row)
+            @php($user = $row['user'])
+            <tr>
+              <td>
+                <input type="checkbox"
+                       class="form-check-input email-check"
+                       value="{{ $user->email }}"
+                       @disabled(blank($user->email))
+                       aria-label="Select {{ $user->family_name }} {{ $user->first_name }} email">
+              </td>
+              <td>{{ $user->employee_code }}</td>
+              <td>{{ $user->family_name }} {{ $user->first_name }}</td>
+              <td>{{ $user->email }}</td>
+              <td>{{ $user->phone_number }}</td>
+              <td>{{ $row['type_code'] }}</td>
+              <td>{{ $row['rest_pattern'] }}</td>
+              <td>{{ $user->district?->name }}</td>
+              <td>{{ $user->department?->name }}</td>
+              <td class="text-end">
+                <a href="{{ route('admin.user.profile', $user) }}" class="btn btn-sm btn-outline-primary">Profile</a>
+                <a href="{{ route('calendar.index.user', $user) }}?month={{ substr($date, 0, 7) }}" class="btn btn-sm btn-outline-secondary">Schedule</a>
+              </td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="10" class="text-center text-muted py-4">No results.</td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+
+    <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+      <button type="button" class="btn btn-sm btn-primary" id="copySelectedEmails">
+        Copy selected emails
+      </button>
+      <input type="text"
+             class="form-control form-control-sm flex-grow-1"
+             id="selectedEmailsOutput"
+             readonly
+             placeholder="Selected emails for BCC">
+      <span class="small text-muted" id="selectedEmailsCount">0 selected</span>
+    </div>
+  @endif
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const selectAll = document.getElementById('selectAllEmails');
+    const checks = Array.from(document.querySelectorAll('.email-check'));
+    const output = document.getElementById('selectedEmailsOutput');
+    const count = document.getElementById('selectedEmailsCount');
+    const copyButton = document.getElementById('copySelectedEmails');
+
+    function selectedEmails() {
+      return checks
+        .filter(check => check.checked && check.value)
+        .map(check => check.value);
+    }
+
+    function refreshOutput() {
+      const emails = selectedEmails();
+      output.value = emails.join('; ');
+      count.textContent = `${emails.length} selected`;
+
+      if (selectAll) {
+        const enabled = checks.filter(check => !check.disabled);
+        selectAll.checked = enabled.length > 0 && enabled.every(check => check.checked);
+        selectAll.indeterminate = enabled.some(check => check.checked) && !selectAll.checked;
+      }
+    }
+
+    selectAll?.addEventListener('change', function () {
+      checks.forEach(check => {
+        if (!check.disabled) check.checked = selectAll.checked;
+      });
+      refreshOutput();
+    });
+
+    checks.forEach(check => check.addEventListener('change', refreshOutput));
+
+    copyButton?.addEventListener('click', async function () {
+      refreshOutput();
+      if (!output.value) return;
+
+      try {
+        await navigator.clipboard.writeText(output.value);
+        copyButton.textContent = 'Copied';
+        setTimeout(() => copyButton.textContent = 'Copy selected emails', 1200);
+      } catch (e) {
+        output.select();
+        document.execCommand('copy');
+      }
+    });
+
+    refreshOutput();
+  });
+</script>
+@endsection

--- a/resources/views/user/search/attendance.blade.php
+++ b/resources/views/user/search/attendance.blade.php
@@ -2,8 +2,45 @@
 
 @section('title', 'Attendance Search')
 
+@push('styles')
+<style>
+  .attendance-page {
+    max-width: 1320px;
+    margin: 20px auto;
+  }
+
+  .attendance-table {
+    min-width: 1120px;
+    table-layout: fixed;
+  }
+
+  .attendance-table th,
+  .attendance-table td {
+    vertical-align: middle;
+  }
+
+  .attendance-table .cell-nowrap {
+    white-space: nowrap;
+  }
+
+  .attendance-table .cell-truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .attendance-actions {
+    white-space: nowrap;
+  }
+
+  .attendance-actions .btn + .btn {
+    margin-left: 4px;
+  }
+</style>
+@endpush
+
 @section('content')
-<div class="page-wrap">
+<div class="attendance-page">
   <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
     <h1 class="mb-0">Attendance Search</h1>
     <a href="{{ route('user.master_list') }}" class="btn btn-sm btn-outline-secondary">Master List</a>
@@ -23,17 +60,11 @@
         </div>
 
         <div class="col-md-6">
-          <div class="form-check">
-            <input class="form-check-input"
-                   type="checkbox"
-                   id="regularOn"
-                   name="regular_on"
-                   value="1"
-                   @checked($mode === 'regular_on')>
-            <label class="form-check-label" for="regularOn">
-              通常出勤する人を探す（未チェック: 残業できる人）
-            </label>
-          </div>
+          <label for="attendanceMode" class="form-label">Search Type</label>
+          <select id="attendanceMode" name="mode" class="form-select">
+            <option value="available" @selected($mode === 'available')>Search teachers with a regular day off</option>
+            <option value="regular_on" @selected($mode === 'regular_on')>Search teachers with a regular shift</option>
+          </select>
         </div>
 
         <div class="col-md-3 d-flex gap-2">
@@ -53,36 +84,51 @@
       <div>
         Date: <strong>{{ $date }}</strong>
         / Mode:
-        <strong>{{ $mode === 'regular_on' ? '通常出勤する人' : '残業できる人' }}</strong>
+        <strong>{{ $mode === 'regular_on' ? 'Teachers with a regular shift' : 'Teachers with a regular day off' }}</strong>
         / Results: <strong>{{ number_format($results->count()) }}</strong>
-      </div>
-      <div class="text-muted small">
-        Calendar Resolver の最終returnで判定しています。
       </div>
     </div>
 
     <div class="table-responsive">
-      <table class="table table-sm table-hover align-middle">
+      <table class="table table-sm table-hover align-middle attendance-table">
+        <colgroup>
+          <col style="width: 150px;">
+          <col style="width: 78px;">
+          <col style="width: 180px;">
+          <col style="width: 46px;">
+          <col style="width: 280px;">
+          <col style="width: 116px;">
+          <col style="width: 56px;">
+          <col style="width: 134px;">
+          <col style="width: 100px;">
+          <col style="width: 110px;">
+        </colgroup>
         <thead>
           <tr>
-            <th style="width: 44px;">
+            <th></th>
+            <th>Code</th>
+            <th>Name</th>
+            <th>
               <input type="checkbox" class="form-check-input" id="selectAllEmails" aria-label="Select all emails">
             </th>
-            <th>Employee Code</th>
-            <th>Name</th>
             <th>Email</th>
-            <th>Phone Number</th>
-            <th>Type Code</th>
+            <th>Phone</th>
+            <th>Type</th>
             <th>Rest Pattern</th>
             <th>District</th>
             <th>Department</th>
-            <th></th>
           </tr>
         </thead>
         <tbody>
           @forelse($results as $row)
             @php($user = $row['user'])
             <tr>
+              <td class="attendance-actions">
+                <a href="{{ route('admin.user.profile', $user) }}" class="btn btn-sm btn-outline-primary">Profile</a>
+                <a href="{{ route('calendar.index.user', $user) }}?month={{ substr($date, 0, 7) }}" class="btn btn-sm btn-outline-secondary">Schedule</a>
+              </td>
+              <td class="cell-nowrap">{{ $user->employee_code }}</td>
+              <td class="cell-truncate" title="{{ $user->family_name }} {{ $user->first_name }}">{{ $user->family_name }} {{ $user->first_name }}</td>
               <td>
                 <input type="checkbox"
                        class="form-check-input email-check"
@@ -90,18 +136,12 @@
                        @disabled(blank($user->email))
                        aria-label="Select {{ $user->family_name }} {{ $user->first_name }} email">
               </td>
-              <td>{{ $user->employee_code }}</td>
-              <td>{{ $user->family_name }} {{ $user->first_name }}</td>
-              <td>{{ $user->email }}</td>
-              <td>{{ $user->phone_number }}</td>
-              <td>{{ $row['type_code'] }}</td>
-              <td>{{ $row['rest_pattern'] }}</td>
-              <td>{{ $user->district?->name }}</td>
-              <td>{{ $user->department?->name }}</td>
-              <td class="text-end">
-                <a href="{{ route('admin.user.profile', $user) }}" class="btn btn-sm btn-outline-primary">Profile</a>
-                <a href="{{ route('calendar.index.user', $user) }}?month={{ substr($date, 0, 7) }}" class="btn btn-sm btn-outline-secondary">Schedule</a>
-              </td>
+              <td class="cell-truncate" title="{{ $user->email }}">{{ $user->email }}</td>
+              <td class="cell-nowrap">{{ $user->phone_number }}</td>
+              <td class="cell-nowrap">{{ $row['type_code'] }}</td>
+              <td class="cell-truncate" title="{{ $row['rest_pattern'] }}">{{ $row['rest_pattern'] }}</td>
+              <td class="cell-truncate" title="{{ $user->district?->name }}">{{ $user->district?->name }}</td>
+              <td class="cell-truncate" title="{{ $user->department?->name }}">{{ $user->department?->name }}</td>
             </tr>
           @empty
             <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\CalendarPatternController;
 use App\Http\Controllers\LeaveApplyController;
 use App\Http\Controllers\LeaveAttachmentController;
 use App\Http\Controllers\CurrentScopeController;
+use App\Http\Controllers\UserAttendanceSearchController;
 
 /*
 |--------------------------------------------------------------------------
@@ -106,6 +107,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::post('/admin/register', [AdminController::class, 'register'])->name('register.submit');
     Route::get('/admin/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
     Route::get('/user/master-list', [AdminController::class, 'masterList'])->name('user.master_list');
+    Route::get('/user/search/attendance', [UserAttendanceSearchController::class, 'attendance'])->name('user.search.attendance');
 });
 
 //プロファイル関連


### PR DESCRIPTION
[非出勤講師の検索及びbcc用email copy機能の実装](https://github.com/Jin6hara/LaravelSprout/commit/36f9ffe482eafa9d97128f6d1ac54b9bc7473eed)
## 概要

指定日の勤務状態を `CalendarResolver` の最終結果ベースで検索できる **Attendance Search** ページを追加しました。

管理者 / スーパー管理者が、特定日について以下の条件でTeacherを検索できます。

- Search teachers with a regular day off
  - 最終イベントに `EventType::ON` / `EventType::OFF` がないTeacher
  - 通常休み扱いのTeacherを検索

- Search teachers with a regular shift
  - 最終イベントに `EventType::ON` かつ `PlanGroup::REGULAR_PLAN` があるTeacher
  - 通常出勤予定があるTeacherを検索

検索結果から対象Teacherをチェックし、選択したEmailをBCC貼り付け用にコピーできます。

## 追加ファイル

### `app/Http/Controllers/UserAttendanceSearchController.php`

Attendance Search画面の表示・検索処理を担当します。

主な処理:

- `CalendarResolver::build()` をユーザーごとに実行
- 指定日の最終イベント配列から `ON` / `OFF` / `REGULAR_PLAN` を判定
- 検索日の有効な `employmentTerms` / `restPatternAssignments` を取得
- 結果に `type_code` と `rest_pattern` を付与

### `resources/views/user/search/attendance.blade.php`

Attendance Search画面を追加しました。

主な内容:

- 日付入力
- 検索タイプ選択
- 検索結果テーブル
- Emailの一括選択
- 選択EmailのBCC用コピー機能

表示列:

- Profile / Schedule
- Code
- Name
- Email選択
- Email
- Phone
- Type
- Rest Pattern
- District
- Department

## 修正ファイル

### `routes/web.php`

管理者向けルートを追加しました。

`GET /user/search/attendance`

route name: `user.search.attendance`

### `resources/views/user/master_list.blade.php`

Master List右上に `Attendance Search` ボタンを追加しました。

### `app/Services/Calendar/CandidateEvent.php`

`toArray()` の `extendedProps` に `type` と `plan_group` を補完しました。

Resolver最終結果から検索判定に必要な情報を取得できるようにしています。

### `app/Services/Calendar/CalendarResolver.php`

配列 / 汎用イベント出力時にも `extendedProps.type` / `extendedProps.plan_group` を補完しました。

`CandidateEvent` 以外のProvider結果でも同じ判定ができるようにしています。

## 技術詳細

検索対象ユーザーは `CurrentScopeService::targetUserQuery()` を使用し、現在の管理スコープ内に限定しています。

指定日に有効な雇用期間を持つTeacherのみを検索対象にしています。

判定はDBの生データではなく、既存カレンダー表示と同じ `CalendarResolver::build()` の最終returnを使用しています。

### `mode=available`

ON なし、かつ OFF なし

### `mode=regular_on`

ON かつ REGULAR_PLAN あり

旧URL互換として `regular_on=1` も受け取れるようにしています。

## UI調整

- 文言は英語で統一
- 検索タイプはチェックボックスからセレクト式に変更
- テーブル幅を調整
- `Code` は6桁想定
- `Type` は2桁想定
- `Phone` / `District` / `Department` は短めに表示
- 長い値は省略表示し、`title` で全文確認可能
- `Profile / Schedule` は先頭列へ移動
- Email選択チェックボックスはEmail列の左へ配置

## 検証

以下を実行済みです。

- `php -l app/Http/Controllers/UserAttendanceSearchController.php`
- `php artisan route:list --path=user/search/attendance`
- `php artisan view:cache`
- `php artisan view:clear`

結果:

- `UserAttendanceSearchController.php` 構文チェック OK
- Attendance Search ルート確認 OK
- Blade cache OK
- 検証後に Blade cache clear 済み