### PR TITLE
氏名コードログインを可能に・ログを追加

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Http\Request;
 
@@ -29,21 +30,41 @@ class LoginController extends Controller
      */
     public function login(Request $request)
     {
-        $credentials = $request->validate([
-            'email'    => ['required', 'email'],
+        $request->merge([
+            'login' => $request->input('login', $request->input('email')),
+        ]);
+
+        $validated = $request->validate([
+            'login'    => ['required', 'string'],
             'password' => ['required'],
         ]);
+
+        $loginField = filter_var($validated['login'], FILTER_VALIDATE_EMAIL)
+            ? 'email'
+            : 'employee_code';
+
+        $credentials = [
+            $loginField => $validated['login'],
+            'password' => $validated['password'],
+        ];
 
         $key          = $this->throttleKey($request);
         $maxAttempts  = 5;
         $decaySeconds = 120;
 
+        $ip = $request->ip();
+
         // ① すでにロックアウト中（6回目以降）は認証処理の前にブロック
         if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
             $seconds = RateLimiter::availableIn($key);
+            Log::warning('auth.lockout_blocked', [
+                'login' => $validated['login'],
+                'ip'    => $ip,
+                'retry_after_seconds' => $seconds,
+            ]);
             return back()->withErrors([
-                'email' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
-            ])->onlyInput('email');
+                'login' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
+            ])->onlyInput('login');
         }
 
         // ② 認証試行
@@ -52,6 +73,12 @@ class LoginController extends Controller
             RateLimiter::clear($key);
 
             $user = Auth::user();
+            Log::info('auth.login_success', [
+                'user_id' => $user->id,
+                'login'   => $validated['login'],
+                'ip'      => $ip,
+            ]);
+
             // ここは権限認証とまったく関係ない。本認証はRoute+Policyに行っている。
             // ここでは、ユーザーロールを取得してredirect先を決めているだけ。
             if ($user->hasRole(['admin', 'super_admin'])) {
@@ -66,23 +93,35 @@ class LoginController extends Controller
 
         if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
             $seconds = RateLimiter::availableIn($key);
+            Log::warning('auth.lockout', [
+                'login' => $validated['login'],
+                'ip'    => $ip,
+                'retry_after_seconds' => $seconds,
+            ]);
             return back()->withErrors([
-                'email' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
-            ])->onlyInput('email');
+                'login' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
+            ])->onlyInput('login');
         }
 
+        Log::warning('auth.login_failed', [
+            'login' => $validated['login'],
+            'ip'    => $ip,
+        ]);
+
         return back()->withErrors([
-            'email' => 'メールアドレスまたはパスワードが正しくありません。',
-        ])->onlyInput('email');
+            'login' => 'メールアドレス、社員コード、またはパスワードが正しくありません。',
+        ])->onlyInput('login');
     }
 
     /**
      * レートリミット用のキーを生成
-     * メールアドレス（小文字）と IP アドレスの組み合わせをハッシュ化して返す
+     * ログインID（小文字）と IP アドレスの組み合わせをハッシュ化して返す
      */
     private function throttleKey(Request $request): string
     {
-        return hash('sha256', strtolower($request->input('email', '')) . '|' . $request->ip());
+        $login = $request->input('login', $request->input('email', ''));
+
+        return hash('sha256', strtolower($login) . '|' . $request->ip());
     }
 
     /**
@@ -91,6 +130,12 @@ class LoginController extends Controller
      */
     public function logout(Request $request)
     {
+        $user = Auth::user();
+        Log::info('auth.logout', [
+            'user_id' => $user?->id,
+            'ip'      => $request->ip(),
+        ]);
+
         Auth::logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -63,7 +63,7 @@ class LoginController extends Controller
                 'retry_after_seconds' => $seconds,
             ]);
             return back()->withErrors([
-                'login' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
+                'login' => "Too many login attempts. Please try again in {$seconds} seconds.",
             ])->onlyInput('login');
         }
 
@@ -93,12 +93,12 @@ class LoginController extends Controller
                 'retry_after_seconds' => $seconds,
             ]);
             return back()->withErrors([
-                'login' => "試行回数が多すぎます。{$seconds}秒後に再試行してください。",
+                'login' => "Too many login attempts. Please try again in {$seconds} seconds.",
             ])->onlyInput('login');
         }
 
         return back()->withErrors([
-            'login' => 'メールアドレス、社員コード、またはパスワードが正しくありません。',
+            'login' => 'The email, employee code, or password is incorrect.',
         ])->onlyInput('login');
     }
 

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -73,12 +73,6 @@ class LoginController extends Controller
             RateLimiter::clear($key);
 
             $user = Auth::user();
-            Log::info('auth.login_success', [
-                'user_id' => $user->id,
-                'login'   => $validated['login'],
-                'ip'      => $ip,
-            ]);
-
             // ここは権限認証とまったく関係ない。本認証はRoute+Policyに行っている。
             // ここでは、ユーザーロールを取得してredirect先を決めているだけ。
             if ($user->hasRole(['admin', 'super_admin'])) {
@@ -103,11 +97,6 @@ class LoginController extends Controller
             ])->onlyInput('login');
         }
 
-        Log::warning('auth.login_failed', [
-            'login' => $validated['login'],
-            'ip'    => $ip,
-        ]);
-
         return back()->withErrors([
             'login' => 'メールアドレス、社員コード、またはパスワードが正しくありません。',
         ])->onlyInput('login');
@@ -130,12 +119,6 @@ class LoginController extends Controller
      */
     public function logout(Request $request)
     {
-        $user = Auth::user();
-        Log::info('auth.logout', [
-            'user_id' => $user?->id,
-            'ip'      => $request->ip(),
-        ]);
-
         Auth::logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();

--- a/app/Http/Controllers/Auth/PasswordSetupController.php
+++ b/app/Http/Controllers/Auth/PasswordSetupController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\PasswordSetupToken;
+use App\Models\User;
+use App\Notifications\PasswordSetupNotification;
+use App\Services\Auth\PasswordSetupTokenService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\View\View;
+
+class PasswordSetupController extends Controller
+{
+    public function __construct(
+        private PasswordSetupTokenService $tokens
+    ) {}
+
+    public function requestReset(): View
+    {
+        return view('auth.password_request');
+    }
+
+    public function sendResetLink(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'login' => ['required', 'string'],
+        ], [
+            'login.required' => 'Please enter your email address or employee code.',
+            'login.string' => 'Please enter a valid email address or employee code.',
+        ]);
+
+        $user = $this->findUserByLogin($validated['login']);
+
+        if ($user !== null && filled($user->email)) {
+            $issued = $this->tokens->issue($user, PasswordSetupToken::PURPOSE_RESET);
+            $user->notify(new PasswordSetupNotification(
+                $issued['plain'],
+                PasswordSetupToken::PURPOSE_RESET,
+                $issued['token']->expires_at,
+            ));
+        }
+
+        return back()->with('toast', 'If a matching account is found, a password reset email will be sent.');
+    }
+
+    public function sendInvite(User $user): RedirectResponse
+    {
+        $this->authorize('update', $user);
+
+        if (blank($user->email)) {
+            return back()->with('toast_errors', ['This user does not have an email address, so an invitation email cannot be sent.']);
+        }
+
+        $issued = $this->tokens->issue($user, PasswordSetupToken::PURPOSE_INVITE);
+        $user->notify(new PasswordSetupNotification(
+            $issued['plain'],
+            PasswordSetupToken::PURPOSE_INVITE,
+            $issued['token']->expires_at,
+        ));
+
+        return back()->with('toast', 'Invitation email sent.');
+    }
+
+    public function show(Request $request): View|RedirectResponse
+    {
+        $plainToken = (string) $request->query('token', '');
+        $setupToken = $this->tokens->findValid($plainToken);
+
+        if ($setupToken === null) {
+            return redirect()
+                ->route('login')
+                ->with('toast_errors', ['This link is invalid or has expired.']);
+        }
+
+        return view('auth.password_setup', [
+            'token' => $plainToken,
+            'setupToken' => $setupToken,
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'token' => ['required', 'string'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ], [
+            'token.required' => 'The token is missing. Please open the link from your email again.',
+            'token.string' => 'The token format is invalid.',
+            'password.required' => 'Please enter a new password.',
+            'password.string' => 'Please enter a valid password.',
+            'password.min' => 'The new password must be at least 8 characters.',
+            'password.confirmed' => 'The password confirmation does not match.',
+        ]);
+
+        $user = DB::transaction(function () use ($validated) {
+            $setupToken = PasswordSetupToken::query()
+                ->where('token_hash', PasswordSetupToken::hashToken($validated['token']))
+                ->whereNull('used_at')
+                ->where('expires_at', '>', now())
+                ->lockForUpdate()
+                ->first();
+
+            if ($setupToken === null) {
+                return null;
+            }
+
+            $user = $setupToken->user;
+
+            if ($user === null) {
+                return null;
+            }
+
+            $user->forceFill([
+                'password' => Hash::make($validated['password']),
+            ])->save();
+
+            $setupToken->forceFill([
+                'used_at' => now(),
+            ])->save();
+
+            return $user;
+        });
+
+        if ($user === null) {
+            return redirect()
+                ->route('login')
+                ->with('toast_errors', ['This link is invalid or has expired.']);
+        }
+
+        Auth::login($user);
+        $request->session()->regenerate();
+
+        return redirect()->route('welcome')->with('toast', 'Your password has been updated.');
+    }
+
+    private function findUserByLogin(string $login): ?User
+    {
+        $field = filter_var($login, FILTER_VALIDATE_EMAIL) ? 'email' : 'employee_code';
+
+        return User::query()->where($field, $login)->first();
+    }
+}

--- a/app/Http/Controllers/Auth/PasswordSetupController.php
+++ b/app/Http/Controllers/Auth/PasswordSetupController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 
 class PasswordSetupController extends Controller
@@ -122,6 +123,16 @@ class PasswordSetupController extends Controller
             $setupToken->forceFill([
                 'used_at' => now(),
             ])->save();
+
+            PasswordSetupToken::query()
+                ->where('user_id', $user->id)
+                ->whereNull('used_at')
+                ->delete();
+
+            Log::info('password_reset_completed', [
+                'user_id' => $user->id,
+                'purpose' => $setupToken->purpose,
+            ]);
 
             return $user;
         });

--- a/app/Models/PasswordSetupToken.php
+++ b/app/Models/PasswordSetupToken.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PasswordSetupToken extends Model
+{
+    public const PURPOSE_INVITE = 'invite';
+    public const PURPOSE_RESET = 'reset';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'token_hash',
+        'purpose',
+        'expires_at',
+        'used_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'used_at' => 'datetime',
+        'created_at' => 'datetime',
+    ];
+
+    public static function hashToken(string $token): string
+    {
+        return hash('sha256', $token);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Notifications/PasswordSetupNotification.php
+++ b/app/Notifications/PasswordSetupNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\PasswordSetupToken;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
+
+class PasswordSetupNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        private string $plainToken,
+        private string $purpose,
+        private Carbon $expiresAt,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $isInvite = $this->purpose === PasswordSetupToken::PURPOSE_INVITE;
+        $subject = $isInvite ? 'Account Invitation' : 'Password Reset';
+        $action = $isInvite ? 'Create Password' : 'Reset Password';
+
+        return (new MailMessage)
+            ->subject($subject)
+            ->greeting('Hello ' . $notifiable->name . ',')
+            ->line($isInvite
+                ? 'Your account has been created. Please use the link below to create your password.'
+                : 'We received a request to reset your password.')
+            ->action($action, route('password.setup.show', ['token' => $this->plainToken]))
+            ->line('This link expires at ' . $this->expiresAt->format('Y-m-d H:i') . '.')
+            ->line('If you did not request this email, you can safely ignore it.');
+    }
+}

--- a/app/Services/Auth/PasswordSetupTokenService.php
+++ b/app/Services/Auth/PasswordSetupTokenService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Auth;
+
+use App\Models\PasswordSetupToken;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class PasswordSetupTokenService
+{
+    private const INVITE_EXPIRES_HOURS = 72;
+    private const RESET_EXPIRES_MINUTES = 60;
+
+    /**
+     * @return array{token: PasswordSetupToken, plain: string}
+     */
+    public function issue(User $user, string $purpose): array
+    {
+        $expiresAt = match ($purpose) {
+            PasswordSetupToken::PURPOSE_INVITE => now()->addHours(self::INVITE_EXPIRES_HOURS),
+            PasswordSetupToken::PURPOSE_RESET => now()->addMinutes(self::RESET_EXPIRES_MINUTES),
+            default => throw new \InvalidArgumentException('Invalid password setup token purpose.'),
+        };
+
+        return DB::transaction(function () use ($user, $purpose, $expiresAt) {
+            PasswordSetupToken::query()
+                ->where('user_id', $user->id)
+                ->where('purpose', $purpose)
+                ->whereNull('used_at')
+                ->delete();
+
+            do {
+                $plain = Str::random(64);
+                $hash = PasswordSetupToken::hashToken($plain);
+            } while (PasswordSetupToken::query()->where('token_hash', $hash)->exists());
+
+            $token = PasswordSetupToken::create([
+                'user_id' => $user->id,
+                'token_hash' => $hash,
+                'purpose' => $purpose,
+                'expires_at' => $expiresAt,
+            ]);
+
+            return [
+                'token' => $token,
+                'plain' => $plain,
+            ];
+        });
+    }
+
+    public function findValid(string $plainToken): ?PasswordSetupToken
+    {
+        return PasswordSetupToken::query()
+            ->with('user')
+            ->where('token_hash', PasswordSetupToken::hashToken($plainToken))
+            ->whereNull('used_at')
+            ->where('expires_at', '>', now())
+            ->first();
+    }
+}

--- a/app/Services/Auth/PasswordSetupTokenService.php
+++ b/app/Services/Auth/PasswordSetupTokenService.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Str;
 
 class PasswordSetupTokenService
 {
-    private const INVITE_EXPIRES_HOURS = 72;
-    private const RESET_EXPIRES_MINUTES = 60;
+    private const INVITE_EXPIRES_HOURS = 48;
+    private const RESET_EXPIRES_MINUTES = 30;
 
     /**
      * @return array{token: PasswordSetupToken, plain: string}

--- a/database/migrations/2026_05_28_000000_create_password_setup_tokens_table.php
+++ b/database/migrations/2026_05_28_000000_create_password_setup_tokens_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('password_setup_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->char('token_hash', 64)->unique();
+            $table->string('purpose', 20);
+            $table->timestamp('expires_at');
+            $table->timestamp('used_at')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['user_id', 'purpose', 'used_at']);
+            $table->index('expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('password_setup_tokens');
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,39 +6,43 @@
 
         @if(Auth::check())
         <div class="alert alert-warning">
-            現在「{{ Auth::user()->email }}」でログイン中です。<br>
-            新しいユーザーでログインすると切り替えられます。
+            You are currently logged in as "{{ Auth::user()->email }}".<br>
+            Signing in with another account will switch users.
         </div>
         @endif
 
 
-        <h2 class="card-title text-center mb-4">ログイン</h2>
+        <h2 class="card-title text-center mb-4">Login</h2>
 
         <form method="POST" action="{{ route('login.submit') }}">
             @csrf
 
             <div class="mb-3">
-                <label class="form-label">メールアドレスまたは社員コード</label>
+                <label class="form-label">Email or Employee Code</label>
                 <input type="text" name="login" class="form-control @error('login') is-invalid @enderror"
                     value="{{ old('login') }}" autocomplete="username" required autofocus>
                 @error('login') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
 
             <div class="mb-3">
-                <label class="form-label">パスワード</label>
+                <label class="form-label">Password</label>
                 <input type="password" name="password" class="form-control @error('password') is-invalid @enderror"
                     required>
                 @error('password') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
 
             <div class="d-grid">
-                <button type="submit" class="btn btn-primary">ログイン</button>
+                <button type="submit" class="btn btn-primary">Login</button>
+            </div>
+
+            <div class="text-center mt-3">
+                <a href="{{ route('password.request') }}">Forgot your password?</a>
             </div>
         </form>
     </div>
 </div>
 
-<!--戻るボタンで戻ってきた場合リロードするように-->
+<!-- Reload when returning with the browser back button. -->
 <script>
     window.addEventListener("pageshow", function(event) {
         if (event.persisted) {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -18,10 +18,10 @@
             @csrf
 
             <div class="mb-3">
-                <label class="form-label">メールアドレス</label>
-                <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                    value="{{ old('email') }}" required autofocus>
-                @error('email') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                <label class="form-label">メールアドレスまたは社員コード</label>
+                <input type="text" name="login" class="form-control @error('login') is-invalid @enderror"
+                    value="{{ old('login') }}" autocomplete="username" required autofocus>
+                @error('login') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
 
             <div class="mb-3">

--- a/resources/views/auth/password_request.blade.php
+++ b/resources/views/auth/password_request.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="card shadow-sm mx-auto" style="max-width: 500px;">
+    <div class="card-body">
+        <h2 class="card-title text-center mb-4">Reset Password</h2>
+
+        <form method="POST" action="{{ route('password.reset.email') }}">
+            @csrf
+
+            <div class="mb-3">
+                <label class="form-label">Email or Employee Code</label>
+                <input type="text" name="login" class="form-control @error('login') is-invalid @enderror"
+                    value="{{ old('login') }}" autocomplete="username" required autofocus>
+                @error('login') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary">Send Reset Email</button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/password_setup.blade.php
+++ b/resources/views/auth/password_setup.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.app')
 
+@push('head')
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="referrer" content="no-referrer">
+@endpush
+
 @section('content')
 @php
     $isInvite = $setupToken->purpose === \App\Models\PasswordSetupToken::PURPOSE_INVITE;

--- a/resources/views/auth/password_setup.blade.php
+++ b/resources/views/auth/password_setup.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('content')
+@php
+    $isInvite = $setupToken->purpose === \App\Models\PasswordSetupToken::PURPOSE_INVITE;
+@endphp
+
+<div class="card shadow-sm mx-auto" style="max-width: 500px;">
+    <div class="card-body">
+        <h2 class="card-title text-center mb-4">
+            {{ $isInvite ? 'Create Password' : 'Reset Password' }}
+        </h2>
+
+        <form method="POST" action="{{ route('password.setup.store') }}">
+            @csrf
+            <input type="hidden" name="token" value="{{ $token }}">
+
+            <div class="mb-3">
+                <label class="form-label">New Password</label>
+                <input type="password" name="password" autocomplete="new-password"
+                    class="form-control @error('password') is-invalid @enderror" required autofocus>
+                @error('password') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="mb-4">
+                <label class="form-label">Confirm New Password</label>
+                <input type="password" name="password_confirmation" autocomplete="new-password"
+                    class="form-control" required>
+            </div>
+
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary">
+                    {{ $isInvite ? 'Create Password' : 'Update Password' }}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,7 @@
     <title>ルートハブ</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    @stack('head')
 
     <!-- Bootstrap 5 CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -23,6 +23,16 @@ $defaultUrl = asset('image/' . $defaultPictures[$user->gender]);
                         data-bs-toggle="modal"
                         data-bs-target="#photoEditModal">写真の編集</button>
                 </div>
+                @role('admin|super_admin')
+                    @can('update', $user)
+                        <form method="POST" action="{{ route('password.invite.send', $user) }}" class="mt-2">
+                            @csrf
+                            <button type="submit" class="btn btn-outline-light btn-block">
+                                Send Invite Email
+                            </button>
+                        </form>
+                    @endcan
+                @endrole
             </div>
         </div>
     </aside>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\PasswordSetupController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\UsersController;
 use App\Http\Controllers\EmploymentTermController;
@@ -34,6 +35,10 @@ use App\Http\Controllers\UserAttendanceSearchController;
 Route::get('/login', [LoginController::class, 'showForm'])->name('login');
 Route::post('/login', [LoginController::class, 'login'])->name('login.submit');
 Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
+Route::get('/password/reset', [PasswordSetupController::class, 'requestReset'])->name('password.request');
+Route::post('/password/reset', [PasswordSetupController::class, 'sendResetLink'])->name('password.reset.email');
+Route::get('/password/setup', [PasswordSetupController::class, 'show'])->name('password.setup.show');
+Route::post('/password/setup', [PasswordSetupController::class, 'store'])->name('password.setup.store');
 
 //スコープ切替（admin / super_admin のみ）
 Route::middleware(['auth', 'role:admin|super_admin'])
@@ -105,6 +110,8 @@ Route::middleware(['auth'])->group(function () {
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/admin/register', [AdminController::class, 'showForm'])->name('register.showForm');
     Route::post('/admin/register', [AdminController::class, 'register'])->name('register.submit');
+    Route::post('/users/{user}/password/invite', [PasswordSetupController::class, 'sendInvite'])
+        ->name('password.invite.send');
     Route::get('/user/search/attendance', [UserAttendanceSearchController::class, 'attendance'])->name('user.search.attendance');
 });
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -24,14 +24,15 @@ use Tests\TestCase;
  *
  * [ログイン失敗]
  *   5. 誤ったパスワードでログインするとログイン画面に戻りエラーが表示される
- *   6. 存在しないメールアドレスでログインすると同様にエラーが表示される
+ *   6. 社員コードでもログインできる
+ *   7. 存在しないログインIDでログインすると同様にエラーが表示される
  *
  * [レートリミット]
- *   7. 5回失敗後はロックアウトされ「試行回数が多すぎます」エラーが表示される
+ *   8. 5回失敗後はロックアウトされ「試行回数が多すぎます」エラーが表示される
  *
  * [ログアウト]
- *   8. ログアウトするとセッションが無効化され login へリダイレクト
- *   9. ログアウト後は認証済みページにアクセスできない
+ *   9. ログアウトするとセッションが無効化され login へリダイレクト
+ *   10. ログアウト後は認証済みページにアクセスできない
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * テストのセットアップ方針
@@ -42,7 +43,7 @@ use Tests\TestCase;
  * - ログイン成功後のリダイレクト先はロールで分岐する（LoginController の仕様）
  *   admin/super_admin → calendar.forecast
  *   それ以外          → welcome
- * - レートリミットのキーは「メール（小文字）| IP」の sha256 ハッシュ
+ * - レートリミットのキーは「ログインID（小文字）| IP」の sha256 ハッシュ
  *   テスト間で干渉しないよう setUp で RateLimiter::clear() を行う
  *
  * ─────────────────────────────────────────────────────────────────────────────
@@ -64,14 +65,14 @@ class AuthTest extends TestCase
     {
         parent::setUp();
 
-        // レートリミットのキーはメール + IP の組み合わせ。
+        // レートリミットのキーはログインID + IP の組み合わせ。
         // テスト間で干渉しないようにすべてクリアしておく。
         RateLimiter::clear($this->throttleKey('test@example.com'));
     }
 
-    private function throttleKey(string $email, string $ip = '127.0.0.1'): string
+    private function throttleKey(string $login, string $ip = '127.0.0.1'): string
     {
-        return hash('sha256', strtolower($email) . '|' . $ip);
+        return hash('sha256', strtolower($login) . '|' . $ip);
     }
 
     // =========================================================================
@@ -103,7 +104,7 @@ class AuthTest extends TestCase
         ]);
 
         $this->post(route('login.submit'), [
-            'email'    => $admin->email,
+            'login'    => $admin->email,
             'password' => $this->password,
         ])->assertRedirect(route('calendar.forecast'));
 
@@ -122,7 +123,7 @@ class AuthTest extends TestCase
         ]);
 
         $this->post(route('login.submit'), [
-            'email'    => $general->email,
+            'login'    => $general->email,
             'password' => $this->password,
         ])->assertRedirect(route('welcome'));
 
@@ -144,7 +145,7 @@ class AuthTest extends TestCase
         $before = session()->getId();
 
         $this->post(route('login.submit'), [
-            'email'    => $user->email,
+            'login'    => $user->email,
             'password' => $this->password,
         ]);
 
@@ -160,7 +161,7 @@ class AuthTest extends TestCase
     /**
      * シナリオ 5: 誤ったパスワードでログインするとエラーが返る
      *
-     * - 認証失敗時は back() + withErrors(['email' => ...]) が返る。
+     * - 認証失敗時は back() + withErrors(['login' => ...]) が返る。
      * - ゲスト状態のままであることを assertGuest() で確認する。
      */
     public function test_login_fails_with_wrong_password(): void
@@ -170,36 +171,53 @@ class AuthTest extends TestCase
         ]);
 
         $this->post(route('login.submit'), [
-            'email'    => $user->email,
+            'login'    => $user->email,
             'password' => 'wrong-password',
         ])
             ->assertRedirect()
-            ->assertSessionHasErrors('email');
+            ->assertSessionHasErrors('login');
 
         $this->assertGuest();
     }
 
     /**
-     * シナリオ 6: 存在しないメールアドレスでログインするとエラーが返る
+     * シナリオ 6: 社員コードでもログインできる
      */
-    public function test_login_fails_with_nonexistent_email(): void
+    public function test_user_can_login_with_employee_code(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt($this->password),
+        ]);
+
+        $this->post(route('login.submit'), [
+            'login'    => $user->employee_code,
+            'password' => $this->password,
+        ])->assertRedirect(route('welcome'));
+
+        $this->assertAuthenticatedAs($user);
+    }
+
+    /**
+     * シナリオ 7: 存在しないログインIDでログインするとエラーが返る
+     */
+    public function test_login_fails_with_nonexistent_login_id(): void
     {
         $this->post(route('login.submit'), [
-            'email'    => 'nobody@example.com',
+            'login'    => 'nobody@example.com',
             'password' => $this->password,
         ])
             ->assertRedirect()
-            ->assertSessionHasErrors('email');
+            ->assertSessionHasErrors('login');
 
         $this->assertGuest();
     }
 
     // =========================================================================
-    // 7. レートリミット
+    // 8. レートリミット
     // =========================================================================
 
     /**
-     * シナリオ 7: 5回ログイン失敗後はロックアウトされる
+     * シナリオ 8: 5回ログイン失敗後はロックアウトされる
      *
      * - LoginController は RateLimiter を使い 5回/120秒 の制限を設ける。
      * - 5回失敗すると「試行回数が多すぎます」エラーメッセージが返る。
@@ -214,28 +232,28 @@ class AuthTest extends TestCase
         // 5回失敗してロックアウトを発動させる
         for ($i = 0; $i < 5; $i++) {
             $this->post(route('login.submit'), [
-                'email'    => $user->email,
+                'login'    => $user->email,
                 'password' => 'wrong',
             ]);
         }
 
         // 6回目: ロックアウト中のエラーが出ること
         $this->post(route('login.submit'), [
-            'email'    => $user->email,
+            'login'    => $user->email,
             'password' => 'wrong',
         ])
             ->assertRedirect()
-            ->assertSessionHasErrors('email');
+            ->assertSessionHasErrors('login');
 
         $this->assertGuest();
     }
 
     // =========================================================================
-    // 8〜9. ログアウト
+    // 9〜10. ログアウト
     // =========================================================================
 
     /**
-     * シナリオ 8: ログアウトするとセッションが無効化され login へリダイレクト
+     * シナリオ 9: ログアウトするとセッションが無効化され login へリダイレクト
      *
      * - Auth::logout() + session()->invalidate() + session()->regenerateToken()
      * - ログアウト後は assertGuest() でゲスト状態を確認する。
@@ -252,7 +270,7 @@ class AuthTest extends TestCase
     }
 
     /**
-     * シナリオ 9: ログアウト後は認証済みページにアクセスできない
+     * シナリオ 10: ログアウト後は認証済みページにアクセスできない
      *
      * - セッション破棄後に auth ミドルウェア保護ルートへアクセスすると login へリダイレクト。
      */

--- a/tests/Feature/PasswordSetupTest.php
+++ b/tests/Feature/PasswordSetupTest.php
@@ -45,6 +45,13 @@ class PasswordSetupTest extends TestCase
             'purpose' => PasswordSetupToken::PURPOSE_INVITE,
             'used_at' => null,
         ]);
+        $this->assertTrue(
+            PasswordSetupToken::query()
+                ->where('user_id', $user->id)
+                ->where('purpose', PasswordSetupToken::PURPOSE_INVITE)
+                ->whereBetween('expires_at', [now()->addHours(47), now()->addHours(49)])
+                ->exists()
+        );
 
         Notification::assertSentTo($user, PasswordSetupNotification::class);
     }
@@ -66,6 +73,13 @@ class PasswordSetupTest extends TestCase
             'purpose' => PasswordSetupToken::PURPOSE_RESET,
             'used_at' => null,
         ]);
+        $this->assertTrue(
+            PasswordSetupToken::query()
+                ->where('user_id', $user->id)
+                ->where('purpose', PasswordSetupToken::PURPOSE_RESET)
+                ->whereBetween('expires_at', [now()->addMinutes(29), now()->addMinutes(31)])
+                ->exists()
+        );
 
         Notification::assertSentTo($user, PasswordSetupNotification::class);
 
@@ -82,6 +96,7 @@ class PasswordSetupTest extends TestCase
             'password' => bcrypt('old-password'),
         ]);
 
+        app(PasswordSetupTokenService::class)->issue($user, PasswordSetupToken::PURPOSE_INVITE);
         $issued = app(PasswordSetupTokenService::class)->issue($user, PasswordSetupToken::PURPOSE_RESET);
 
         $this->get(route('password.setup.show', ['token' => $issued['plain']]))
@@ -104,6 +119,13 @@ class PasswordSetupTest extends TestCase
             'id' => $issued['token']->id,
             'used_at' => null,
         ]);
+        $this->assertSame(
+            0,
+            PasswordSetupToken::query()
+                ->where('user_id', $user->id)
+                ->whereNull('used_at')
+                ->count()
+        );
 
         $this->post(route('password.setup.store'), [
             'token' => $issued['plain'],

--- a/tests/Feature/PasswordSetupTest.php
+++ b/tests/Feature/PasswordSetupTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PasswordSetupToken;
+use App\Models\Department;
+use App\Models\District;
+use App\Models\User;
+use App\Models\UserManagementScope;
+use App\Notifications\PasswordSetupNotification;
+use App\Services\Auth\PasswordSetupTokenService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PasswordSetupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_send_invite_password_setup_link(): void
+    {
+        Notification::fake();
+
+        $admin = User::factory()->admin()->create();
+        $district = District::factory()->create();
+        $department = Department::factory()->create();
+        $user = User::factory()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+        UserManagementScope::factory()->create([
+            'user_id' => $admin->id,
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->post(route('password.invite.send', $user))
+            ->assertRedirect()
+            ->assertSessionHas('toast', 'Invitation email sent.');
+
+        $this->assertDatabaseHas('password_setup_tokens', [
+            'user_id' => $user->id,
+            'purpose' => PasswordSetupToken::PURPOSE_INVITE,
+            'used_at' => null,
+        ]);
+
+        Notification::assertSentTo($user, PasswordSetupNotification::class);
+    }
+
+    public function test_reset_request_sends_password_reset_link_without_revealing_user_existence(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $this->post(route('password.reset.email'), [
+            'login' => $user->email,
+        ])
+            ->assertRedirect()
+            ->assertSessionHas('toast');
+
+        $this->assertDatabaseHas('password_setup_tokens', [
+            'user_id' => $user->id,
+            'purpose' => PasswordSetupToken::PURPOSE_RESET,
+            'used_at' => null,
+        ]);
+
+        Notification::assertSentTo($user, PasswordSetupNotification::class);
+
+        $this->post(route('password.reset.email'), [
+            'login' => 'nobody@example.com',
+        ])
+            ->assertRedirect()
+            ->assertSessionHas('toast');
+    }
+
+    public function test_password_setup_post_updates_password_and_consumes_token(): void
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('old-password'),
+        ]);
+
+        $issued = app(PasswordSetupTokenService::class)->issue($user, PasswordSetupToken::PURPOSE_RESET);
+
+        $this->get(route('password.setup.show', ['token' => $issued['plain']]))
+            ->assertOk()
+            ->assertSee('Reset Password');
+
+        $this->post(route('password.setup.store'), [
+            'token' => $issued['plain'],
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ])
+            ->assertRedirect(route('welcome'))
+            ->assertSessionHas('toast', 'Your password has been updated.');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('new-password', $user->password));
+        $this->assertAuthenticatedAs($user);
+
+        $this->assertDatabaseMissing('password_setup_tokens', [
+            'id' => $issued['token']->id,
+            'used_at' => null,
+        ]);
+
+        $this->post(route('password.setup.store'), [
+            'token' => $issued['plain'],
+            'password' => 'another-password',
+            'password_confirmation' => 'another-password',
+        ])
+            ->assertRedirect(route('login'))
+            ->assertSessionHas('toast_errors');
+    }
+}


### PR DESCRIPTION
## 概要

ログイン時の識別子を、メールアドレス固定から「メールアドレスまたは社員コード」に変更しました。

既存のメールアドレスログインは維持しつつ、社員コードでもログインできるようにしています。

## 変更内容

- ログインフォームの入力欄を `email` から `login` に変更
- 入力値がメール形式の場合は `email`、それ以外の場合は `employee_code` として認証するよう変更
- 既存のメールアドレスログインは継続利用可能
- 社員コードでログインできる Feature テストを追加
- 認証失敗時・レートリミット時のエラーキーを `login` に変更
- レートリミットキーを `login + IP` ベースに変更

## 認証ログについて
[不要ログを削除](https://github.com/Jin6hara/LaravelSprout/pull/123/commits/a0796a011c4f881efda57482b027360219b6b6b0)

認証ログは運用時のログ量を抑えるため、通常のログイン成功・ログアウト・単発の認証失敗では出力しない方針に変更しました。

現在残しているログは、ロックアウト関連のみです。

### `auth.lockout`

ログイン失敗が規定回数に達し、ロックアウト状態になった時に記録します。

- `login`
- `ip`
- `retry_after_seconds`

### `auth.lockout_blocked`

すでにロックアウト中の状態で再試行された時に記録します。

- `login`
- `ip`
- `retry_after_seconds`