### PR TITLE
Teacher Master List と Commuting Expense Reportsに対するスクロール UX 改善

### DIFF
--- a/public/css/expenseReport.css
+++ b/public/css/expenseReport.css
@@ -24,6 +24,38 @@
     font-size: 14px;
 }
 
+.expense-table-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.expense-height-select {
+    width: 130px;
+}
+
+.expense-report-top-scroll {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-bottom: 0;
+    height: 18px;
+}
+
+.expense-report-top-scroll-inner {
+    height: 1px;
+}
+
+.expense-report-scroll {
+    border: 1px solid #dee2e6;
+}
+
 #sheet {
     width: 100%;
     height: auto;

--- a/public/css/masterList.css
+++ b/public/css/masterList.css
@@ -35,6 +35,38 @@
     padding: 12px 16px;
 }
 
+.master-table-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.master-height-select {
+    width: 130px;
+}
+
+.master-list-top-scroll {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-bottom: 0;
+    height: 18px;
+}
+
+.master-list-top-scroll-inner {
+    height: 1px;
+}
+
+.master-list-scroll {
+    border: 1px solid #dee2e6;
+}
+
 #masterListSheet {
     width: 100%;
     height: auto;

--- a/public/js/expenseReport.js
+++ b/public/js/expenseReport.js
@@ -100,11 +100,130 @@ document.addEventListener('DOMContentLoaded', function () {
     const el = document.getElementById('sheet');
     if (!el) return;
 
-    // スマホ横スクロール：jSpreadsheet の外側をラップ
+    const heightSelect = document.getElementById('expenseReportHeight');
+    const savedHeight = localStorage.getItem('expenseReportHeight') || '560';
+    if (heightSelect) {
+        heightSelect.value = savedHeight;
+    }
+
+    const topScroll = document.createElement('div');
+    topScroll.className = 'expense-report-top-scroll';
+    const topScrollInner = document.createElement('div');
+    topScrollInner.className = 'expense-report-top-scroll-inner';
+    topScroll.appendChild(topScrollInner);
+
     const scrollWrapper = document.createElement('div');
-    scrollWrapper.style.cssText = 'width:100%;overflow-x:auto;-webkit-overflow-scrolling:touch;';
-    el.parentNode.insertBefore(scrollWrapper, el);
+    scrollWrapper.className = 'expense-report-scroll';
+    scrollWrapper.style.cssText = 'width:100%;overflow:auto;-webkit-overflow-scrolling:touch;';
+    el.parentNode.insertBefore(topScroll, el);
+    topScroll.parentNode.insertBefore(scrollWrapper, el);
     scrollWrapper.appendChild(el);
+
+    function applyTableHeight(value) {
+        if (value === 'full') {
+            scrollWrapper.style.maxHeight = '';
+        } else {
+            scrollWrapper.style.maxHeight = `${Number(value) || 560}px`;
+        }
+    }
+
+    function syncTopScrollWidth() {
+        topScrollInner.style.width = `${scrollWrapper.scrollWidth}px`;
+    }
+
+    function syncScrollLeft(source, target) {
+        if (Math.abs(target.scrollLeft - source.scrollLeft) > 1) {
+            target.scrollLeft = source.scrollLeft;
+        }
+    }
+
+    function enableSelectionAutoScroll(wrapper, sheetEl) {
+        let isSelecting = false;
+        let scrollXSpeed = 0;
+        let scrollYSpeed = 0;
+        let frameId = null;
+        const horizontalEdgeSize = 80;
+        const verticalEdgeSize = 110;
+        const maxHorizontalSpeed = 28;
+        const maxVerticalSpeed = 24;
+
+        function stopAutoScroll() {
+            isSelecting = false;
+            scrollXSpeed = 0;
+            scrollYSpeed = 0;
+            if (frameId) {
+                window.cancelAnimationFrame(frameId);
+                frameId = null;
+            }
+        }
+
+        function scrollStep() {
+            if (!isSelecting || (scrollXSpeed === 0 && scrollYSpeed === 0)) {
+                frameId = null;
+                return;
+            }
+
+            if (scrollXSpeed !== 0) {
+                wrapper.scrollLeft += scrollXSpeed;
+            }
+
+            if (scrollYSpeed !== 0) {
+                wrapper.scrollTop += scrollYSpeed;
+            }
+
+            frameId = window.requestAnimationFrame(scrollStep);
+        }
+
+        function updateAutoScroll(clientX, clientY) {
+            if (!isSelecting) return;
+
+            const rect = wrapper.getBoundingClientRect();
+            const distanceLeft = clientX - rect.left;
+            const distanceRight = rect.right - clientX;
+            const distanceTop = clientY - rect.top;
+            const distanceBottom = rect.bottom - clientY;
+
+            if (distanceLeft >= 0 && distanceLeft < horizontalEdgeSize) {
+                scrollXSpeed = -Math.ceil(((horizontalEdgeSize - distanceLeft) / horizontalEdgeSize) * maxHorizontalSpeed);
+            } else if (distanceRight >= 0 && distanceRight < horizontalEdgeSize) {
+                scrollXSpeed = Math.ceil(((horizontalEdgeSize - distanceRight) / horizontalEdgeSize) * maxHorizontalSpeed);
+            } else {
+                scrollXSpeed = 0;
+            }
+
+            if (distanceTop >= 0 && distanceTop < verticalEdgeSize) {
+                scrollYSpeed = -Math.ceil(((verticalEdgeSize - distanceTop) / verticalEdgeSize) * maxVerticalSpeed);
+            } else if (distanceBottom >= 0 && distanceBottom < verticalEdgeSize) {
+                scrollYSpeed = Math.ceil(((verticalEdgeSize - distanceBottom) / verticalEdgeSize) * maxVerticalSpeed);
+            } else {
+                scrollYSpeed = 0;
+            }
+
+            if ((scrollXSpeed !== 0 || scrollYSpeed !== 0) && !frameId) {
+                frameId = window.requestAnimationFrame(scrollStep);
+            }
+        }
+
+        sheetEl.addEventListener('mousedown', (e) => {
+            if (e.button !== 0) return;
+            isSelecting = true;
+            updateAutoScroll(e.clientX, e.clientY);
+        }, true);
+
+        document.addEventListener('mousemove', (e) => updateAutoScroll(e.clientX, e.clientY), true);
+        document.addEventListener('mouseup', stopAutoScroll, true);
+        window.addEventListener('blur', stopAutoScroll);
+    }
+
+    applyTableHeight(savedHeight);
+    heightSelect?.addEventListener('change', () => {
+        localStorage.setItem('expenseReportHeight', heightSelect.value);
+        applyTableHeight(heightSelect.value);
+        window.requestAnimationFrame(syncTopScrollWidth);
+    });
+
+    topScroll.addEventListener('scroll', () => syncScrollLeft(topScroll, scrollWrapper));
+    scrollWrapper.addEventListener('scroll', () => syncScrollLeft(scrollWrapper, topScroll));
 
     jspreadsheet(el, {
         worksheets: [{
@@ -131,6 +250,17 @@ document.addEventListener('DOMContentLoaded', function () {
             tableHeight: '470px',
         }],
     });
+
+    window.requestAnimationFrame(syncTopScrollWidth);
+    if (window.ResizeObserver) {
+        const resizeObserver = new ResizeObserver(syncTopScrollWidth);
+        resizeObserver.observe(el);
+        resizeObserver.observe(scrollWrapper);
+    } else {
+        window.addEventListener('resize', syncTopScrollWidth);
+    }
+
+    enableSelectionAutoScroll(scrollWrapper, el);
 
     // 参考: 合計（未使用・必要なら利用）
     // const total = sheet[0].getColumnData(3).reduce((a, v) => a + (+v || 0), 0);

--- a/public/js/masterList.js
+++ b/public/js/masterList.js
@@ -57,10 +57,130 @@ document.addEventListener('DOMContentLoaded', function () {
         r.updated_at ?? '',
     ]));
 
+    const heightSelect = document.getElementById('masterListHeight');
+    const savedHeight = localStorage.getItem('masterListHeight') || '560';
+    if (heightSelect) {
+        heightSelect.value = savedHeight;
+    }
+
+    const topScroll = document.createElement('div');
+    topScroll.className = 'master-list-top-scroll';
+    const topScrollInner = document.createElement('div');
+    topScrollInner.className = 'master-list-top-scroll-inner';
+    topScroll.appendChild(topScrollInner);
+
     const scrollWrapper = document.createElement('div');
-    scrollWrapper.style.cssText = 'width:100%;overflow-x:auto;-webkit-overflow-scrolling:touch;';
-    el.parentNode.insertBefore(scrollWrapper, el);
+    scrollWrapper.className = 'master-list-scroll';
+    scrollWrapper.style.cssText = 'width:100%;overflow:auto;-webkit-overflow-scrolling:touch;';
+    el.parentNode.insertBefore(topScroll, el);
+    topScroll.parentNode.insertBefore(scrollWrapper, el);
     scrollWrapper.appendChild(el);
+
+    function applyTableHeight(value) {
+        if (value === 'full') {
+            scrollWrapper.style.maxHeight = '';
+        } else {
+            scrollWrapper.style.maxHeight = `${Number(value) || 560}px`;
+        }
+    }
+
+    function syncTopScrollWidth() {
+        topScrollInner.style.width = `${scrollWrapper.scrollWidth}px`;
+    }
+
+    function syncScrollLeft(source, target) {
+        if (Math.abs(target.scrollLeft - source.scrollLeft) > 1) {
+            target.scrollLeft = source.scrollLeft;
+        }
+    }
+
+    applyTableHeight(savedHeight);
+    heightSelect?.addEventListener('change', () => {
+        localStorage.setItem('masterListHeight', heightSelect.value);
+        applyTableHeight(heightSelect.value);
+        window.requestAnimationFrame(syncTopScrollWidth);
+    });
+
+    topScroll.addEventListener('scroll', () => syncScrollLeft(topScroll, scrollWrapper));
+    scrollWrapper.addEventListener('scroll', () => syncScrollLeft(scrollWrapper, topScroll));
+
+    function enableSelectionAutoScroll(wrapper, sheetEl) {
+        let isSelecting = false;
+        let scrollXSpeed = 0;
+        let scrollYSpeed = 0;
+        let frameId = null;
+        const horizontalEdgeSize = 80;
+        const verticalEdgeSize = 110;
+        const maxHorizontalSpeed = 28;
+        const maxVerticalSpeed = 24;
+
+        function stopAutoScroll() {
+            isSelecting = false;
+            scrollXSpeed = 0;
+            scrollYSpeed = 0;
+            if (frameId) {
+                window.cancelAnimationFrame(frameId);
+                frameId = null;
+            }
+        }
+
+        function scrollStep() {
+            if (!isSelecting || (scrollXSpeed === 0 && scrollYSpeed === 0)) {
+                frameId = null;
+                return;
+            }
+
+            if (scrollXSpeed !== 0) {
+                wrapper.scrollLeft += scrollXSpeed;
+            }
+
+            if (scrollYSpeed !== 0) {
+                wrapper.scrollTop += scrollYSpeed;
+            }
+
+            frameId = window.requestAnimationFrame(scrollStep);
+        }
+
+        function updateAutoScroll(clientX, clientY) {
+            if (!isSelecting) return;
+
+            const rect = wrapper.getBoundingClientRect();
+            const distanceLeft = clientX - rect.left;
+            const distanceRight = rect.right - clientX;
+            const distanceTop = clientY - rect.top;
+            const distanceBottom = rect.bottom - clientY;
+
+            if (distanceLeft >= 0 && distanceLeft < horizontalEdgeSize) {
+                scrollXSpeed = -Math.ceil(((horizontalEdgeSize - distanceLeft) / horizontalEdgeSize) * maxHorizontalSpeed);
+            } else if (distanceRight >= 0 && distanceRight < horizontalEdgeSize) {
+                scrollXSpeed = Math.ceil(((horizontalEdgeSize - distanceRight) / horizontalEdgeSize) * maxHorizontalSpeed);
+            } else {
+                scrollXSpeed = 0;
+            }
+
+            if (distanceTop >= 0 && distanceTop < verticalEdgeSize) {
+                scrollYSpeed = -Math.ceil(((verticalEdgeSize - distanceTop) / verticalEdgeSize) * maxVerticalSpeed);
+            } else if (distanceBottom >= 0 && distanceBottom < verticalEdgeSize) {
+                scrollYSpeed = Math.ceil(((verticalEdgeSize - distanceBottom) / verticalEdgeSize) * maxVerticalSpeed);
+            } else {
+                scrollYSpeed = 0;
+            }
+
+            if ((scrollXSpeed !== 0 || scrollYSpeed !== 0) && !frameId) {
+                frameId = window.requestAnimationFrame(scrollStep);
+            }
+        }
+
+        sheetEl.addEventListener('mousedown', (e) => {
+            if (e.button !== 0) return;
+            isSelecting = true;
+            updateAutoScroll(e.clientX, e.clientY);
+        }, true);
+
+        document.addEventListener('mousemove', (e) => updateAutoScroll(e.clientX, e.clientY), true);
+        document.addEventListener('mouseup', stopAutoScroll, true);
+        window.addEventListener('blur', stopAutoScroll);
+    }
 
     jspreadsheet(el, {
         worksheets: [{
@@ -98,4 +218,15 @@ document.addEventListener('DOMContentLoaded', function () {
             tableHeight: '560px',
         }],
     });
+
+    window.requestAnimationFrame(syncTopScrollWidth);
+    if (window.ResizeObserver) {
+        const resizeObserver = new ResizeObserver(syncTopScrollWidth);
+        resizeObserver.observe(el);
+        resizeObserver.observe(scrollWrapper);
+    } else {
+        window.addEventListener('resize', syncTopScrollWidth);
+    }
+
+    enableSelectionAutoScroll(scrollWrapper, el);
 });

--- a/resources/views/expenses/report.blade.php
+++ b/resources/views/expenses/report.blade.php
@@ -102,13 +102,14 @@
         @endif
       </div>
 
-      <div class="ms-auto d-flex align-items-center" style="gap:8px; flex-wrap:wrap">
-        @foreach(($summary['by_status'] ?? []) as $st => $cnt)
-        @php
-        $cls = match (strtolower($st)) { 'draft' => 'badge-draft', 'submitted' => 'badge-submitted', default => 'badge-secondary', };
-        @endphp
-        <span class="badge {{ $cls }}" title="{{ $st }}">{{ strtoupper($st) }}: {{ $cnt }}</span>
-        @endforeach
+      <div class="expense-table-toolbar ms-auto">
+        <label for="expenseReportHeight" class="form-label m-0 small text-muted">Table Height</label>
+        <select id="expenseReportHeight" class="form-select form-select-sm expense-height-select">
+          <option value="420">Compact</option>
+          <option value="560">Standard</option>
+          <option value="720">Tall</option>
+          <option value="full">Full</option>
+        </select>
       </div>
 
       {{-- ▼ レコード無しメッセージ（count=0 の時のみ表示） --}}

--- a/resources/views/user/master_list.blade.php
+++ b/resources/views/user/master_list.blade.php
@@ -74,9 +74,19 @@
   </form>
 
   <div class="header-box mb-4">
-    <div class="meta w-100">
+    <div class="meta w-100 align-items-center">
       <div>Total Teachers: <strong>{{ number_format($summary['count'] ?? 0) }}</strong></div>
       <div class="muted">Current employment/rest pattern is shown first when available.</div>
+
+      <div class="master-table-toolbar ms-auto">
+        <label for="masterListHeight" class="form-label m-0 small text-muted">Table Height</label>
+        <select id="masterListHeight" class="form-select form-select-sm master-height-select">
+          <option value="420">Compact</option>
+          <option value="560">Standard</option>
+          <option value="720">Tall</option>
+          <option value="full">Full</option>
+        </select>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## 関連
https://github.com/Jin6hara/LaravelSprout/pull/122
https://github.com/Jin6hara/LaravelSprout/pull/127

## Scroll UX Improvements for Master List / CER Report

### Overview

`Teacher Master List` と `Commuting Expense Reports` の jSpreadsheet テーブルに対して、横長テーブルを操作しやすくするためのスクロール UX 改善を追加しました。

対象画面:

- `Teacher Master List`
- `Commuting Expense Reports (CER Report)`

主な追加内容:

- テーブル上部の横スクロールバー
- 下部スクロールとの同期
- テーブル高さ切替
- 高さ設定の保存
- 範囲選択ドラッグ中の自動スクロール
- テーブル内の縦スクロール対応

---

## Background

jSpreadsheet の横スクロールバーは通常テーブル下部に表示されます。

そのため、横に長いテーブルで右側の列を確認したい場合、ユーザーは一度テーブル下部まで移動してから横スクロールする必要がありました。

また、セル範囲をドラッグ選択する際に、テーブル端までドラッグしても自然にスクロールしないため、広い範囲の選択がしにくい状態でした。

今回の変更では、上部にも横スクロール操作を追加し、さらにテーブル高さを調整できるようにすることで、一覧画面の操作性を改善しています。

---

## Technical Summary

### 1. Top Horizontal Scrollbar

jSpreadsheet を外側の scroll wrapper で包み、その上に独立した horizontal scroll element を追加しました。

```js
const topScroll = document.createElement('div');
const topScrollInner = document.createElement('div');

topScroll.appendChild(topScrollInner);
el.parentNode.insertBefore(topScroll, el);
topScroll.parentNode.insertBefore(scrollWrapper, el);
scrollWrapper.appendChild(el);
```

上部スクロールバーの内部要素幅を、実際のテーブル scroll width に同期しています。

```js
function syncTopScrollWidth() {
    topScrollInner.style.width = `${scrollWrapper.scrollWidth}px`;
}
```

---

### 2. Scroll Position Sync

上部スクロールバーと実テーブル wrapper の `scrollLeft` を双方向に同期しています。

```js
function syncScrollLeft(source, target) {
    if (Math.abs(target.scrollLeft - source.scrollLeft) > 1) {
        target.scrollLeft = source.scrollLeft;
    }
}
```

これにより、上部・下部どちらで横スクロールしても同じ位置に移動します。

---

### 3. Table Height Control

`Compact / Standard / Tall / Full` の高さ切替を追加しました。

```js
function applyTableHeight(value) {
    if (value === 'full') {
        scrollWrapper.style.maxHeight = '';
    } else {
        scrollWrapper.style.maxHeight = `${Number(value) || 560}px`;
    }
}
```

選択値は `localStorage` に保存されるため、次回表示時も前回の高さが維持されます。

```js
localStorage.setItem('masterListHeight', heightSelect.value);
localStorage.setItem('expenseReportHeight', heightSelect.value);
```

---

### 4. Auto Scroll While Selecting Cells

セル範囲選択中に、カーソルが wrapper の上下左右端に近づいた場合、自動でスクロールする処理を追加しました。

```js
function enableSelectionAutoScroll(wrapper, sheetEl) {
    // mousedown で選択開始
    // mousemove で端との距離を計算
    // requestAnimationFrame で scrollLeft / scrollTop を更新
}
```

横方向:

```js
wrapper.scrollLeft += scrollXSpeed;
```

縦方向:

```js
wrapper.scrollTop += scrollYSpeed;
```

これにより、ドラッグ選択中でも自然に広い範囲を選択できます。

---

## Files Changed

### Master List

#### `resources/views/user/master_list.blade.php`

変更目的:

- `Table Height` セレクトを追加
- `Total Teachers` 表示枠の右側に配置
- 一覧情報とテーブル操作設定を同じ header area にまとめるため

主な追加 UI:

```blade
<select id="masterListHeight" class="form-select form-select-sm master-height-select">
  <option value="420">Compact</option>
  <option value="560">Standard</option>
  <option value="720">Tall</option>
  <option value="full">Full</option>
</select>
```

---

#### `public/js/masterList.js`

変更目的:

- jSpreadsheet の外側に scroll wrapper を追加
- 上部横スクロールバーを追加
- 上下スクロールの操作性を改善
- 範囲選択ドラッグ中の自動スクロールを実装
- テーブル高さ設定を保存・復元

主な機能:

- `master-list-top-scroll`
- `master-list-scroll`
- `syncTopScrollWidth()`
- `syncScrollLeft()`
- `applyTableHeight()`
- `enableSelectionAutoScroll()`

---

#### `public/css/masterList.css`

変更目的:

- 上部横スクロールバーの見た目を定義
- テーブル wrapper に枠線を追加
- `Table Height` UI の配置とサイズを調整

主な追加 class:

```css
.master-table-toolbar
.master-height-select
.master-list-top-scroll
.master-list-top-scroll-inner
.master-list-scroll
```

---

## CER Report

### `resources/views/expenses/report.blade.php`

変更目的:

- 右側に表示していた `DRAFT:` / `SUBMITTED:` badge エリアを `Table Height` に差し替え
- CER Report でも Master List と同じテーブル操作 UX に揃えるため

主な追加 UI:

```blade
<select id="expenseReportHeight" class="form-select form-select-sm expense-height-select">
  <option value="420">Compact</option>
  <option value="560">Standard</option>
  <option value="720">Tall</option>
  <option value="full">Full</option>
</select>
```

---

### `public/js/expenseReport.js`

変更目的:

- CER Report の jSpreadsheet にも Master List と同じスクロール補助を追加
- 上部横スクロールバーを追加
- 下部スクロールと同期
- 高さ切替を保存・復元
- 範囲選択ドラッグ中の上下左右スクロールを実装

主な機能:

- `expense-report-top-scroll`
- `expense-report-scroll`
- `syncTopScrollWidth()`
- `syncScrollLeft()`
- `applyTableHeight()`
- `enableSelectionAutoScroll()`

---

### `public/css/expenseReport.css`

変更目的:

- CER Report 用の上部横スクロールバーを定義
- `Table Height` UI の見た目を追加
- scroll wrapper に枠線を付け、テーブル領域を明確化

主な追加 class:

```css
.expense-table-toolbar
.expense-height-select
.expense-report-top-scroll
.expense-report-top-scroll-inner
.expense-report-scroll
```

---

## Verification

以下を確認済みです。

```bash
node --check public/js/masterList.js
node --check public/js/expenseReport.js
php artisan view:cache
php artisan view:clear
```

All checks passed.