### PR TITLE
⭐️Schedule閲覧をpermission認証に変更しtrainerへ権限付与

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -51,10 +51,11 @@ class AdminController extends Controller
 
     public function masterList(Request $request): View
     {
-        $this->authorize('viewAny', User::class);
+        $this->authorize('viewTeacherAny', User::class);
 
         $todayDate = today();
         $today = $todayDate->toDateString();
+        $viewer = $request->user();
         $search = trim((string) $request->query('search', ''));
         $statuses = collect((array) $request->query('statuses', ['active']))
             ->intersect(['active', 'terminated'])
@@ -64,7 +65,17 @@ class AdminController extends Controller
             $statuses = collect(['active']);
         }
 
-        $query = $this->scopeService->targetUserQuery()
+        $districtId = $this->scopeService->currentDistrictId();
+        $departmentId = $this->scopeService->currentDepartmentId();
+
+        $query = User::query()
+            ->when(
+                $districtId !== null && $departmentId !== null,
+                fn (Builder $q) => $q
+                    ->where('district_id', $districtId)
+                    ->where('department_id', $departmentId),
+                fn (Builder $q) => $q->whereKey($viewer->id)
+            )
             ->when(filled($search), function (Builder $q) use ($search) {
                 $q->where(function (Builder $w) use ($search) {
                     $w->whereLikeInsensitive('employee_code', $search)
@@ -102,7 +113,7 @@ class AdminController extends Controller
             ])
             ->orderBy('employee_code')
             ->get()
-            ->map(function (User $user) use ($today) {
+            ->map(function (User $user) use ($today, $viewer) {
                 $term = $user->employmentTerms->first(
                     fn ($row) => $row->start_date?->toDateString() <= $today
                         && (is_null($row->end_date) || $row->end_date->toDateString() >= $today)
@@ -114,7 +125,11 @@ class AdminController extends Controller
                 ) ?? $user->restPatternAssignments->first();
 
                 return [
-                    'profile_url' => route('admin.user.profile', $user),
+                    'detail_url' => $viewer->isAdmin()
+                        ? ($viewer->is($user) ? route('user.profile') : route('admin.user.profile', $user))
+                        : route('calendar.index.user', $user),
+                    'detail_label' => $viewer->isAdmin() ? 'Details' : 'Schedule',
+                    'detail_disabled' => $viewer->isAdmin() && ! $viewer->can('update', $user),
                     'employee_code' => $user->employee_code,
                     'family_name' => $user->family_name,
                     'first_name' => $user->first_name,

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -129,7 +129,6 @@ class AdminController extends Controller
                         ? ($viewer->is($user) ? route('user.profile') : route('admin.user.profile', $user))
                         : route('calendar.index.user', $user),
                     'detail_label' => $viewer->isAdmin() ? 'Details' : 'Schedule',
-                    'detail_disabled' => $viewer->isAdmin() && ! $viewer->can('update', $user),
                     'employee_code' => $user->employee_code,
                     'family_name' => $user->family_name,
                     'first_name' => $user->first_name,

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -30,10 +30,11 @@ class CalendarController extends Controller
             return redirect()->route('calendar.index', $request->only('month'));
         }
 
-        $this->authorize('view', $user ?? $viewer);
+        $this->authorize('viewCalendar', $user ?? $viewer); // Policy で viewCalendar を定義して、ユーザー自身・スコープ内管理者・schedule.viewAll 権限のいずれかで閲覧可能にする
 
-        // 管理者だけにセレクト用リストを渡す（district/department で直接絞り込み）
-        $userOptions = $canViewAnyUser
+        // schedule.viewAll 対象にセレクト用リストを渡す（district/department で直接絞り込み）
+        $canViewScheduleAll = $viewer->can('schedule.viewAll');
+        $userOptions = $canViewScheduleAll
             ? User::query()
                 ->when($this->scopeService->currentDistrictId(),
                     fn($q, $did) => $q->where('district_id', $did))
@@ -77,7 +78,7 @@ class CalendarController extends Controller
 
             $targetUserId = (int) $request->query('user_id', $viewer->id);
             $user = User::findOrFail($targetUserId);
-            $this->authorize('view', $user);
+            $this->authorize('viewCalendar', $user);
 
             $events = $resolver->build($user, $start, $end);
             return response()->json($events);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -150,6 +150,7 @@ class User extends Authenticatable
 
         $map = [
             'general'      => '一般',
+            'trainer'      => 'トレーナー',
             'admin'        => '管理者',
             'super_admin'  => 'スーパー管理者',
         ];

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -15,6 +15,11 @@ class UserPolicy
         return $user->isAdmin();
     }
 
+    public function viewTeacherAny(User $user): bool
+    {
+        return $user->can('teacher.viewAll');
+    }
+
     /**
      * Determine whether the user can view the model.
      */

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -23,6 +23,14 @@ class UserPolicy
         return $currentUser->is($targetUser)
             || $this->isScopedAdminFor($currentUser, $targetUser);
     }
+
+    public function viewCalendar(User $currentUser, User $targetUser): bool
+    {
+        return $currentUser->is($targetUser)
+            || $this->isScopedAdminFor($currentUser, $targetUser)
+            || $currentUser->can('schedule.viewAll');
+    }
+
     /**
      * Determine whether the user can create models.
      */

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -28,7 +28,8 @@ class UserPolicy
     {
         return $currentUser->is($targetUser)
             || $this->isScopedAdminFor($currentUser, $targetUser)
-            || $currentUser->can('schedule.viewAll');
+            // schedule.viewAll 権限があってスコープ内のユーザーも閲覧可能にする
+            || ($currentUser->can('schedule.viewAll') && $this->isInCurrentDistrictDepartment($targetUser));
     }
 
     /**
@@ -86,5 +87,13 @@ class UserPolicy
     {
         return $actor->isAdmin()
             && in_array($target->id, app(CurrentScopeService::class)->targetUserIds(), true);
+    }
+
+    private function isInCurrentDistrictDepartment(User $target): bool
+    {
+        $scope = app(CurrentScopeService::class);
+
+        return $target->district_id === $scope->currentDistrictId()
+            && $target->department_id === $scope->currentDepartmentId();
     }
 }

--- a/database/seeders/PermissionRoleSeeder.php
+++ b/database/seeders/PermissionRoleSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use App\Models\User;
 
@@ -15,14 +16,22 @@ class PermissionRoleSeeder extends Seeder
         $super   = Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
         $admin   = Role::firstOrCreate(['name' => 'admin',       'guard_name' => 'web']);
         $general = Role::firstOrCreate(['name' => 'general',     'guard_name' => 'web']);
+        $trainer = Role::firstOrCreate(['name' => 'trainer',     'guard_name' => 'web']);
+
+        $scheduleViewAll = Permission::firstOrCreate(['name' => 'schedule.viewAll', 'guard_name' => 'web']);
+
+        $super->givePermissionTo($scheduleViewAll);
+        $admin->givePermissionTo($scheduleViewAll);
+        $trainer->givePermissionTo($scheduleViewAll);
 
         // 2) ユーザーID → ロールの割当マップ
         $explicit = [
             6 => 'super_admin',
             5 => 'admin',
+            4 => 'trainer',
         ];
 
-        // 3) ID 1〜19 を走査し、6→super_admin、5→admin、それ以外→general を付与
+        // 3) ID 1〜19 を走査し、明示指定以外は general を付与
         foreach (range(1, 19) as $id) {
             $user = User::find($id);
             if (!$user) {

--- a/database/seeders/PermissionRoleSeeder.php
+++ b/database/seeders/PermissionRoleSeeder.php
@@ -19,10 +19,15 @@ class PermissionRoleSeeder extends Seeder
         $trainer = Role::firstOrCreate(['name' => 'trainer',     'guard_name' => 'web']);
 
         $scheduleViewAll = Permission::firstOrCreate(['name' => 'schedule.viewAll', 'guard_name' => 'web']);
+        $teacherViewAll = Permission::firstOrCreate(['name' => 'teacher.viewAll', 'guard_name' => 'web']);
 
         $super->givePermissionTo($scheduleViewAll);
         $admin->givePermissionTo($scheduleViewAll);
         $trainer->givePermissionTo($scheduleViewAll);
+
+        $super->givePermissionTo($teacherViewAll);
+        $admin->givePermissionTo($teacherViewAll);
+        $trainer->givePermissionTo($teacherViewAll);
 
         // 2) ユーザーID → ロールの割当マップ
         $explicit = [

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -13,7 +13,7 @@ class RoleSeeder extends Seeder
 {
     public function run(): void
     {
-        foreach (['super_admin', 'admin', 'general'] as $role) {
+        foreach (['super_admin', 'admin', 'general', 'trainer'] as $role) {
             Role::firstOrCreate(['name' => $role, 'guard_name' => 'web']);
         }
     }

--- a/public/css/masterList.css
+++ b/public/css/masterList.css
@@ -84,7 +84,8 @@ h1 {
     text-decoration: none !important;
 }
 
-#masterListSheet .btn.btn-sm.btn-outline-primary {
+#masterListSheet .master-detail-btn {
+    width: 84px;
     padding: 2px 8px;
     line-height: 0.9;
 }

--- a/public/js/masterList.js
+++ b/public/js/masterList.js
@@ -31,17 +31,13 @@ document.addEventListener('DOMContentLoaded', function () {
         rows = [];
     }
 
-    function detailsBtn(url, label, disabled) {
-        if (disabled) {
-            return '<button type="button" class="btn btn-sm btn-outline-secondary master-detail-btn" disabled>Readonly</button>';
-        }
-
+    function detailsBtn(url, label) {
         if (!url) return '';
         return `<a href="${url}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary master-detail-btn">${label || 'Details'}</a>`;
     }
 
     const matrix = rows.map(r => ([
-        detailsBtn(r.detail_url, r.detail_label, r.detail_disabled),
+        detailsBtn(r.detail_url, r.detail_label),
         r.employee_code ?? '',
         r.family_name ?? '',
         r.first_name ?? '',

--- a/public/js/masterList.js
+++ b/public/js/masterList.js
@@ -31,13 +31,17 @@ document.addEventListener('DOMContentLoaded', function () {
         rows = [];
     }
 
-    function detailsBtn(url) {
+    function detailsBtn(url, label, disabled) {
+        if (disabled) {
+            return '<button type="button" class="btn btn-sm btn-outline-secondary master-detail-btn" disabled>Readonly</button>';
+        }
+
         if (!url) return '';
-        return `<a href="${url}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary">Details</a>`;
+        return `<a href="${url}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary master-detail-btn">${label || 'Details'}</a>`;
     }
 
     const matrix = rows.map(r => ([
-        detailsBtn(r.profile_url),
+        detailsBtn(r.detail_url, r.detail_label, r.detail_disabled),
         r.employee_code ?? '',
         r.family_name ?? '',
         r.first_name ?? '',
@@ -186,7 +190,7 @@ document.addEventListener('DOMContentLoaded', function () {
         worksheets: [{
             data: matrix,
             columns: [
-                { title: 'Details', width: 90, readOnly: true, type: 'html' },
+                { title: 'Details', width: 100, readOnly: true, type: 'html' },
                 { title: 'Employee Code', width: 130, readOnly: true },
                 { title: 'Family Name', width: 140, readOnly: true },
                 { title: 'First Name', width: 140, readOnly: true },

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -21,7 +21,7 @@
     </button>
     @endif
     @else
-    <span class="badge text-bg-secondary">Schedule</span>
+    <span class="badge text-bg-secondary">{{ $viewUser ? ($viewUser->first_name.' '.$viewUser->family_name) : 'Not Selected' }}</span>
     @endrole
   </div>
 </div>
@@ -42,7 +42,7 @@
     </div>
 
     {{-- ▼ 管理者だけ：対象ユーザーの選択 --}}
-    @role('admin|super_admin')
+    @can('schedule.viewAll')
     <div class="col-6 col-md-3 col-lg-2 ">
       <label class="form-label small mb-1 ">Teacher</label>
       <select name="user" class="form-select form-select-sm"
@@ -56,7 +56,7 @@
         @endforeach
       </select>
     </div>
-    @endrole
+    @endcan
     {{-- ▲ 管理者だけ：対象ユーザーの選択 --}}
 
   </div>
@@ -80,7 +80,7 @@
   </div>
 </div>
 {{-- Calendar Pattern モーダル（admin + viewUser 選択済み時のみ描画） --}}
-@role('admin|super_admin')
+@can('schedule.viewAll')
 @if($viewUser)
 @php
 $cpeProps = [
@@ -106,7 +106,7 @@ $cpeProps = [
   </div>
 </div>
 @endif
-@endrole
+@endcan
 
 @endsection
 

--- a/resources/views/commons/role/generalHeader.blade.php
+++ b/resources/views/commons/role/generalHeader.blade.php
@@ -1,4 +1,4 @@
-@role('general')
+@unlessrole('admin|super_admin')
 
 <li class="nav-item">
     <a class="btn btn-sm btn-outline-secondary header-btn" href="{{ route('calendar.index') }}">

--- a/resources/views/commons/role/generalHeader.blade.php
+++ b/resources/views/commons/role/generalHeader.blade.php
@@ -48,6 +48,16 @@
 
 <span class="nav-divider">|</span>
 
+@can('teacher.viewAll')
+<li class="nav-item">
+    <a class="btn btn-sm btn-outline-secondary header-btn" href="{{ route('user.master_list') }}">
+        Teacher
+    </a>
+</li>
+
+<span class="nav-divider">|</span>
+@endcan
+
 <li class="nav-item">
     <a class="btn btn-sm btn-outline-secondary header-btn" href="{{ route('user.profile') }}">
         Profile

--- a/resources/views/user/master_list.blade.php
+++ b/resources/views/user/master_list.blade.php
@@ -19,11 +19,13 @@
   <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
     <h1 class="mb-0">Teacher Master List</h1>
 
+    @role('admin|super_admin')
     <div class="d-flex flex-wrap gap-2">
       <a href="{{ route('user.search.attendance') }}" class="btn btn-sm btn-outline-primary">
         Attendance Search
       </a>
     </div>
+    @endrole
   </div>
 
   <form method="GET" action="{{ route('user.master_list') }}" class="master-search mb-3" id="masterSearchForm">

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,8 +105,11 @@ Route::middleware(['auth'])->group(function () {
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/admin/register', [AdminController::class, 'showForm'])->name('register.showForm');
     Route::post('/admin/register', [AdminController::class, 'register'])->name('register.submit');
-    Route::get('/user/master-list', [AdminController::class, 'masterList'])->name('user.master_list');
     Route::get('/user/search/attendance', [UserAttendanceSearchController::class, 'attendance'])->name('user.search.attendance');
+});
+
+Route::middleware(['auth', 'permission:teacher.viewAll'])->group(function () {
+    Route::get('/user/master-list', [AdminController::class, 'masterList'])->name('user.master_list');
 });
 
 //プロファイル関連

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,7 +41,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])
     ->name('current-scope.store');
 
 //共通
-Route::middleware(['auth', 'role:general|admin|super_admin'])->group(function () {
+Route::middleware(['auth'])->group(function () {
     Route::get('/', function () {
         return view('welcome');
     })->name('welcome');
@@ -54,7 +54,7 @@ Route::middleware(['auth'])->group(function () {
     // 自分のカレンダー
     Route::get('/calendar', [CalendarController::class, 'index'])->name('calendar.index');
     // 管理者: 任意ユーザーのカレンダー（/calendar/{user}）
-    Route::get('/calendar/{user}', [CalendarController::class, 'index'])->middleware('role:admin|super_admin')->name('calendar.index.user');
+    Route::get('/calendar/{user}', [CalendarController::class, 'index'])->middleware('permission:schedule.viewAll')->name('calendar.index.user');
 });
 
 // Forecast関連

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -7,6 +7,8 @@ use App\Models\District;
 use App\Models\User;
 use App\Models\UserManagementScope;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 /**
@@ -88,6 +90,8 @@ class CalendarControllerTest extends TestCase
             'district_id'   => $district->id,
             'department_id' => $department->id,
         ]);
+        $scheduleViewAll = Permission::firstOrCreate(['name' => 'schedule.viewAll', 'guard_name' => 'web']);
+        Role::findByName('admin', 'web')->givePermissionTo($scheduleViewAll);
 
         $scope = UserManagementScope::factory()->create([
             'user_id'       => $admin->id,

--- a/tests/Feature/TeacherMasterListPermissionTest.php
+++ b/tests/Feature/TeacherMasterListPermissionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\EmploymentTerm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Teacher Master List の permission テスト
+ *
+ * シナリオ:
+ * 1. teacher.viewAll を持たない general は /user/master-list に入れない
+ * 2. teacher.viewAll を持つ trainer は /user/master-list に入れる
+ * 3. trainer の一覧は自分と同じ district / department のユーザーだけ表示する
+ */
+class TeacherMasterListPermissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function giveTeacherViewAllTo(string $roleName): void
+    {
+        $permission = Permission::firstOrCreate(['name' => 'teacher.viewAll', 'guard_name' => 'web']);
+        Role::findByName($roleName, 'web')->givePermissionTo($permission);
+    }
+
+    private function makeActive(User $user): void
+    {
+        EmploymentTerm::create([
+            'user_id' => $user->id,
+            'start_date' => now()->subMonth()->toDateString(),
+            'end_date' => null,
+            'type_name' => 'Full-time',
+            'type_code' => 'FT',
+        ]);
+    }
+
+    public function test_general_user_without_teacher_view_all_cannot_view_master_list(): void
+    {
+        $general = User::factory()->general()->create();
+
+        $this->actingAs($general)
+            ->get(route('user.master_list'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_trainer_with_teacher_view_all_can_view_master_list(): void
+    {
+        $this->giveTeacherViewAllTo('trainer');
+
+        $trainer = User::factory()->create();
+        $trainer->assignRole('trainer');
+
+        $this->actingAs($trainer)
+            ->get(route('user.master_list'))
+            ->assertOk();
+    }
+
+    public function test_trainer_master_list_is_limited_to_own_district_and_department(): void
+    {
+        $this->giveTeacherViewAllTo('trainer');
+
+        $district = District::factory()->create();
+        $department = Department::factory()->create();
+        $otherDistrict = District::factory()->create();
+        $otherDepartment = Department::factory()->create();
+
+        $trainer = User::factory()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+        $trainer->assignRole('trainer');
+        $this->makeActive($trainer);
+
+        $inScopeUser = User::factory()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+            'employee_code' => 'IN001',
+        ]);
+        $this->makeActive($inScopeUser);
+
+        $outsideUser = User::factory()->create([
+            'district_id' => $otherDistrict->id,
+            'department_id' => $otherDepartment->id,
+            'employee_code' => 'OUT001',
+        ]);
+        $this->makeActive($outsideUser);
+
+        $this->actingAs($trainer)
+            ->get(route('user.master_list'))
+            ->assertOk()
+            ->assertSee($inScopeUser->employee_code)
+            ->assertDontSee($outsideUser->employee_code);
+    }
+}


### PR DESCRIPTION
**実装概要**
`trainer` ロールを追加し、`schedule.viewAll` 権限を持つユーザーが `/calendar/{user}` で他ユーザーのカレンダーを閲覧できるようにしました。  
`trainer` は基本的に `general` と同等の扱いですが、カレンダーの他ユーザー閲覧だけを追加で許可する設計です。

**技術概要**
ロール判定ではなく permission 判定へ寄せることで、`admin` / `super_admin` / `trainer` が同じ `schedule.viewAll` 権限で `/calendar/{user}` にアクセスできます。  
画面表示、ルート制御、Controllerのユーザー選択肢、Policyの認可を同じ permission に揃えています。

**変更ファイルと目的**
[database/seeders/RoleSeeder.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/database/seeders/RoleSeeder.php)  
`trainer` ロールを作成対象に追加しました。

[database/seeders/PermissionRoleSeeder.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/database/seeders/PermissionRoleSeeder.php)  
`schedule.viewAll` permissionを作成し、`admin` / `super_admin` / `trainer` に付与しました。  
また、`user_id=4` に `trainer` ロールを割り当てるようにしました。

[database/seeders/DatabaseSeeder.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/database/seeders/DatabaseSeeder.php)  
`TrainerSeeder` を分離せず、`PermissionRoleSeeder` に集約したため、追加Seederの呼び出しを不要にしました。

[routes/web.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/routes/web.php)  
`/calendar/{user}` のmiddlewareを `role:admin|super_admin` から `permission:schedule.viewAll` に変更しました。  
これにより `trainer` も権限があれば対象ルートに入れます。

[app/Http/Controllers/CalendarController.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/app/Http/Controllers/CalendarController.php)  
カレンダー表示とイベント取得で `viewCalendar` 認可を使うようにしました。  
また、ユーザー選択肢 `$userOptions` を `schedule.viewAll` 権限を持つユーザーに渡すようにしました。

[app/Policies/UserPolicy.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/app/Policies/UserPolicy.php)  
カレンダー専用の `viewCalendar()` を追加しました。  
通常のプロフィール閲覧などに使う `view()` と分けることで、カレンダーだけ権限を広げられるようにしています。

[resources/views/calendar/index.blade.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/resources/views/calendar/index.blade.php)  
`admin|super_admin` のロール判定を `schedule.viewAll` の permission 判定に変更しました。  
これにより `trainer` でもTeacher選択欄や関連UIが表示されます。

[resources/views/commons/role/generalHeader.blade.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/resources/views/commons/role/generalHeader.blade.php)  
`trainer` は `general` と同等のヘッダーを使うため、`general|trainer` に変更しました。

[app/Models/User.php](/Users/jin6hara/Docker_6hara/Jin_Laravel/jin_docker/src/Jin_10/app/Models/User.php)  
ロール表示ラベルに `trainer => トレーナー` を追加しました。

**viewCalendar の説明**
```php
public function viewCalendar(User $currentUser, User $targetUser): bool
{
    return $currentUser->is($targetUser)
        || $this->isScopedAdminFor($currentUser, $targetUser)
        || $currentUser->can('schedule.viewAll');
}
```

`public function viewCalendar(...)`  
ユーザーのカレンダー閲覧可否を判定する、カレンダー専用のPolicyメソッドです。

`$currentUser`  
現在ログインしているユーザーです。

`$targetUser`  
閲覧対象のカレンダー所有者です。

`$currentUser->is($targetUser)`  
本人が自分のカレンダーを見る場合は許可します。  
`general` / `trainer` / `admin` すべてに共通する基本条件です。

`$this->isScopedAdminFor($currentUser, $targetUser)`  
`admin` / `super_admin` が管理スコープ内のユーザーを見る場合に許可します。  
既存の管理者向け閲覧ルールを維持するための条件です。

`$currentUser->can('schedule.viewAll')`  
`schedule.viewAll` permissionを持つユーザーにカレンダー閲覧を許可します。  
今回追加した `trainer` を `/calendar/{user}` に通すための条件です。

[schedule.viewAll 権限のカレンダー閲覧範囲を現在の district / department に限定する](https://github.com/Jin6hara/LaravelSprout/pull/121/commits/fde52e0ae76b51b6c42f844a49714d5a9fee2cd3)

```php
return $currentUser->is($targetUser)
    || $this->isScopedAdminFor($currentUser, $targetUser)
    || ($currentUser->can('schedule.viewAll') && $this->isInCurrentDistrictDepartment($targetUser));
```

追加した `isInCurrentDistrictDepartment()` で、対象ユーザーが現在の `district_id` / `department_id` と一致する場合だけ `schedule.viewAll` を許可します。

`CurrentScopeService` の仕様により:
- `admin` / `super_admin`: 選択中Scopeの district/department
- `trainer` などScopeなしユーザー: 自分自身の district/department
