### PR TITLE
SpatieのRole Management機能を追加

### DIFF
--- a/app/Http/Controllers/RoleChangeController.php
+++ b/app/Http/Controllers/RoleChangeController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Services\RoleChange\RoleChangeApplicationService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Spatie\Permission\Models\Role;
 
 class RoleChangeController extends Controller
 {
@@ -21,7 +22,7 @@ class RoleChangeController extends Controller
     public function show(User $user): View
     {
         $currentRole    = $user->getRoleNames()->first();
-        $availableRoles = ['general', 'admin', 'super_admin'];
+        $availableRoles = Role::where('guard_name', 'web')->orderBy('name')->pluck('name')->all();
 
         $districts   = District::whereNull('parent_id')->with('children')->orderBy('name')->get();
         $departments = Department::orderBy('name')->get();
@@ -51,6 +52,6 @@ class RoleChangeController extends Controller
             $data['scopes'] ?? [],
         );
 
-        return back()->with('toast', '権限変更の申請を受け付けました。');
+        return back()->with('toast', 'Role change request submitted.');
     }
 }

--- a/app/Http/Controllers/RoleManageController.php
+++ b/app/Http/Controllers/RoleManageController.php
@@ -120,57 +120,6 @@ class RoleManageController extends Controller
         return response()->json(null, 204);
     }
 
-    public function storePermission(Request $request)
-    {
-        $this->authorizeSuperAdmin();
-        $this->requireConfirmed($request);
-
-        $data = $request->validate([
-            'name' => ['required', 'string', 'max:255', 'regex:/^[A-Za-z0-9_.-]+$/', Rule::unique('permissions')->where('guard_name', self::GUARD)],
-        ]);
-
-        $permission = Permission::create(['name' => $data['name'], 'guard_name' => self::GUARD]);
-        $this->forgetPermissionCache();
-
-        return response()->json($this->formatPermission($permission->loadCount('roles')), 201);
-    }
-
-    public function updatePermission(Request $request, Permission $permission)
-    {
-        $this->authorizeSuperAdmin();
-        $this->requireWebGuard($permission);
-        $this->requireConfirmed($request);
-        $this->ensurePermissionCanBeChanged($permission, 'updated');
-
-        $data = $request->validate([
-            'name' => [
-                'required',
-                'string',
-                'max:255',
-                'regex:/^[A-Za-z0-9_.-]+$/',
-                Rule::unique('permissions')->where('guard_name', self::GUARD)->ignore($permission->id),
-            ],
-        ]);
-
-        $permission->update(['name' => $data['name']]);
-        $this->forgetPermissionCache();
-
-        return response()->json($this->formatPermission($permission->fresh()->loadCount('roles')));
-    }
-
-    public function destroyPermission(Request $request, Permission $permission)
-    {
-        $this->authorizeSuperAdmin();
-        $this->requireWebGuard($permission);
-        $this->requireConfirmed($request);
-        $this->ensurePermissionCanBeChanged($permission, 'deleted');
-
-        $permission->delete();
-        $this->forgetPermissionCache();
-
-        return response()->json(null, 204);
-    }
-
     public function storeRolePermission(Request $request)
     {
         $this->authorizeSuperAdmin();
@@ -410,16 +359,6 @@ class RoleManageController extends Controller
         abort_if($role->permissions_count > 0, 422, "This role has permissions and cannot be {$action}.");
     }
 
-    private function ensurePermissionCanBeChanged(Permission $permission, string $action): void
-    {
-        abort_if(in_array($permission->name, self::CODE_PERMISSIONS, true), 422, "Code permission '{$permission->name}' cannot be {$action}.");
-
-        $roleCount = $permission->roles()->count();
-        $modelCount = $this->directUserPermissionCount($permission);
-        abort_if($roleCount > 0, 422, "This permission is assigned to roles and cannot be {$action}.");
-        abort_if($modelCount > 0, 422, "This permission is assigned directly to users and cannot be {$action}.");
-    }
-
     private function ensureRolePermissionCanBeRemoved(Role $role, Permission $permission): void
     {
         abort_if(
@@ -531,9 +470,19 @@ class RoleManageController extends Controller
             'roles_count' => $rolesCount,
             'users_count' => $usersCount,
             'is_code_permission' => $isCodePermission,
+            'description' => $this->permissionDescription($permission->name),
             'can_update' => ! $isCodePermission && $rolesCount === 0 && $usersCount === 0,
             'can_delete' => ! $isCodePermission && $rolesCount === 0 && $usersCount === 0,
         ];
+    }
+
+    private function permissionDescription(string $name): string
+    {
+        return match ($name) {
+            'schedule.viewAll' => '自分以外のScheduleの観覧権限',
+            'teacher.viewAll' => 'Master List の観覧権限',
+            default => 'コード側で定義された権限です。利用前にmiddleware / policy / view条件を確認してください。',
+        };
     }
 
     private function directUserPermissionCount(Permission $permission): int

--- a/app/Http/Controllers/RoleManageController.php
+++ b/app/Http/Controllers/RoleManageController.php
@@ -17,8 +17,6 @@ class RoleManageController extends Controller
     private const CORE_ROLES = [
         'super_admin',
         'admin',
-        'general',
-        'trainer',
     ];
 
     private const CODE_PERMISSIONS = [
@@ -55,10 +53,12 @@ class RoleManageController extends Controller
             'users' => User::query()
                 ->orderBy('family_name')
                 ->orderBy('first_name')
-                ->get(['id', 'employee_code', 'name', 'email'])
+                ->get(['id', 'employee_code', 'family_name', 'first_name', 'name', 'email'])
                 ->map(fn (User $user) => [
                     'id' => $user->id,
                     'employee_code' => $user->employee_code,
+                    'family_name' => $user->family_name,
+                    'first_name' => $user->first_name,
                     'name' => $user->name,
                     'email' => $user->email,
                 ])
@@ -470,6 +470,8 @@ class RoleManageController extends Controller
             ->get([
                 'u.id as user_id',
                 'u.employee_code',
+                'u.family_name',
+                'u.first_name',
                 'u.name as user_name',
                 'u.email',
                 'r.id as role_id',

--- a/app/Http/Controllers/RoleManageController.php
+++ b/app/Http/Controllers/RoleManageController.php
@@ -1,0 +1,549 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RoleManageController extends Controller
+{
+    private const GUARD = 'web';
+
+    private const CORE_ROLES = [
+        'super_admin',
+        'admin',
+        'general',
+        'trainer',
+    ];
+
+    private const CODE_PERMISSIONS = [
+        'schedule.viewAll',
+        'teacher.viewAll',
+    ];
+
+    public function index()
+    {
+        $this->authorizeSuperAdmin();
+
+        return view('data.role_manage');
+    }
+
+    public function snapshot()
+    {
+        $this->authorizeSuperAdmin();
+
+        return response()->json([
+            'roles' => Role::query()
+                ->withCount(['permissions', 'users'])
+                ->where('guard_name', self::GUARD)
+                ->orderBy('name')
+                ->get()
+                ->map(fn (Role $role) => $this->formatRole($role))
+                ->values(),
+            'permissions' => Permission::query()
+                ->withCount('roles')
+                ->where('guard_name', self::GUARD)
+                ->orderBy('name')
+                ->get()
+                ->map(fn (Permission $permission) => $this->formatPermission($permission))
+                ->values(),
+            'users' => User::query()
+                ->orderBy('family_name')
+                ->orderBy('first_name')
+                ->get(['id', 'employee_code', 'name', 'email'])
+                ->map(fn (User $user) => [
+                    'id' => $user->id,
+                    'employee_code' => $user->employee_code,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                ])
+                ->values(),
+            'role_permissions' => $this->rolePermissions(),
+            'model_roles' => $this->modelRoles(),
+            'model_permissions' => $this->modelPermissions(),
+        ]);
+    }
+
+    public function storeRole(Request $request)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireConfirmed($request);
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255', 'regex:/^[A-Za-z0-9_.-]+$/', Rule::unique('roles')->where('guard_name', self::GUARD)],
+        ]);
+
+        $role = Role::create(['name' => $data['name'], 'guard_name' => self::GUARD]);
+        $this->forgetPermissionCache();
+
+        return response()->json($this->formatRole($role->loadCount(['permissions', 'users'])), 201);
+    }
+
+    public function updateRole(Request $request, Role $role)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($role);
+        $this->requireConfirmed($request);
+        $this->ensureRoleCanBeChanged($role, 'updated');
+
+        $data = $request->validate([
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'regex:/^[A-Za-z0-9_.-]+$/',
+                Rule::unique('roles')->where('guard_name', self::GUARD)->ignore($role->id),
+            ],
+        ]);
+
+        $role->update(['name' => $data['name']]);
+        $this->forgetPermissionCache();
+
+        return response()->json($this->formatRole($role->fresh()->loadCount(['permissions', 'users'])));
+    }
+
+    public function destroyRole(Request $request, Role $role)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($role);
+        $this->requireConfirmed($request);
+        $this->ensureRoleCanBeChanged($role, 'deleted');
+
+        $role->delete();
+        $this->forgetPermissionCache();
+
+        return response()->json(null, 204);
+    }
+
+    public function storePermission(Request $request)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireConfirmed($request);
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255', 'regex:/^[A-Za-z0-9_.-]+$/', Rule::unique('permissions')->where('guard_name', self::GUARD)],
+        ]);
+
+        $permission = Permission::create(['name' => $data['name'], 'guard_name' => self::GUARD]);
+        $this->forgetPermissionCache();
+
+        return response()->json($this->formatPermission($permission->loadCount('roles')), 201);
+    }
+
+    public function updatePermission(Request $request, Permission $permission)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($permission);
+        $this->requireConfirmed($request);
+        $this->ensurePermissionCanBeChanged($permission, 'updated');
+
+        $data = $request->validate([
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'regex:/^[A-Za-z0-9_.-]+$/',
+                Rule::unique('permissions')->where('guard_name', self::GUARD)->ignore($permission->id),
+            ],
+        ]);
+
+        $permission->update(['name' => $data['name']]);
+        $this->forgetPermissionCache();
+
+        return response()->json($this->formatPermission($permission->fresh()->loadCount('roles')));
+    }
+
+    public function destroyPermission(Request $request, Permission $permission)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($permission);
+        $this->requireConfirmed($request);
+        $this->ensurePermissionCanBeChanged($permission, 'deleted');
+
+        $permission->delete();
+        $this->forgetPermissionCache();
+
+        return response()->json(null, 204);
+    }
+
+    public function storeRolePermission(Request $request)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireConfirmed($request);
+
+        [$role, $permission] = $this->validateRolePermissionInput($request);
+
+        abort_if($role->hasPermissionTo($permission), 422, 'This role already has the selected permission.');
+
+        $role->givePermissionTo($permission);
+        $this->forgetPermissionCache();
+
+        return response()->json(['message' => 'Role permission added.'], 201);
+    }
+
+    public function updateRolePermission(Request $request, Role $role, Permission $permission)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($role);
+        $this->requireWebGuard($permission);
+        $this->requireConfirmed($request);
+
+        $data = $request->validate([
+            'permission_id' => ['required', 'integer', 'exists:permissions,id'],
+        ]);
+
+        $newPermission = Permission::findOrFail($data['permission_id']);
+        $this->requireWebGuard($newPermission);
+        $this->ensureRolePermissionCanBeRemoved($role, $permission);
+
+        abort_unless($role->hasPermissionTo($permission), 422, 'The selected relation does not exist.');
+        abort_if($role->hasPermissionTo($newPermission), 422, 'This role already has the target permission.');
+
+        DB::transaction(function () use ($role, $permission, $newPermission) {
+            $role->revokePermissionTo($permission);
+            $role->givePermissionTo($newPermission);
+        });
+        $this->forgetPermissionCache();
+
+        return response()->json(['message' => 'Role permission updated.']);
+    }
+
+    public function destroyRolePermission(Request $request, Role $role, Permission $permission)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($role);
+        $this->requireWebGuard($permission);
+        $this->requireConfirmed($request);
+        $this->ensureRolePermissionCanBeRemoved($role, $permission);
+
+        abort_unless($role->hasPermissionTo($permission), 422, 'The selected relation does not exist.');
+
+        $role->revokePermissionTo($permission);
+        $this->forgetPermissionCache();
+
+        return response()->json(null, 204);
+    }
+
+    public function storeModelRole(Request $request)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireConfirmed($request);
+
+        [$user, $role] = $this->validateUserRoleInput($request);
+
+        abort_if($user->hasRole($role), 422, 'This user already has the selected role.');
+
+        $user->assignRole($role);
+        $this->forgetPermissionCache();
+
+        return response()->json(['message' => 'User role added.'], 201);
+    }
+
+    public function updateModelRole(Request $request, User $user, Role $role)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($role);
+        $this->requireConfirmed($request);
+
+        $data = $request->validate([
+            'role_id' => ['required', 'integer', 'exists:roles,id'],
+        ]);
+
+        $newRole = Role::findOrFail($data['role_id']);
+        $this->requireWebGuard($newRole);
+        $this->ensureRoleCanBeDetachedFromUser($user, $role);
+
+        abort_unless($user->hasRole($role), 422, 'The selected relation does not exist.');
+        abort_if($user->hasRole($newRole), 422, 'This user already has the target role.');
+
+        DB::transaction(function () use ($user, $role, $newRole) {
+            $user->removeRole($role);
+            $user->assignRole($newRole);
+        });
+        $this->forgetPermissionCache();
+
+        return response()->json(['message' => 'User role updated.']);
+    }
+
+    public function destroyModelRole(Request $request, User $user, Role $role)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($role);
+        $this->requireConfirmed($request);
+        $this->ensureRoleCanBeDetachedFromUser($user, $role);
+
+        abort_unless($user->hasRole($role), 422, 'The selected relation does not exist.');
+
+        $user->removeRole($role);
+        $this->forgetPermissionCache();
+
+        return response()->json(null, 204);
+    }
+
+    public function storeModelPermission(Request $request)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireConfirmed($request);
+
+        [$user, $permission] = $this->validateUserPermissionInput($request);
+
+        abort_if($user->hasDirectPermission($permission), 422, 'This user already has the selected direct permission.');
+
+        $user->givePermissionTo($permission);
+        $this->forgetPermissionCache();
+
+        return response()->json(['message' => 'User direct permission added.'], 201);
+    }
+
+    public function updateModelPermission(Request $request, User $user, Permission $permission)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($permission);
+        $this->requireConfirmed($request);
+
+        $data = $request->validate([
+            'permission_id' => ['required', 'integer', 'exists:permissions,id'],
+        ]);
+
+        $newPermission = Permission::findOrFail($data['permission_id']);
+        $this->requireWebGuard($newPermission);
+
+        abort_unless($user->hasDirectPermission($permission), 422, 'The selected relation does not exist.');
+        abort_if($user->hasDirectPermission($newPermission), 422, 'This user already has the target direct permission.');
+
+        DB::transaction(function () use ($user, $permission, $newPermission) {
+            $user->revokePermissionTo($permission);
+            $user->givePermissionTo($newPermission);
+        });
+        $this->forgetPermissionCache();
+
+        return response()->json(['message' => 'User direct permission updated.']);
+    }
+
+    public function destroyModelPermission(Request $request, User $user, Permission $permission)
+    {
+        $this->authorizeSuperAdmin();
+        $this->requireWebGuard($permission);
+        $this->requireConfirmed($request);
+
+        abort_unless($user->hasDirectPermission($permission), 422, 'The selected relation does not exist.');
+
+        $user->revokePermissionTo($permission);
+        $this->forgetPermissionCache();
+
+        return response()->json(null, 204);
+    }
+
+    private function authorizeSuperAdmin(): void
+    {
+        abort_unless(auth()->user()?->isSuperAdmin(), 403);
+    }
+
+    private function requireConfirmed(Request $request): void
+    {
+        $request->validate([
+            'confirm' => ['accepted'],
+        ], [
+            'confirm.accepted' => 'Confirmation is required before changing role management data.',
+        ]);
+    }
+
+    private function requireWebGuard(Role|Permission $model): void
+    {
+        abort_unless($model->guard_name === self::GUARD, 404);
+    }
+
+    private function validateRolePermissionInput(Request $request): array
+    {
+        $data = $request->validate([
+            'role_id' => ['required', 'integer', 'exists:roles,id'],
+            'permission_id' => ['required', 'integer', 'exists:permissions,id'],
+        ]);
+
+        $role = Role::findOrFail($data['role_id']);
+        $permission = Permission::findOrFail($data['permission_id']);
+        $this->requireWebGuard($role);
+        $this->requireWebGuard($permission);
+
+        return [$role, $permission];
+    }
+
+    private function validateUserRoleInput(Request $request): array
+    {
+        $data = $request->validate([
+            'user_id' => ['required', 'integer', 'exists:users,id'],
+            'role_id' => ['required', 'integer', 'exists:roles,id'],
+        ]);
+
+        $user = User::findOrFail($data['user_id']);
+        $role = Role::findOrFail($data['role_id']);
+        $this->requireWebGuard($role);
+
+        return [$user, $role];
+    }
+
+    private function validateUserPermissionInput(Request $request): array
+    {
+        $data = $request->validate([
+            'user_id' => ['required', 'integer', 'exists:users,id'],
+            'permission_id' => ['required', 'integer', 'exists:permissions,id'],
+        ]);
+
+        $user = User::findOrFail($data['user_id']);
+        $permission = Permission::findOrFail($data['permission_id']);
+        $this->requireWebGuard($permission);
+
+        return [$user, $permission];
+    }
+
+    private function ensureRoleCanBeChanged(Role $role, string $action): void
+    {
+        abort_if(in_array($role->name, self::CORE_ROLES, true), 422, "Core role '{$role->name}' cannot be {$action}.");
+
+        $role->loadCount(['permissions', 'users']);
+        abort_if($role->users_count > 0, 422, "This role is assigned to users and cannot be {$action}.");
+        abort_if($role->permissions_count > 0, 422, "This role has permissions and cannot be {$action}.");
+    }
+
+    private function ensurePermissionCanBeChanged(Permission $permission, string $action): void
+    {
+        abort_if(in_array($permission->name, self::CODE_PERMISSIONS, true), 422, "Code permission '{$permission->name}' cannot be {$action}.");
+
+        $roleCount = $permission->roles()->count();
+        $modelCount = $this->directUserPermissionCount($permission);
+        abort_if($roleCount > 0, 422, "This permission is assigned to roles and cannot be {$action}.");
+        abort_if($modelCount > 0, 422, "This permission is assigned directly to users and cannot be {$action}.");
+    }
+
+    private function ensureRolePermissionCanBeRemoved(Role $role, Permission $permission): void
+    {
+        abort_if(
+            $role->name === 'super_admin' && in_array($permission->name, self::CODE_PERMISSIONS, true),
+            422,
+            'Code permissions cannot be removed from super_admin.'
+        );
+    }
+
+    private function ensureRoleCanBeDetachedFromUser(User $user, Role $role): void
+    {
+        if ($role->name !== 'super_admin') {
+            return;
+        }
+
+        abort_if($user->id === auth()->id(), 422, 'You cannot remove super_admin from your own account.');
+        abort_if($role->users()->count() <= 1, 422, 'At least one super_admin user must remain.');
+    }
+
+    private function rolePermissions()
+    {
+        return DB::table(config('permission.table_names.role_has_permissions') . ' as rp')
+            ->join('roles as r', 'r.id', '=', 'rp.role_id')
+            ->join('permissions as p', 'p.id', '=', 'rp.permission_id')
+            ->where('r.guard_name', self::GUARD)
+            ->where('p.guard_name', self::GUARD)
+            ->orderBy('r.name')
+            ->orderBy('p.name')
+            ->get([
+                'r.id as role_id',
+                'r.name as role_name',
+                'p.id as permission_id',
+                'p.name as permission_name',
+            ]);
+    }
+
+    private function modelRoles()
+    {
+        return DB::table(config('permission.table_names.model_has_roles') . ' as mr')
+            ->join('roles as r', 'r.id', '=', 'mr.role_id')
+            ->join('users as u', 'u.id', '=', 'mr.model_id')
+            ->where('mr.model_type', User::class)
+            ->whereNull('u.deleted_at')
+            ->where('r.guard_name', self::GUARD)
+            ->orderBy('u.family_name')
+            ->orderBy('u.first_name')
+            ->orderBy('r.name')
+            ->get([
+                'u.id as user_id',
+                'u.employee_code',
+                'u.name as user_name',
+                'u.email',
+                'r.id as role_id',
+                'r.name as role_name',
+            ]);
+    }
+
+    private function modelPermissions()
+    {
+        return DB::table(config('permission.table_names.model_has_permissions') . ' as mp')
+            ->join('permissions as p', 'p.id', '=', 'mp.permission_id')
+            ->join('users as u', 'u.id', '=', 'mp.model_id')
+            ->where('mp.model_type', User::class)
+            ->whereNull('u.deleted_at')
+            ->where('p.guard_name', self::GUARD)
+            ->orderBy('u.family_name')
+            ->orderBy('u.first_name')
+            ->orderBy('p.name')
+            ->get([
+                'u.id as user_id',
+                'u.employee_code',
+                'u.name as user_name',
+                'u.email',
+                'p.id as permission_id',
+                'p.name as permission_name',
+            ]);
+    }
+
+    private function formatRole(Role $role): array
+    {
+        $permissionsCount = (int) ($role->permissions_count ?? $role->permissions()->count());
+        $usersCount = (int) ($role->users_count ?? $role->users()->count());
+        $isCore = in_array($role->name, self::CORE_ROLES, true);
+
+        return [
+            'id' => $role->id,
+            'name' => $role->name,
+            'guard_name' => $role->guard_name,
+            'permissions_count' => $permissionsCount,
+            'users_count' => $usersCount,
+            'is_core' => $isCore,
+            'can_update' => ! $isCore && $permissionsCount === 0 && $usersCount === 0,
+            'can_delete' => ! $isCore && $permissionsCount === 0 && $usersCount === 0,
+        ];
+    }
+
+    private function formatPermission(Permission $permission): array
+    {
+        $rolesCount = (int) ($permission->roles_count ?? $permission->roles()->count());
+        $usersCount = $this->directUserPermissionCount($permission);
+        $isCodePermission = in_array($permission->name, self::CODE_PERMISSIONS, true);
+
+        return [
+            'id' => $permission->id,
+            'name' => $permission->name,
+            'guard_name' => $permission->guard_name,
+            'roles_count' => $rolesCount,
+            'users_count' => $usersCount,
+            'is_code_permission' => $isCodePermission,
+            'can_update' => ! $isCodePermission && $rolesCount === 0 && $usersCount === 0,
+            'can_delete' => ! $isCodePermission && $rolesCount === 0 && $usersCount === 0,
+        ];
+    }
+
+    private function directUserPermissionCount(Permission $permission): int
+    {
+        return DB::table(config('permission.table_names.model_has_permissions'))
+            ->where('permission_id', $permission->id)
+            ->where('model_type', User::class)
+            ->count();
+    }
+
+    private function forgetPermissionCache(): void
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+}

--- a/app/Http/Requests/RoleChange/ApplyRoleChangeRequest.php
+++ b/app/Http/Requests/RoleChange/ApplyRoleChangeRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\RoleChange;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class ApplyRoleChangeRequest extends FormRequest
 {
@@ -17,7 +18,7 @@ class ApplyRoleChangeRequest extends FormRequest
         $isAdmin = in_array($role, ['admin', 'super_admin']);
 
         return [
-            'role'                    => ['required', 'in:general,admin,super_admin'],
+            'role'                    => ['required', 'string', Rule::exists('roles', 'name')->where('guard_name', 'web')],
             'reason'                  => ['required', 'string', 'max:2000'],
             'district_id'             => ['required', 'integer', 'exists:districts,id'],
             'department_id'           => ['required', 'integer', 'exists:departments,id'],
@@ -33,8 +34,8 @@ class ApplyRoleChangeRequest extends FormRequest
             $role   = $this->input('role');
             $scopes = $this->input('scopes') ?? [];
 
-            if ($role === 'general' && !empty($scopes)) {
-                $v->errors()->add('scopes', '一般ユーザーには管理範囲を設定できません。');
+            if (!in_array($role, ['admin', 'super_admin'], true) && !empty($scopes)) {
+                $v->errors()->add('scopes', 'Only admin and super_admin roles can have management scopes.');
                 return;
             }
 
@@ -46,7 +47,7 @@ class ApplyRoleChangeRequest extends FormRequest
             foreach ($scopes as $i => $scope) {
                 $key = ($scope['district_id'] ?? '') . '-' . ($scope['department_id'] ?? '');
                 if (isset($seen[$key])) {
-                    $v->errors()->add("scopes.$i", '同じ地区・部署の組み合わせが重複しています。');
+                    $v->errors()->add("scopes.$i", 'The same district and department combination is duplicated.');
                 }
                 $seen[$key] = true;
             }
@@ -56,16 +57,17 @@ class ApplyRoleChangeRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'district_id.required'          => '所属地区を選択してください。',
-            'district_id.exists'            => '選択された所属地区は存在しません。',
-            'department_id.required'        => '所属部署を選択してください。',
-            'department_id.exists'          => '選択された所属部署は存在しません。',
-            'scopes.required'               => '管理地区・部署を1件以上追加してください。',
-            'scopes.min'                    => '管理地区・部署を1件以上追加してください。',
-            'scopes.*.district_id.required' => '管理範囲の地区を選択してください。',
-            'scopes.*.district_id.exists'   => '選択された管理地区は存在しません。',
-            'scopes.*.department_id.required' => '管理範囲の部署を選択してください。',
-            'scopes.*.department_id.exists' => '選択された管理部署は存在しません。',
+            'role.exists'                   => 'The selected role does not exist.',
+            'district_id.required'          => 'Please select a district.',
+            'district_id.exists'            => 'The selected district does not exist.',
+            'department_id.required'        => 'Please select a department.',
+            'department_id.exists'          => 'The selected department does not exist.',
+            'scopes.required'               => 'Please add at least one management scope.',
+            'scopes.min'                    => 'Please add at least one management scope.',
+            'scopes.*.district_id.required' => 'Please select a district for each management scope.',
+            'scopes.*.district_id.exists'   => 'The selected management district does not exist.',
+            'scopes.*.department_id.required' => 'Please select a department for each management scope.',
+            'scopes.*.department_id.exists' => 'The selected management department does not exist.',
         ];
     }
 }

--- a/app/Services/RoleChange/RoleChangeApplicationService.php
+++ b/app/Services/RoleChange/RoleChangeApplicationService.php
@@ -33,8 +33,8 @@ class RoleChangeApplicationService
                 'scopes'          => $scopes,
             ]);
 
-            $roleLabels = ['general' => '一般', 'admin' => '管理者', 'super_admin' => 'スーパー管理者'];
-            $title = '権限・所属・管理範囲変更: ' . $rc->targetUser->role_label . ' → ' . ($roleLabels[$role] ?? $role);
+            $currentRole = $targetUser->getRoleNames()->first() ?? 'none';
+            $title = 'Role / district / department change: ' . $currentRole . ' -> ' . $role;
 
             $targetUser->load(['district', 'department', 'managementScopes.district', 'managementScopes.department']);
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -75,3 +75,11 @@ if (ddeEl) {
     const props = ddeEl.dataset.props ? JSON.parse(ddeEl.dataset.props) : {};
     createApp(DistrictDepartmentEditor, props).mount(ddeEl);
 }
+
+import RoleManageEditor from './components/RoleManageEditor.vue';
+
+const rmeEl = document.getElementById('roleManageEditor');
+if (rmeEl) {
+    const props = rmeEl.dataset.props ? JSON.parse(rmeEl.dataset.props) : {};
+    createApp(RoleManageEditor, props).mount(rmeEl);
+}

--- a/resources/js/components/RoleManageEditor.vue
+++ b/resources/js/components/RoleManageEditor.vue
@@ -245,14 +245,14 @@
               </div>
 
               <datalist id="role-search-datalist">
-                <option v-for="role in roles" :key="role.id" :value="role.name">{{ role.guard_name }}</option>
+                <option v-for="role in roles" :key="role.id" :value="role.name"></option>
               </datalist>
               <datalist id="user-search-datalist">
                 <option
                   v-for="user in users"
                   :key="user.id"
                   :value="userSearchValue(user)"
-                >{{ user.email }}</option>
+                ></option>
               </datalist>
 
               <div class="row g-2 align-items-start mb-3">

--- a/resources/js/components/RoleManageEditor.vue
+++ b/resources/js/components/RoleManageEditor.vue
@@ -1,9 +1,5 @@
 <template>
   <div>
-    <div v-if="flash.text" :class="['alert', 'py-2', 'px-3', 'mb-3', flash.ok ? 'alert-success' : 'alert-danger']">
-      {{ flash.text }}
-    </div>
-
     <div class="alert alert-warning py-2 small">
       Role and permission changes affect access immediately. Core roles and code-referenced permissions are locked when they are in use.
     </div>
@@ -375,7 +371,6 @@ export default {
     return {
       loading: true,
       saving: false,
-      flash: { text: '', ok: true },
       roles: [],
       permissions: [],
       users: [],
@@ -425,8 +420,9 @@ export default {
     },
 
     showFlash(text, ok = true) {
-      this.flash = { text, ok };
-      setTimeout(() => { this.flash.text = ''; }, 3500);
+      if (typeof window.showToast === 'function') {
+        window.showToast(text, { variant: ok ? 'success' : 'danger', delay: 9000 });
+      }
     },
 
     lockTitle(row, type) {

--- a/resources/js/components/RoleManageEditor.vue
+++ b/resources/js/components/RoleManageEditor.vue
@@ -10,7 +10,7 @@
       <div class="row g-3 mb-4">
         <div class="col-lg-6">
           <section class="card h-100">
-            <div class="card-header d-flex justify-content-between align-items-center py-2">
+            <div class="card-header d-flex justify-content-between align-items-center py-2 rm-card-header">
               <span class="fw-semibold">Role list</span>
               <button class="btn btn-sm btn-outline-primary" @click="resetRoleForm">New</button>
             </div>
@@ -48,7 +48,6 @@
                     <tr v-for="role in roles" :key="role.id">
                       <td>
                         <span class="fw-semibold">{{ role.name }}</span>
-                        <span v-if="role.is_core" class="badge text-bg-secondary ms-1">core</span>
                       </td>
                       <td class="text-muted small">{{ role.guard_name }}</td>
                       <td class="text-end">{{ role.users_count }}</td>
@@ -77,63 +76,29 @@
 
         <div class="col-lg-6">
           <section class="card h-100">
-            <div class="card-header d-flex justify-content-between align-items-center py-2">
+            <div class="card-header d-flex justify-content-between align-items-center py-2 rm-card-header">
               <span class="fw-semibold">Permission list</span>
-              <button class="btn btn-sm btn-outline-primary" @click="resetPermissionForm">New</button>
+              <button class="btn btn-sm btn-outline-primary invisible" type="button" aria-hidden="true" tabindex="-1">New</button>
             </div>
             <div class="card-body">
-              <div class="row g-2 align-items-start mb-3">
-                <div class="col">
-                  <input
-                    v-model="permissionForm.name"
-                    type="text"
-                    class="form-control form-control-sm"
-                    :class="{ 'is-invalid': errors.permission.name }"
-                    placeholder="permission.name"
-                  >
-                  <div class="invalid-feedback">{{ errors.permission.name }}</div>
-                </div>
-                <div class="col-auto">
-                  <button class="btn btn-sm btn-primary" :disabled="saving" @click="savePermission">
-                    {{ permissionForm.id ? 'Update' : 'Add' }}
-                  </button>
-                </div>
-              </div>
-
               <div class="table-responsive">
                 <table class="table table-sm table-hover align-middle mb-0">
                   <thead class="table-light">
                     <tr>
                       <th>Name</th>
-                      <th>Guard</th>
+                      <th>Description</th>
                       <th class="text-end">Roles</th>
                       <th class="text-end">Users</th>
-                      <th style="width:120px"></th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr v-for="permission in permissions" :key="permission.id">
                       <td>
                         <span class="fw-semibold">{{ permission.name }}</span>
-                        <span v-if="permission.is_code_permission" class="badge text-bg-secondary ms-1">code</span>
                       </td>
-                      <td class="text-muted small">{{ permission.guard_name }}</td>
+                      <td class="text-muted small rm-description">{{ permission.description }}</td>
                       <td class="text-end">{{ permission.roles_count }}</td>
                       <td class="text-end">{{ permission.users_count }}</td>
-                      <td class="text-end">
-                        <button
-                          class="btn btn-xs btn-outline-secondary me-1"
-                          :disabled="!permission.can_update"
-                          :title="lockTitle(permission, 'permission')"
-                          @click="editPermission(permission)"
-                        >Edit</button>
-                        <button
-                          class="btn btn-xs btn-outline-danger"
-                          :disabled="!permission.can_delete"
-                          :title="lockTitle(permission, 'permission')"
-                          @click="deletePermission(permission)"
-                        >Del</button>
-                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -405,7 +370,6 @@ export default {
   props: {
     snapshotUrl: { type: String, required: true },
     roleUrl: { type: String, required: true },
-    permissionUrl: { type: String, required: true },
     rolePermissionUrl: { type: String, required: true },
     modelRoleUrl: { type: String, required: true },
     modelPermissionUrl: { type: String, required: true },
@@ -423,14 +387,12 @@ export default {
       modelRoles: [],
       modelPermissions: [],
       roleForm: { id: null, name: '', original_name: '' },
-      permissionForm: { id: null, name: '', original_name: '' },
       rolePermissionForm: { editing: false, role_id: '', permission_id: '', original_permission_id: '' },
       modelRoleSearch: { role: '', user: '', searched: false },
       modelRoleForm: { editing: false, user_id: '', role_id: '', original_role_id: '' },
       modelPermissionForm: { editing: false, user_id: '', permission_id: '', original_permission_id: '' },
       errors: {
         role: {},
-        permission: {},
       },
       confirmModal: null,
       confirm: {
@@ -549,10 +511,6 @@ export default {
       return `${this.roleUrl}/${id}`;
     },
 
-    permissionItemUrl(id) {
-      return `${this.permissionUrl}/${id}`;
-    },
-
     rolePermissionItemUrl(roleId, permissionId) {
       return `${this.roleUrl}/${roleId}/permissions/${permissionId}`;
     },
@@ -636,49 +594,6 @@ export default {
         await axios.delete(this.roleItemUrl(role.id), { data: { confirm: true } });
         await this.loadSnapshot();
         this.showFlash('Role deleted.');
-      });
-    },
-
-    resetPermissionForm() {
-      this.permissionForm = { id: null, name: '', original_name: '' };
-      this.errors.permission = {};
-    },
-
-    editPermission(permission) {
-      this.permissionForm = { id: permission.id, name: permission.name, original_name: permission.name };
-      this.errors.permission = {};
-    },
-
-    savePermission() {
-      this.errors.permission = {};
-      const name = this.permissionForm.name.trim();
-      const isEdit = Boolean(this.permissionForm.id);
-      const lines = isEdit
-        ? [`Permission: ${this.permissionForm.original_name}`, `New name: ${name}`]
-        : [`New permission: ${name}`, 'Guard: web'];
-
-      this.ask(isEdit ? 'Update permission' : 'Create permission', lines, async () => {
-        try {
-          if (isEdit) {
-            await axios.put(this.permissionItemUrl(this.permissionForm.id), { name, confirm: true });
-          } else {
-            await axios.post(this.permissionUrl, { name, confirm: true });
-          }
-          this.resetPermissionForm();
-          await this.loadSnapshot();
-          this.showFlash(isEdit ? 'Permission updated.' : 'Permission added.');
-        } catch (err) {
-          this.handleError(err, 'permission');
-          throw err;
-        }
-      });
-    },
-
-    deletePermission(permission) {
-      this.ask('Delete permission', [`Permission: ${permission.name}`, 'This is allowed only when the permission is unused.'], async () => {
-        await axios.delete(this.permissionItemUrl(permission.id), { data: { confirm: true } });
-        await this.loadSnapshot();
-        this.showFlash('Permission deleted.');
       });
     },
 
@@ -842,5 +757,10 @@ export default {
   min-width: 0;
   padding-left: 0.35rem;
   padding-right: 0.35rem;
+}
+
+.table td.rm-description {
+  white-space: normal;
+  min-width: 220px;
 }
 </style>

--- a/resources/js/components/RoleManageEditor.vue
+++ b/resources/js/components/RoleManageEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="alert alert-warning py-2 small">
+    <div class="alert alert-info py-2 small">
       Role and permission changes affect access immediately. Core roles and code-referenced permissions are locked when they are in use.
     </div>
 
@@ -215,6 +215,48 @@
             <div class="card-body">
               <div class="row g-2 align-items-start mb-3">
                 <div class="col-md-5">
+                  <input
+                    v-model="modelRoleSearch.user"
+                    list="user-search-datalist"
+                    class="form-control form-control-sm"
+                    placeholder="User search: Last / First / employee_code"
+                    autocomplete="off"
+                    aria-label="User search"
+                    @keyup.enter="searchModelRoles"
+                  >
+                </div>
+                <div class="col-md-5">
+                  <input
+                    v-model="modelRoleSearch.role"
+                    list="role-search-datalist"
+                    class="form-control form-control-sm"
+                    placeholder="Role search"
+                    autocomplete="off"
+                    aria-label="Role search"
+                    @keyup.enter="searchModelRoles"
+                  >
+                </div>
+                <div class="col-md-2">
+                  <div class="btn-group w-100 rm-search-actions" role="group" aria-label="Model role search actions">
+                    <button class="btn btn-sm btn-primary" @click="searchModelRoles">Search</button>
+                    <button class="btn btn-sm btn-outline-secondary" @click="clearModelRoleSearch">Clear</button>
+                  </div>
+                </div>
+              </div>
+
+              <datalist id="role-search-datalist">
+                <option v-for="role in roles" :key="role.id" :value="role.name">{{ role.guard_name }}</option>
+              </datalist>
+              <datalist id="user-search-datalist">
+                <option
+                  v-for="user in users"
+                  :key="user.id"
+                  :value="userSearchValue(user)"
+                >{{ user.email }}</option>
+              </datalist>
+
+              <div class="row g-2 align-items-start mb-3">
+                <div class="col-md-5">
                   <select v-model="modelRoleForm.user_id" class="form-select form-select-sm" :disabled="modelRoleForm.editing">
                     <option value="">Select user</option>
                     <option v-for="user in users" :key="user.id" :value="user.id">{{ userLabel(user) }}</option>
@@ -245,7 +287,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <tr v-for="row in modelRoles" :key="`${row.user_id}-${row.role_id}`">
+                    <tr v-for="row in filteredModelRoles" :key="`${row.user_id}-${row.role_id}`">
                       <td>{{ row.employee_code }} - {{ row.user_name }}</td>
                       <td class="text-muted small">{{ row.email }}</td>
                       <td>{{ row.role_name }}</td>
@@ -254,8 +296,11 @@
                         <button class="btn btn-xs btn-outline-danger" @click="deleteModelRole(row)">Del</button>
                       </td>
                     </tr>
-                    <tr v-if="modelRoles.length === 0">
-                      <td colspan="4" class="text-muted small">No user role relations.</td>
+                    <tr v-if="!modelRoleSearch.searched">
+                      <td colspan="4" class="text-muted small">Search by role or user to show user role relations.</td>
+                    </tr>
+                    <tr v-else-if="filteredModelRoles.length === 0">
+                      <td colspan="4" class="text-muted small">No user role relations match the search.</td>
                     </tr>
                   </tbody>
                 </table>
@@ -380,6 +425,7 @@ export default {
       roleForm: { id: null, name: '', original_name: '' },
       permissionForm: { id: null, name: '', original_name: '' },
       rolePermissionForm: { editing: false, role_id: '', permission_id: '', original_permission_id: '' },
+      modelRoleSearch: { role: '', user: '', searched: false },
       modelRoleForm: { editing: false, user_id: '', role_id: '', original_role_id: '' },
       modelPermissionForm: { editing: false, user_id: '', permission_id: '', original_permission_id: '' },
       errors: {
@@ -399,6 +445,29 @@ export default {
   mounted() {
     this.confirmModal = new window.bootstrap.Modal(this.$refs.confirmModalEl);
     this.loadSnapshot();
+  },
+
+  computed: {
+    filteredModelRoles() {
+      if (!this.modelRoleSearch.searched) return [];
+
+      const roleQuery = this.normalizeSearch(this.modelRoleSearch.role);
+      const userQuery = this.normalizeSearch(this.modelRoleSearch.user);
+
+      return this.modelRoles.filter((row) => {
+        const roleMatches = !roleQuery || this.normalizeSearch(row.role_name).includes(roleQuery);
+        const userHaystack = this.normalizeSearch([
+          row.employee_code,
+          row.family_name,
+          row.first_name,
+          row.user_name,
+          row.email,
+        ].filter(Boolean).join(' '));
+        const userMatches = !userQuery || userHaystack.includes(userQuery);
+
+        return roleMatches && userMatches;
+      });
+    },
   },
 
   methods: {
@@ -440,6 +509,27 @@ export default {
 
     userLabel(user) {
       return `${user.employee_code} - ${user.name}`;
+    },
+
+    userSearchValue(user) {
+      return `${user.employee_code} ${user.family_name ?? ''} ${user.first_name ?? ''}`.trim();
+    },
+
+    normalizeSearch(value) {
+      return String(value ?? '').trim().toLowerCase();
+    },
+
+    searchModelRoles() {
+      if (!this.normalizeSearch(this.modelRoleSearch.role) && !this.normalizeSearch(this.modelRoleSearch.user)) {
+        this.showFlash('Enter a role or user search term.', false);
+        return;
+      }
+
+      this.modelRoleSearch.searched = true;
+    },
+
+    clearModelRoleSearch() {
+      this.modelRoleSearch = { role: '', user: '', searched: false };
     },
 
     roleName(id) {
@@ -746,5 +836,11 @@ export default {
 .table td,
 .table th {
   white-space: nowrap;
+}
+
+.rm-search-actions .btn {
+  min-width: 0;
+  padding-left: 0.35rem;
+  padding-right: 0.35rem;
 }
 </style>

--- a/resources/js/components/RoleManageEditor.vue
+++ b/resources/js/components/RoleManageEditor.vue
@@ -1,0 +1,754 @@
+<template>
+  <div>
+    <div v-if="flash.text" :class="['alert', 'py-2', 'px-3', 'mb-3', flash.ok ? 'alert-success' : 'alert-danger']">
+      {{ flash.text }}
+    </div>
+
+    <div class="alert alert-warning py-2 small">
+      Role and permission changes affect access immediately. Core roles and code-referenced permissions are locked when they are in use.
+    </div>
+
+    <div v-if="loading" class="text-muted small py-4">Loading...</div>
+
+    <template v-else>
+      <div class="row g-3 mb-4">
+        <div class="col-lg-6">
+          <section class="card h-100">
+            <div class="card-header d-flex justify-content-between align-items-center py-2">
+              <span class="fw-semibold">Role list</span>
+              <button class="btn btn-sm btn-outline-primary" @click="resetRoleForm">New</button>
+            </div>
+            <div class="card-body">
+              <div class="row g-2 align-items-start mb-3">
+                <div class="col">
+                  <input
+                    v-model="roleForm.name"
+                    type="text"
+                    class="form-control form-control-sm"
+                    :class="{ 'is-invalid': errors.role.name }"
+                    placeholder="role_name"
+                  >
+                  <div class="invalid-feedback">{{ errors.role.name }}</div>
+                </div>
+                <div class="col-auto">
+                  <button class="btn btn-sm btn-primary" :disabled="saving" @click="saveRole">
+                    {{ roleForm.id ? 'Update' : 'Add' }}
+                  </button>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>Name</th>
+                      <th>Guard</th>
+                      <th class="text-end">Users</th>
+                      <th class="text-end">Perms</th>
+                      <th style="width:120px"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="role in roles" :key="role.id">
+                      <td>
+                        <span class="fw-semibold">{{ role.name }}</span>
+                        <span v-if="role.is_core" class="badge text-bg-secondary ms-1">core</span>
+                      </td>
+                      <td class="text-muted small">{{ role.guard_name }}</td>
+                      <td class="text-end">{{ role.users_count }}</td>
+                      <td class="text-end">{{ role.permissions_count }}</td>
+                      <td class="text-end">
+                        <button
+                          class="btn btn-xs btn-outline-secondary me-1"
+                          :disabled="!role.can_update"
+                          :title="lockTitle(role, 'role')"
+                          @click="editRole(role)"
+                        >Edit</button>
+                        <button
+                          class="btn btn-xs btn-outline-danger"
+                          :disabled="!role.can_delete"
+                          :title="lockTitle(role, 'role')"
+                          @click="deleteRole(role)"
+                        >Del</button>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div class="col-lg-6">
+          <section class="card h-100">
+            <div class="card-header d-flex justify-content-between align-items-center py-2">
+              <span class="fw-semibold">Permission list</span>
+              <button class="btn btn-sm btn-outline-primary" @click="resetPermissionForm">New</button>
+            </div>
+            <div class="card-body">
+              <div class="row g-2 align-items-start mb-3">
+                <div class="col">
+                  <input
+                    v-model="permissionForm.name"
+                    type="text"
+                    class="form-control form-control-sm"
+                    :class="{ 'is-invalid': errors.permission.name }"
+                    placeholder="permission.name"
+                  >
+                  <div class="invalid-feedback">{{ errors.permission.name }}</div>
+                </div>
+                <div class="col-auto">
+                  <button class="btn btn-sm btn-primary" :disabled="saving" @click="savePermission">
+                    {{ permissionForm.id ? 'Update' : 'Add' }}
+                  </button>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>Name</th>
+                      <th>Guard</th>
+                      <th class="text-end">Roles</th>
+                      <th class="text-end">Users</th>
+                      <th style="width:120px"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="permission in permissions" :key="permission.id">
+                      <td>
+                        <span class="fw-semibold">{{ permission.name }}</span>
+                        <span v-if="permission.is_code_permission" class="badge text-bg-secondary ms-1">code</span>
+                      </td>
+                      <td class="text-muted small">{{ permission.guard_name }}</td>
+                      <td class="text-end">{{ permission.roles_count }}</td>
+                      <td class="text-end">{{ permission.users_count }}</td>
+                      <td class="text-end">
+                        <button
+                          class="btn btn-xs btn-outline-secondary me-1"
+                          :disabled="!permission.can_update"
+                          :title="lockTitle(permission, 'permission')"
+                          @click="editPermission(permission)"
+                        >Edit</button>
+                        <button
+                          class="btn btn-xs btn-outline-danger"
+                          :disabled="!permission.can_delete"
+                          :title="lockTitle(permission, 'permission')"
+                          @click="deletePermission(permission)"
+                        >Del</button>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <ul class="nav nav-tabs mb-3" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#rolePermTab" type="button">Role has permission</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#modelRoleTab" type="button">Model has role</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#modelPermTab" type="button">Model has permission</button>
+        </li>
+      </ul>
+
+      <div class="tab-content">
+        <div id="rolePermTab" class="tab-pane fade show active">
+          <section class="card">
+            <div class="card-header py-2 fw-semibold">Role has permission</div>
+            <div class="card-body">
+              <div class="row g-2 align-items-start mb-3">
+                <div class="col-md-5">
+                  <select v-model="rolePermissionForm.role_id" class="form-select form-select-sm" :disabled="rolePermissionForm.editing">
+                    <option value="">Select role</option>
+                    <option v-for="role in roles" :key="role.id" :value="role.id">{{ role.name }}</option>
+                  </select>
+                </div>
+                <div class="col-md-5">
+                  <select v-model="rolePermissionForm.permission_id" class="form-select form-select-sm">
+                    <option value="">Select permission</option>
+                    <option v-for="permission in permissions" :key="permission.id" :value="permission.id">{{ permission.name }}</option>
+                  </select>
+                </div>
+                <div class="col-md-2 d-flex gap-1">
+                  <button class="btn btn-sm btn-primary w-100" :disabled="saving" @click="saveRolePermission">
+                    {{ rolePermissionForm.editing ? 'Update' : 'Add' }}
+                  </button>
+                  <button v-if="rolePermissionForm.editing" class="btn btn-sm btn-outline-secondary" @click="resetRolePermissionForm">Cancel</button>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>Role</th>
+                      <th>Permission</th>
+                      <th style="width:120px"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="row in rolePermissions" :key="`${row.role_id}-${row.permission_id}`">
+                      <td>{{ row.role_name }}</td>
+                      <td>{{ row.permission_name }}</td>
+                      <td class="text-end">
+                        <button class="btn btn-xs btn-outline-secondary me-1" @click="editRolePermission(row)">Edit</button>
+                        <button class="btn btn-xs btn-outline-danger" @click="deleteRolePermission(row)">Del</button>
+                      </td>
+                    </tr>
+                    <tr v-if="rolePermissions.length === 0">
+                      <td colspan="3" class="text-muted small">No role permission relations.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div id="modelRoleTab" class="tab-pane fade">
+          <section class="card">
+            <div class="card-header py-2 fw-semibold">Model has role</div>
+            <div class="card-body">
+              <div class="row g-2 align-items-start mb-3">
+                <div class="col-md-5">
+                  <select v-model="modelRoleForm.user_id" class="form-select form-select-sm" :disabled="modelRoleForm.editing">
+                    <option value="">Select user</option>
+                    <option v-for="user in users" :key="user.id" :value="user.id">{{ userLabel(user) }}</option>
+                  </select>
+                </div>
+                <div class="col-md-5">
+                  <select v-model="modelRoleForm.role_id" class="form-select form-select-sm">
+                    <option value="">Select role</option>
+                    <option v-for="role in roles" :key="role.id" :value="role.id">{{ role.name }}</option>
+                  </select>
+                </div>
+                <div class="col-md-2 d-flex gap-1">
+                  <button class="btn btn-sm btn-primary w-100" :disabled="saving" @click="saveModelRole">
+                    {{ modelRoleForm.editing ? 'Update' : 'Add' }}
+                  </button>
+                  <button v-if="modelRoleForm.editing" class="btn btn-sm btn-outline-secondary" @click="resetModelRoleForm">Cancel</button>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>User</th>
+                      <th>Email</th>
+                      <th>Role</th>
+                      <th style="width:120px"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="row in modelRoles" :key="`${row.user_id}-${row.role_id}`">
+                      <td>{{ row.employee_code }} - {{ row.user_name }}</td>
+                      <td class="text-muted small">{{ row.email }}</td>
+                      <td>{{ row.role_name }}</td>
+                      <td class="text-end">
+                        <button class="btn btn-xs btn-outline-secondary me-1" @click="editModelRole(row)">Edit</button>
+                        <button class="btn btn-xs btn-outline-danger" @click="deleteModelRole(row)">Del</button>
+                      </td>
+                    </tr>
+                    <tr v-if="modelRoles.length === 0">
+                      <td colspan="4" class="text-muted small">No user role relations.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div id="modelPermTab" class="tab-pane fade">
+          <section class="card">
+            <div class="card-header py-2 fw-semibold">Model has permission</div>
+            <div class="card-body">
+              <div class="row g-2 align-items-start mb-3">
+                <div class="col-md-5">
+                  <select v-model="modelPermissionForm.user_id" class="form-select form-select-sm" :disabled="modelPermissionForm.editing">
+                    <option value="">Select user</option>
+                    <option v-for="user in users" :key="user.id" :value="user.id">{{ userLabel(user) }}</option>
+                  </select>
+                </div>
+                <div class="col-md-5">
+                  <select v-model="modelPermissionForm.permission_id" class="form-select form-select-sm">
+                    <option value="">Select permission</option>
+                    <option v-for="permission in permissions" :key="permission.id" :value="permission.id">{{ permission.name }}</option>
+                  </select>
+                </div>
+                <div class="col-md-2 d-flex gap-1">
+                  <button class="btn btn-sm btn-primary w-100" :disabled="saving" @click="saveModelPermission">
+                    {{ modelPermissionForm.editing ? 'Update' : 'Add' }}
+                  </button>
+                  <button v-if="modelPermissionForm.editing" class="btn btn-sm btn-outline-secondary" @click="resetModelPermissionForm">Cancel</button>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                  <thead class="table-light">
+                    <tr>
+                      <th>User</th>
+                      <th>Email</th>
+                      <th>Direct permission</th>
+                      <th style="width:120px"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="row in modelPermissions" :key="`${row.user_id}-${row.permission_id}`">
+                      <td>{{ row.employee_code }} - {{ row.user_name }}</td>
+                      <td class="text-muted small">{{ row.email }}</td>
+                      <td>{{ row.permission_name }}</td>
+                      <td class="text-end">
+                        <button class="btn btn-xs btn-outline-secondary me-1" @click="editModelPermission(row)">Edit</button>
+                        <button class="btn btn-xs btn-outline-danger" @click="deleteModelPermission(row)">Del</button>
+                      </td>
+                    </tr>
+                    <tr v-if="modelPermissions.length === 0">
+                      <td colspan="4" class="text-muted small">No direct user permission relations.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </template>
+
+    <div class="modal fade" tabindex="-1" ref="confirmModalEl">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header py-2">
+            <h6 class="modal-title mb-0">{{ confirm.title }}</h6>
+            <button type="button" class="btn-close btn-sm" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="alert alert-danger py-2 small mb-3">
+              Confirm this change only after checking the target and relation names.
+            </div>
+            <ul class="mb-0 small">
+              <li v-for="line in confirm.lines" :key="line">{{ line }}</li>
+            </ul>
+          </div>
+          <div class="modal-footer py-2">
+            <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-sm btn-danger" :disabled="confirm.saving" @click="runConfirmedAction">
+              {{ confirm.saving ? 'Processing...' : 'Confirm' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+const csrfToken = () => document.querySelector('meta[name="csrf-token"]')?.content ?? '';
+axios.defaults.headers.common['X-CSRF-TOKEN'] = csrfToken();
+
+export default {
+  name: 'RoleManageEditor',
+
+  props: {
+    snapshotUrl: { type: String, required: true },
+    roleUrl: { type: String, required: true },
+    permissionUrl: { type: String, required: true },
+    rolePermissionUrl: { type: String, required: true },
+    modelRoleUrl: { type: String, required: true },
+    modelPermissionUrl: { type: String, required: true },
+    userUrl: { type: String, required: true },
+  },
+
+  data() {
+    return {
+      loading: true,
+      saving: false,
+      flash: { text: '', ok: true },
+      roles: [],
+      permissions: [],
+      users: [],
+      rolePermissions: [],
+      modelRoles: [],
+      modelPermissions: [],
+      roleForm: { id: null, name: '', original_name: '' },
+      permissionForm: { id: null, name: '', original_name: '' },
+      rolePermissionForm: { editing: false, role_id: '', permission_id: '', original_permission_id: '' },
+      modelRoleForm: { editing: false, user_id: '', role_id: '', original_role_id: '' },
+      modelPermissionForm: { editing: false, user_id: '', permission_id: '', original_permission_id: '' },
+      errors: {
+        role: {},
+        permission: {},
+      },
+      confirmModal: null,
+      confirm: {
+        title: '',
+        lines: [],
+        action: null,
+        saving: false,
+      },
+    };
+  },
+
+  mounted() {
+    this.confirmModal = new window.bootstrap.Modal(this.$refs.confirmModalEl);
+    this.loadSnapshot();
+  },
+
+  methods: {
+    async loadSnapshot() {
+      this.loading = true;
+      try {
+        const { data } = await axios.get(this.snapshotUrl);
+        this.roles = data.roles;
+        this.permissions = data.permissions;
+        this.users = data.users;
+        this.rolePermissions = data.role_permissions;
+        this.modelRoles = data.model_roles;
+        this.modelPermissions = data.model_permissions;
+      } catch (err) {
+        this.showFlash(err.response?.data?.message ?? 'Failed to load role management data.', false);
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    showFlash(text, ok = true) {
+      this.flash = { text, ok };
+      setTimeout(() => { this.flash.text = ''; }, 3500);
+    },
+
+    lockTitle(row, type) {
+      if (type === 'role') {
+        if (row.is_core) return 'Core roles cannot be renamed or deleted.';
+        if (row.users_count > 0) return 'This role is assigned to users.';
+        if (row.permissions_count > 0) return 'This role has permissions.';
+      }
+
+      if (row.is_code_permission) return 'This permission is referenced by application code.';
+      if (row.roles_count > 0) return 'This permission is assigned to roles.';
+      if (row.users_count > 0) return 'This permission is assigned directly to users.';
+      return '';
+    },
+
+    userLabel(user) {
+      return `${user.employee_code} - ${user.name}`;
+    },
+
+    roleName(id) {
+      return this.roles.find((role) => Number(role.id) === Number(id))?.name ?? id;
+    },
+
+    permissionName(id) {
+      return this.permissions.find((permission) => Number(permission.id) === Number(id))?.name ?? id;
+    },
+
+    userName(id) {
+      const user = this.users.find((item) => Number(item.id) === Number(id));
+      return user ? this.userLabel(user) : id;
+    },
+
+    roleItemUrl(id) {
+      return `${this.roleUrl}/${id}`;
+    },
+
+    permissionItemUrl(id) {
+      return `${this.permissionUrl}/${id}`;
+    },
+
+    rolePermissionItemUrl(roleId, permissionId) {
+      return `${this.roleUrl}/${roleId}/permissions/${permissionId}`;
+    },
+
+    modelRoleItemUrl(userId, roleId) {
+      return `${this.userUrl}/${userId}/roles/${roleId}`;
+    },
+
+    modelPermissionItemUrl(userId, permissionId) {
+      return `${this.userUrl}/${userId}/permissions/${permissionId}`;
+    },
+
+    ask(title, lines, action) {
+      this.confirm = { title, lines, action, saving: false };
+      this.confirmModal.show();
+    },
+
+    async runConfirmedAction() {
+      if (!this.confirm.action) return;
+
+      this.confirm.saving = true;
+      this.saving = true;
+      try {
+        await this.confirm.action();
+        this.confirmModal.hide();
+      } catch (err) {
+        this.handleError(err);
+      } finally {
+        this.confirm.saving = false;
+        this.saving = false;
+      }
+    },
+
+    handleError(err, bucket = null) {
+      const validation = err.response?.data?.errors ?? null;
+      if (validation && bucket) {
+        this.errors[bucket] = Object.fromEntries(
+          Object.entries(validation).map(([key, messages]) => [key, messages[0]])
+        );
+      }
+      this.showFlash(err.response?.data?.message ?? 'The change failed.', false);
+    },
+
+    resetRoleForm() {
+      this.roleForm = { id: null, name: '', original_name: '' };
+      this.errors.role = {};
+    },
+
+    editRole(role) {
+      this.roleForm = { id: role.id, name: role.name, original_name: role.name };
+      this.errors.role = {};
+    },
+
+    saveRole() {
+      this.errors.role = {};
+      const name = this.roleForm.name.trim();
+      const isEdit = Boolean(this.roleForm.id);
+      const lines = isEdit
+        ? [`Role: ${this.roleForm.original_name}`, `New name: ${name}`]
+        : [`New role: ${name}`, 'Guard: web'];
+
+      this.ask(isEdit ? 'Update role' : 'Create role', lines, async () => {
+        try {
+          if (isEdit) {
+            await axios.put(this.roleItemUrl(this.roleForm.id), { name, confirm: true });
+          } else {
+            await axios.post(this.roleUrl, { name, confirm: true });
+          }
+          this.resetRoleForm();
+          await this.loadSnapshot();
+          this.showFlash(isEdit ? 'Role updated.' : 'Role added.');
+        } catch (err) {
+          this.handleError(err, 'role');
+          throw err;
+        }
+      });
+    },
+
+    deleteRole(role) {
+      this.ask('Delete role', [`Role: ${role.name}`, 'This is allowed only when the role is unused.'], async () => {
+        await axios.delete(this.roleItemUrl(role.id), { data: { confirm: true } });
+        await this.loadSnapshot();
+        this.showFlash('Role deleted.');
+      });
+    },
+
+    resetPermissionForm() {
+      this.permissionForm = { id: null, name: '', original_name: '' };
+      this.errors.permission = {};
+    },
+
+    editPermission(permission) {
+      this.permissionForm = { id: permission.id, name: permission.name, original_name: permission.name };
+      this.errors.permission = {};
+    },
+
+    savePermission() {
+      this.errors.permission = {};
+      const name = this.permissionForm.name.trim();
+      const isEdit = Boolean(this.permissionForm.id);
+      const lines = isEdit
+        ? [`Permission: ${this.permissionForm.original_name}`, `New name: ${name}`]
+        : [`New permission: ${name}`, 'Guard: web'];
+
+      this.ask(isEdit ? 'Update permission' : 'Create permission', lines, async () => {
+        try {
+          if (isEdit) {
+            await axios.put(this.permissionItemUrl(this.permissionForm.id), { name, confirm: true });
+          } else {
+            await axios.post(this.permissionUrl, { name, confirm: true });
+          }
+          this.resetPermissionForm();
+          await this.loadSnapshot();
+          this.showFlash(isEdit ? 'Permission updated.' : 'Permission added.');
+        } catch (err) {
+          this.handleError(err, 'permission');
+          throw err;
+        }
+      });
+    },
+
+    deletePermission(permission) {
+      this.ask('Delete permission', [`Permission: ${permission.name}`, 'This is allowed only when the permission is unused.'], async () => {
+        await axios.delete(this.permissionItemUrl(permission.id), { data: { confirm: true } });
+        await this.loadSnapshot();
+        this.showFlash('Permission deleted.');
+      });
+    },
+
+    resetRolePermissionForm() {
+      this.rolePermissionForm = { editing: false, role_id: '', permission_id: '', original_permission_id: '' };
+    },
+
+    editRolePermission(row) {
+      this.rolePermissionForm = {
+        editing: true,
+        role_id: row.role_id,
+        permission_id: row.permission_id,
+        original_permission_id: row.permission_id,
+      };
+    },
+
+    saveRolePermission() {
+      const form = this.rolePermissionForm;
+      const isEdit = form.editing;
+      const lines = isEdit
+        ? [`Role: ${this.roleName(form.role_id)}`, `From: ${this.permissionName(form.original_permission_id)}`, `To: ${this.permissionName(form.permission_id)}`]
+        : [`Role: ${this.roleName(form.role_id)}`, `Permission: ${this.permissionName(form.permission_id)}`];
+
+      this.ask(isEdit ? 'Update role permission' : 'Add role permission', lines, async () => {
+        if (isEdit) {
+          await axios.put(this.rolePermissionItemUrl(form.role_id, form.original_permission_id), {
+            permission_id: form.permission_id,
+            confirm: true,
+          });
+        } else {
+          await axios.post(this.rolePermissionUrl, {
+            role_id: form.role_id,
+            permission_id: form.permission_id,
+            confirm: true,
+          });
+        }
+        this.resetRolePermissionForm();
+        await this.loadSnapshot();
+        this.showFlash(isEdit ? 'Role permission updated.' : 'Role permission added.');
+      });
+    },
+
+    deleteRolePermission(row) {
+      this.ask('Delete role permission', [`Role: ${row.role_name}`, `Permission: ${row.permission_name}`], async () => {
+        await axios.delete(this.rolePermissionItemUrl(row.role_id, row.permission_id), { data: { confirm: true } });
+        await this.loadSnapshot();
+        this.showFlash('Role permission deleted.');
+      });
+    },
+
+    resetModelRoleForm() {
+      this.modelRoleForm = { editing: false, user_id: '', role_id: '', original_role_id: '' };
+    },
+
+    editModelRole(row) {
+      this.modelRoleForm = {
+        editing: true,
+        user_id: row.user_id,
+        role_id: row.role_id,
+        original_role_id: row.role_id,
+      };
+    },
+
+    saveModelRole() {
+      const form = this.modelRoleForm;
+      const isEdit = form.editing;
+      const lines = isEdit
+        ? [`User: ${this.userName(form.user_id)}`, `From: ${this.roleName(form.original_role_id)}`, `To: ${this.roleName(form.role_id)}`]
+        : [`User: ${this.userName(form.user_id)}`, `Role: ${this.roleName(form.role_id)}`];
+
+      this.ask(isEdit ? 'Update user role' : 'Add user role', lines, async () => {
+        if (isEdit) {
+          await axios.put(this.modelRoleItemUrl(form.user_id, form.original_role_id), {
+            role_id: form.role_id,
+            confirm: true,
+          });
+        } else {
+          await axios.post(this.modelRoleUrl, {
+            user_id: form.user_id,
+            role_id: form.role_id,
+            confirm: true,
+          });
+        }
+        this.resetModelRoleForm();
+        await this.loadSnapshot();
+        this.showFlash(isEdit ? 'User role updated.' : 'User role added.');
+      });
+    },
+
+    deleteModelRole(row) {
+      this.ask('Delete user role', [`User: ${row.employee_code} - ${row.user_name}`, `Role: ${row.role_name}`], async () => {
+        await axios.delete(this.modelRoleItemUrl(row.user_id, row.role_id), { data: { confirm: true } });
+        await this.loadSnapshot();
+        this.showFlash('User role deleted.');
+      });
+    },
+
+    resetModelPermissionForm() {
+      this.modelPermissionForm = { editing: false, user_id: '', permission_id: '', original_permission_id: '' };
+    },
+
+    editModelPermission(row) {
+      this.modelPermissionForm = {
+        editing: true,
+        user_id: row.user_id,
+        permission_id: row.permission_id,
+        original_permission_id: row.permission_id,
+      };
+    },
+
+    saveModelPermission() {
+      const form = this.modelPermissionForm;
+      const isEdit = form.editing;
+      const lines = isEdit
+        ? [`User: ${this.userName(form.user_id)}`, `From: ${this.permissionName(form.original_permission_id)}`, `To: ${this.permissionName(form.permission_id)}`]
+        : [`User: ${this.userName(form.user_id)}`, `Permission: ${this.permissionName(form.permission_id)}`];
+
+      this.ask(isEdit ? 'Update user direct permission' : 'Add user direct permission', lines, async () => {
+        if (isEdit) {
+          await axios.put(this.modelPermissionItemUrl(form.user_id, form.original_permission_id), {
+            permission_id: form.permission_id,
+            confirm: true,
+          });
+        } else {
+          await axios.post(this.modelPermissionUrl, {
+            user_id: form.user_id,
+            permission_id: form.permission_id,
+            confirm: true,
+          });
+        }
+        this.resetModelPermissionForm();
+        await this.loadSnapshot();
+        this.showFlash(isEdit ? 'User direct permission updated.' : 'User direct permission added.');
+      });
+    },
+
+    deleteModelPermission(row) {
+      this.ask('Delete user direct permission', [`User: ${row.employee_code} - ${row.user_name}`, `Permission: ${row.permission_name}`], async () => {
+        await axios.delete(this.modelPermissionItemUrl(row.user_id, row.permission_id), { data: { confirm: true } });
+        await this.loadSnapshot();
+        this.showFlash('User direct permission deleted.');
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.btn-xs {
+  padding: 0.1rem 0.45rem;
+  font-size: 0.75rem;
+  border-radius: 0.2rem;
+}
+
+.table td,
+.table th {
+  white-space: nowrap;
+}
+</style>

--- a/resources/views/approvals/show.blade.php
+++ b/resources/views/approvals/show.blade.php
@@ -2,10 +2,10 @@
 
 @section('content')
 <div class="container">
-    <h2>承認依頼の詳細</h2>
+    <h2>Approval Request Details</h2>
 
     <div class="card mt-3">
-        <div class="card-body">
+        <div class="card-body approval-show-panel">
             @php
             $meta       = $approvalRequest->metadata ?? [];
             $approvable = $approvalRequest->approvable;
@@ -14,36 +14,36 @@
 
             <table class="table table-bordered">
                 <tr>
-                    <th>タイトル</th>
+                    <th>Title</th>
                     <td>{{ $approvalRequest->title }}</td>
                 </tr>
                 <tr>
-                    <th>依頼者</th>
+                    <th>Requester</th>
                     <td>{{ $approvalRequest->requester->name }} [{{ $approvalRequest->requester->employee_code }}]</td>
                 </tr>
                 <tr>
-                    <th>状態</th>
+                    <th>Status</th>
                     <td>
                         @if($approvalRequest->current_state === 'pending')
-                        <span class="badge bg-warning">承認待ち</span>
+                        <span class="badge bg-warning">Pending</span>
                         @elseif($approvalRequest->current_state === 'approved')
-                        <span class="badge bg-success">承認済み</span>
+                        <span class="badge bg-success">Approved</span>
                         @elseif($approvalRequest->current_state === 'denied')
-                        <span class="badge bg-danger">却下</span>
+                        <span class="badge bg-danger">Denied</span>
                         @endif
                     </td>
                 </tr>
 
                 @if($isLeave)
-                {{-- 有給/特別休暇申請の場合 --}}
+                {{-- Leave request --}}
                 <tr>
-                    <th>申請種別</th>
+                    <th>Request Type</th>
                     <td>
                         @php
                         $kind = $meta['kind'] ?? $approvable->kind ?? null;
                         $kindLabel = match($kind) {
-                        'paid' => '有給（ALP）',
-                        'special' => '特別休暇',
+                        'paid' => 'Paid Leave (ALP)',
+                        'special' => 'Special Leave',
                         default => $kind,
                         };
                         @endphp
@@ -52,15 +52,15 @@
                 </tr>
                 @if(($meta['kind'] ?? null) === 'special' || ($approvable->kind ?? null) === 'special')
                 <tr>
-                    <th>特別休暇の種類</th>
+                    <th>Special Leave Type</th>
                     <td>{{ $meta['special_type'] ?? $approvable->special_type ?? '-' }}</td>
                 </tr>
                 <tr>
-                    <th>添付</th>
+                    <th>Attachment</th>
                     <td>
                         @if($approvable->attachment)
                         <a href="{{ route('leaves.attachments.show', ['leave' => $approvable->id, 'attachment' => $approvable->attachment->id]) }}" target="_blank">
-                            {{ $approvable->attachment->original_name ?? '添付ファイルを開く' }}
+                            {{ $approvable->attachment->original_name ?? 'Open attachment' }}
                         </a>
                         @if($approvable->attachment->size)
                         <small>　{{ number_format($approvable->attachment->size / 1024, 1) }} KB</small>
@@ -72,33 +72,30 @@
                 </tr>
                 @endif
                 <tr>
-                    <th>対象日</th>
+                    <th>Target Date</th>
                     <td>{{ $dateSummary ?? ($meta['date'] ?? optional($approvable->start_date)->format('Y-m-d') ?? '-') }}</td>
                 </tr>
                 <tr>
-                    <th>理由</th>
+                    <th>Reason</th>
                     <td>{{ $meta['reason'] ?? ($approvable->reason ?? '-') }}</td>
                 </tr>
 
                 @else
-                {{-- 権限変更申請の場合 --}}
+                {{-- Role change request --}}
                 <tr>
-                    <th>対象ユーザー</th>
-                    <td>{{ $meta['target_user_name'] ?? '不明' }}</td>
+                    <th>Target User</th>
+                    <td>{{ $meta['target_user_name'] ?? 'Unknown' }}</td>
                 </tr>
                 <tr>
-                    <th>権限</th>
+                    <th>Role</th>
                     <td>
-                        @php
-                        $roleLabels = ['general' => '一般', 'admin' => '管理者', 'super_admin' => 'スーパー管理者'];
-                        @endphp
-                        {{ $roleLabels[$meta['current_role'] ?? ''] ?? ($meta['current_role'] ?? '—') }}
+                        {{ $meta['current_role'] ?? '—' }}
                         →
-                        <strong>{{ $roleLabels[$meta['requested_role'] ?? ''] ?? ($meta['requested_role'] ?? '—') }}</strong>
+                        <strong>{{ $meta['requested_role'] ?? '—' }}</strong>
                     </td>
                 </tr>
                 <tr>
-                    <th>所属地区</th>
+                    <th>District</th>
                     <td>
                         {{ $meta['current_district'] ?? '—' }}
                         →
@@ -106,7 +103,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>所属部署</th>
+                    <th>Department</th>
                     <td>
                         {{ $meta['current_department'] ?? '—' }}
                         →
@@ -114,11 +111,11 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>管理範囲</th>
+                    <th>Management Scope</th>
                     <td>
                         <div class="d-flex gap-4">
                             <div>
-                                <div class="text-muted small mb-1">現在</div>
+                                <div class="text-muted small mb-1">Current</div>
                                 @php $currentScopes = $meta['current_scopes'] ?? []; @endphp
                                 @if(empty($currentScopes))
                                     <span class="text-muted">—</span>
@@ -132,7 +129,7 @@
                             </div>
                             <div class="text-muted align-self-center">→</div>
                             <div>
-                                <div class="text-muted small mb-1">変更後</div>
+                                <div class="text-muted small mb-1">Requested</div>
                                 @php $requestedScopes = $meta['requested_scopes'] ?? []; @endphp
                                 @if(empty($requestedScopes))
                                     <span class="text-muted">—</span>
@@ -148,45 +145,56 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>申請理由</th>
+                    <th>Reason</th>
                     <td>{{ $meta['reason'] ?? '—' }}</td>
                 </tr>
                 @endif
             </table>
 
-            {{-- 過去のアクション履歴 --}}
-            <h5 class="mt-4">アクション履歴</h5>
+            {{-- Action history --}}
+            <h5 class="mt-4">Action History</h5>
             <ul class="list-group mb-4">
                 @forelse ($approvalRequest->actions as $action)
                 <li class="list-group-item">
                     <strong>{{ $action->actor->name }}</strong>
-                    が <span class="text-primary">{{ $action->action }}</span>
-                    （{{ $action->created_at->format('Y-m-d H:i') }}）
+                    <span class="text-primary">{{ $action->action }}</span>
+                    ({{ $action->created_at->format('Y-m-d H:i') }})
                     <br>
-                    コメント: {{ $action->comment ?? '（なし）' }}
+                    Comment: {{ $action->comment ?? 'None' }}
                 </li>
                 @empty
-                <li class="list-group-item">まだ承認/却下の履歴はありません。</li>
+                <li class="list-group-item">No approval or denial history yet.</li>
                 @endforelse
             </ul>
 
-            {{-- 承認・却下ボタン（権限がある場合のみ） --}}
+            {{-- Approve / deny actions --}}
             @can('act', $approvalRequest)
             @if($approvalRequest->current_state === 'pending')
             <form action="{{ route('approvals.approve', $approvalRequest) }}" method="POST" class="d-inline">
                 @csrf
-                <input type="text" name="comment" class="form-control mb-2" placeholder="承認コメント（任意）">
-                <button type="submit" class="btn btn-success mb-2">承認する</button>
+                <input type="text" name="comment" class="form-control mb-2" placeholder="Approval comment (optional)">
+                <button type="submit" class="btn btn-success mb-2">Approve</button>
             </form>
 
             <form action="{{ route('approvals.deny', $approvalRequest) }}" method="POST" class="d-inline ms-2">
                 @csrf
-                <input type="text" name="comment" class="form-control mb-2" placeholder="却下理由（任意）">
-                <button type="submit" class="btn btn-danger mb-2">却下する</button>
+                <input type="text" name="comment" class="form-control mb-2" placeholder="Denial reason (optional)">
+                <button type="submit" class="btn btn-danger mb-2">Deny</button>
             </form>
             @endif
             @endcan
         </div>
     </div>
 </div>
+
+<style>
+.approval-show-panel {
+    background-color: #eef6ff;
+}
+
+.approval-show-panel .form-control,
+.approval-show-panel .form-select {
+    background-color: #fff;
+}
+</style>
 @endsection

--- a/resources/views/data/data_list.blade.php
+++ b/resources/views/data/data_list.blade.php
@@ -22,6 +22,11 @@
             District &amp; Department
         </a>
         @endcan
+        @role('super_admin')
+        <a href="{{ route('data.role_manage') }}" class="list-group-item list-group-item-action">
+            Role Management
+        </a>
+        @endrole
     </div>
 </div>
 @endsection

--- a/resources/views/data/role_manage.blade.php
+++ b/resources/views/data/role_manage.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">Role Management</h2>
+  <a href="{{ route('data.list') }}" class="btn btn-sm btn-outline-secondary">&larr; Data</a>
+</div>
+
+@php
+$props = [
+    'snapshotUrl'        => route('api.role_manage.snapshot'),
+    'roleUrl'            => url('/api/role-manage/roles'),
+    'permissionUrl'      => url('/api/role-manage/permissions'),
+    'rolePermissionUrl'  => url('/api/role-manage/role-permissions'),
+    'modelRoleUrl'       => url('/api/role-manage/model-roles'),
+    'modelPermissionUrl' => url('/api/role-manage/model-permissions'),
+    'userUrl'            => url('/api/role-manage/users'),
+];
+@endphp
+
+<div id="roleManageEditor" data-props='@json($props)'></div>
+@endsection

--- a/resources/views/data/role_manage.blade.php
+++ b/resources/views/data/role_manage.blade.php
@@ -10,7 +10,6 @@
 $props = [
     'snapshotUrl'        => route('api.role_manage.snapshot'),
     'roleUrl'            => url('/api/role-manage/roles'),
-    'permissionUrl'      => url('/api/role-manage/permissions'),
     'rolePermissionUrl'  => url('/api/role-manage/role-permissions'),
     'modelRoleUrl'       => url('/api/role-manage/model-roles'),
     'modelPermissionUrl' => url('/api/role-manage/model-permissions'),

--- a/resources/views/user/roleChange.blade.php
+++ b/resources/views/user/roleChange.blade.php
@@ -2,10 +2,10 @@
 
 @section('content')
 <div class="container">
-    <h2>権限変更申請</h2>
+    <h2>Role Change Request</h2>
 
     <div class="card mt-3">
-        <div class="card-body">
+        <div class="card-body role-change-panel">
             {{-- 本人情報 --}}
             <table class="table table-bordered">
                 <colgroup>
@@ -13,28 +13,28 @@
                     <col>
                 </colgroup>
                 <tr>
-                    <th>社員コード</th>
+                    <th>Employee Code</th>
                     <td>{{ $user->employee_code }}</td>
                 </tr>
                 <tr>
-                    <th>氏名</th>
+                    <th>Name</th>
                     <td>{{ $user->name }}</td>
                 </tr>
                 <tr>
-                    <th>現在の権限</th>
-                    <td>{{ $user->role_label }}</td>
+                    <th>Current Role</th>
+                    <td>{{ $currentRole ?? '—' }}</td>
                 </tr>
                 <tr>
-                    <th>現在の所属地区</th>
+                    <th>Current District</th>
                     <td>{{ $user->district?->name ?? '—' }}</td>
                 </tr>
                 <tr>
-                    <th>現在の所属部署</th>
+                    <th>Current Department</th>
                     <td>{{ $user->department?->name ?? '—' }}</td>
                 </tr>
                 @if($user->isAdmin())
                 <tr>
-                    <th>現在の管理範囲</th>
+                    <th>Current Management Scope</th>
                     <td>
                         @if($user->managementScopes->isEmpty())
                             <span class="text-muted">—</span>
@@ -48,7 +48,7 @@
                 @endif
             </table>
 
-            {{-- 申請フォーム --}}
+            {{-- Request form --}}
             @if ($errors->any())
             <div class="alert alert-danger">
                 <ul class="mb-0">
@@ -62,43 +62,40 @@
             <form action="{{ route('roleChange.apply', $user) }}" method="POST">
                 @csrf
 
-                {{-- 変更後の権限 --}}
+                {{-- Requested role --}}
                 <div class="mb-3">
-                    <label for="role" class="form-label">変更後の権限 <span class="text-danger">*</span></label>
+                    <label for="role" class="form-label">Requested Role <span class="text-danger">*</span></label>
                     <select name="role" id="role" class="form-select" required>
                         @foreach ($availableRoles as $r)
-                        @php
-                            $labels = ['general' => '一般', 'admin' => '管理者', 'super_admin' => 'スーパー管理者'];
-                        @endphp
                         <option value="{{ $r }}" {{ old('role', $currentRole) === $r ? 'selected' : '' }}>
-                            {{ $labels[$r] ?? $r }}
+                            {{ $r }}
                         </option>
                         @endforeach
                     </select>
                 </div>
 
-                {{-- 所属地区（read-only） --}}
+                {{-- District (read-only) --}}
                 <div class="mb-3">
-                    <label class="form-label">所属地区</label>
+                    <label class="form-label">District</label>
                     <input type="hidden" name="district_id" value="{{ $user->district_id }}">
                     <p class="form-control-plaintext border rounded px-3 py-2 bg-light mb-0">
                         {{ $user->district?->name ?? '—' }}
                     </p>
                 </div>
 
-                {{-- 所属部署（read-only） --}}
+                {{-- Department (read-only) --}}
                 <div class="mb-3">
-                    <label class="form-label">所属部署</label>
+                    <label class="form-label">Department</label>
                     <input type="hidden" name="department_id" value="{{ $user->department_id }}">
                     <p class="form-control-plaintext border rounded px-3 py-2 bg-light mb-0">
                         {{ $user->department?->name ?? '—' }}
                     </p>
                 </div>
 
-                {{-- 管理範囲（admin / super_admin のみ） --}}
+                {{-- Management scopes (admin / super_admin only) --}}
                 <div id="scopesSection" class="mb-3" style="display:none;">
-                    <label class="form-label">管理範囲 <span class="text-danger">*</span></label>
-                    <div class="mb-1 text-muted small">地区と部署の組み合わせを1件以上追加してください。</div>
+                    <label class="form-label">Management Scope <span class="text-danger">*</span></label>
+                    <div class="mb-1 text-muted small">Add at least one district and department combination.</div>
                     @error('scopes')<div class="text-danger small mb-2">{{ $message }}</div>@enderror
 
                     <div id="scopeRows">
@@ -107,7 +104,7 @@
                             @foreach(old('scopes') as $i => $scope)
                             <div class="scope-row d-flex gap-2 mb-2">
                                 <select name="scopes[{{ $i }}][district_id]" class="form-select @error('scopes.'.$i) is-invalid @enderror">
-                                    <option value="">— 地区 —</option>
+                                    <option value="">— District —</option>
                                     @foreach ($districts as $district)
                                         <option value="{{ $district->id }}" {{ ($scope['district_id'] ?? '') == $district->id ? 'selected' : '' }}>
                                             {{ $district->name }}
@@ -120,31 +117,31 @@
                                     @endforeach
                                 </select>
                                 <select name="scopes[{{ $i }}][department_id]" class="form-select">
-                                    <option value="">— 部署 —</option>
+                                    <option value="">— Department —</option>
                                     @foreach ($departments as $dept)
                                     <option value="{{ $dept->id }}" {{ ($scope['department_id'] ?? '') == $dept->id ? 'selected' : '' }}>
                                         {{ $dept->name }}
                                     </option>
                                     @endforeach
                                 </select>
-                                <button type="button" class="btn btn-outline-danger btn-sm scope-remove" style="white-space:nowrap;">削除</button>
+                                <button type="button" class="btn btn-outline-danger btn-sm scope-remove" style="white-space:nowrap;">Remove</button>
                             </div>
                             @endforeach
                         @endif
                     </div>
 
-                    <button type="button" id="addScope" class="btn btn-outline-secondary btn-sm mt-1">+ 管理範囲を追加</button>
+                    <button type="button" id="addScope" class="btn btn-outline-secondary btn-sm mt-1">+ Add Management Scope</button>
                 </div>
 
-                {{-- 申請理由 --}}
+                {{-- Request reason --}}
                 <div class="mb-3">
-                    <label for="reason" class="form-label">申請理由 <span class="text-danger">*</span></label>
+                    <label for="reason" class="form-label">Reason <span class="text-danger">*</span></label>
                     <textarea name="reason" id="reason" class="form-control @error('reason') is-invalid @enderror"
                               rows="3" required>{{ old('reason') }}</textarea>
                     @error('reason')<div class="invalid-feedback">{{ $message }}</div>@enderror
                 </div>
 
-                <button type="submit" class="btn btn-primary">申請する</button>
+                <button type="submit" class="btn btn-primary">Submit Request</button>
             </form>
         </div>
     </div>
@@ -183,7 +180,7 @@ $existingScopesData = $user->managementScopes->map(function ($s) {
     let rowIndex = {{ old('scopes') ? count(old('scopes')) : 0 }};
 
     function buildDistrictOptions(selectedId) {
-        let html = '<option value="">— 地区 —</option>';
+        let html = '<option value="">— District —</option>';
         districtsJson.forEach(d => {
             const sel = d.id == selectedId ? ' selected' : '';
             html += `<option value="${d.id}"${sel}>${d.name}</option>`;
@@ -196,7 +193,7 @@ $existingScopesData = $user->managementScopes->map(function ($s) {
     }
 
     function buildDepartmentOptions(selectedId) {
-        let html = '<option value="">— 部署 —</option>';
+        let html = '<option value="">— Department —</option>';
         departmentsJson.forEach(d => {
             const sel = d.id == selectedId ? ' selected' : '';
             html += `<option value="${d.id}"${sel}>${d.name}</option>`;
@@ -215,7 +212,7 @@ $existingScopesData = $user->managementScopes->map(function ($s) {
             <select name="scopes[${i}][department_id]" class="form-select">
                 ${buildDepartmentOptions(departmentId)}
             </select>
-            <button type="button" class="btn btn-outline-danger btn-sm scope-remove" style="white-space:nowrap;">削除</button>
+            <button type="button" class="btn btn-outline-danger btn-sm scope-remove" style="white-space:nowrap;">Remove</button>
         `;
         scopeRows.appendChild(row);
     }
@@ -251,4 +248,16 @@ $existingScopesData = $user->managementScopes->map(function ($s) {
     // old() でエラー時に行が既にある場合は追加しない（Bladeで描画済み）
 })();
 </script>
+
+<style>
+.role-change-panel {
+    background-color: #eef6ff;
+}
+
+.role-change-panel .form-control,
+.role-change-panel .form-select,
+.role-change-panel .form-control-plaintext {
+    background-color: #fff;
+}
+</style>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -477,10 +477,6 @@ Route::middleware(['auth', 'role:super_admin'])->group(function () {
     Route::put('/api/role-manage/roles/{role}', [RoleManageController::class, 'updateRole'])->name('api.role_manage.roles.update');
     Route::delete('/api/role-manage/roles/{role}', [RoleManageController::class, 'destroyRole'])->name('api.role_manage.roles.destroy');
 
-    Route::post('/api/role-manage/permissions', [RoleManageController::class, 'storePermission'])->name('api.role_manage.permissions.store');
-    Route::put('/api/role-manage/permissions/{permission}', [RoleManageController::class, 'updatePermission'])->name('api.role_manage.permissions.update');
-    Route::delete('/api/role-manage/permissions/{permission}', [RoleManageController::class, 'destroyPermission'])->name('api.role_manage.permissions.destroy');
-
     Route::post('/api/role-manage/role-permissions', [RoleManageController::class, 'storeRolePermission'])->name('api.role_manage.role_permissions.store');
     Route::put('/api/role-manage/roles/{role}/permissions/{permission}', [RoleManageController::class, 'updateRolePermission'])->name('api.role_manage.role_permissions.update');
     Route::delete('/api/role-manage/roles/{role}/permissions/{permission}', [RoleManageController::class, 'destroyRolePermission'])->name('api.role_manage.role_permissions.destroy');

--- a/routes/web.php
+++ b/routes/web.php
@@ -408,6 +408,7 @@ Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
 use App\Http\Controllers\CalendarPatternEditorController;
 use App\Http\Controllers\DistrictDepartmentController;
 use App\Http\Controllers\LessonEditController;
+use App\Http\Controllers\RoleManageController;
 
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/data', function () {
@@ -465,6 +466,34 @@ Route::middleware(['auth', 'role:super_admin'])->group(function () {
     Route::delete('/api/department/{department}',[DistrictDepartmentController::class, 'departmentDestroy'])->name('api.department.destroy');
 });
 // ---------------------------------------------------------------------------------------------------------▲ District & Department
+
+// ---------------------------------------------------------------------------------------------------------▼ Role Management (super_admin only)
+Route::middleware(['auth', 'role:super_admin'])->group(function () {
+    Route::get('/data/role-manage', [RoleManageController::class, 'index'])->name('data.role_manage');
+
+    Route::get('/api/role-manage', [RoleManageController::class, 'snapshot'])->name('api.role_manage.snapshot');
+
+    Route::post('/api/role-manage/roles', [RoleManageController::class, 'storeRole'])->name('api.role_manage.roles.store');
+    Route::put('/api/role-manage/roles/{role}', [RoleManageController::class, 'updateRole'])->name('api.role_manage.roles.update');
+    Route::delete('/api/role-manage/roles/{role}', [RoleManageController::class, 'destroyRole'])->name('api.role_manage.roles.destroy');
+
+    Route::post('/api/role-manage/permissions', [RoleManageController::class, 'storePermission'])->name('api.role_manage.permissions.store');
+    Route::put('/api/role-manage/permissions/{permission}', [RoleManageController::class, 'updatePermission'])->name('api.role_manage.permissions.update');
+    Route::delete('/api/role-manage/permissions/{permission}', [RoleManageController::class, 'destroyPermission'])->name('api.role_manage.permissions.destroy');
+
+    Route::post('/api/role-manage/role-permissions', [RoleManageController::class, 'storeRolePermission'])->name('api.role_manage.role_permissions.store');
+    Route::put('/api/role-manage/roles/{role}/permissions/{permission}', [RoleManageController::class, 'updateRolePermission'])->name('api.role_manage.role_permissions.update');
+    Route::delete('/api/role-manage/roles/{role}/permissions/{permission}', [RoleManageController::class, 'destroyRolePermission'])->name('api.role_manage.role_permissions.destroy');
+
+    Route::post('/api/role-manage/model-roles', [RoleManageController::class, 'storeModelRole'])->name('api.role_manage.model_roles.store');
+    Route::put('/api/role-manage/users/{user:id}/roles/{role}', [RoleManageController::class, 'updateModelRole'])->name('api.role_manage.model_roles.update');
+    Route::delete('/api/role-manage/users/{user:id}/roles/{role}', [RoleManageController::class, 'destroyModelRole'])->name('api.role_manage.model_roles.destroy');
+
+    Route::post('/api/role-manage/model-permissions', [RoleManageController::class, 'storeModelPermission'])->name('api.role_manage.model_permissions.store');
+    Route::put('/api/role-manage/users/{user:id}/permissions/{permission}', [RoleManageController::class, 'updateModelPermission'])->name('api.role_manage.model_permissions.update');
+    Route::delete('/api/role-manage/users/{user:id}/permissions/{permission}', [RoleManageController::class, 'destroyModelPermission'])->name('api.role_manage.model_permissions.destroy');
+});
+// ---------------------------------------------------------------------------------------------------------▲ Role Management
 
 // ---------------------------------------------------------------------------------------------------------▼ CSV関連ルート
 use App\Http\Controllers\CsvController;

--- a/tests/Feature/RoleChangeTest.php
+++ b/tests/Feature/RoleChangeTest.php
@@ -8,6 +8,7 @@ use App\Models\RoleChange;
 use App\Models\User;
 use App\Models\UserManagementScope;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 /**
@@ -288,6 +289,32 @@ class RoleChangeTest extends TestCase
             ])
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['scopes']);
+    }
+
+    public function test_custom_role_appears_in_role_change_form_and_can_be_requested(): void
+    {
+        [$actor, $target, $district, $department] = $this->setUpActorAndTarget();
+        Role::firstOrCreate(['name' => 'school', 'guard_name' => 'web']);
+
+        $this->actingAs($actor)
+            ->get(route('admin.user.roleChange', $target))
+            ->assertOk()
+            ->assertSee('value="school"', false);
+
+        $this->actingAs($actor)
+            ->postJson(route('roleChange.apply', $target), [
+                'role'          => 'school',
+                'reason'        => 'test',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('role_changes', [
+            'user_id' => $target->id,
+            'requested_role' => 'school',
+            'status' => 'pending',
+        ]);
     }
 
     /** 10. admin + scopes なし → 422（管理範囲は1件以上必須） */

--- a/tests/Feature/RoleManageControllerTest.php
+++ b/tests/Feature/RoleManageControllerTest.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class RoleManageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeSuperAdmin(): User
+    {
+        return User::factory()->superAdmin()->create();
+    }
+
+    private function makeAdmin(): User
+    {
+        return User::factory()->admin()->create();
+    }
+
+    private function makeGeneral(): User
+    {
+        return User::factory()->general()->create();
+    }
+
+    public function test_guest_is_redirected_from_page_and_unauthorized_from_api(): void
+    {
+        $this->get(route('data.role_manage'))
+            ->assertRedirect(route('login'));
+
+        $this->getJson(route('api.role_manage.snapshot'))
+            ->assertStatus(401);
+    }
+
+    public function test_non_super_admin_users_cannot_access_role_manage(): void
+    {
+        $this->actingAs($this->makeGeneral())
+            ->get(route('data.role_manage'))
+            ->assertRedirect(route('welcome'));
+
+        $this->actingAs($this->makeAdmin())
+            ->getJson(route('api.role_manage.snapshot'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    public function test_data_list_link_is_only_visible_to_super_admin(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->get(route('data.list'))
+            ->assertOk()
+            ->assertSee(route('data.role_manage'));
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('data.list'))
+            ->assertOk()
+            ->assertDontSee(route('data.role_manage'));
+    }
+
+    public function test_super_admin_can_view_snapshot_with_all_five_sections(): void
+    {
+        $permission = Permission::firstOrCreate(['name' => 'feature.test', 'guard_name' => 'web']);
+        Role::findByName('admin', 'web')->givePermissionTo($permission);
+        $target = $this->makeGeneral();
+        $target->givePermissionTo($permission);
+
+        $this->actingAs($this->makeSuperAdmin())
+            ->getJson(route('api.role_manage.snapshot'))
+            ->assertOk()
+            ->assertJsonStructure([
+                'roles',
+                'permissions',
+                'users',
+                'role_permissions',
+                'model_roles',
+                'model_permissions',
+            ])
+            ->assertJsonFragment(['name' => 'feature.test'])
+            ->assertJsonFragment(['permission_name' => 'feature.test']);
+    }
+
+    public function test_mutations_require_confirmation(): void
+    {
+        $this->actingAs($this->makeSuperAdmin())
+            ->postJson(route('api.role_manage.roles.store'), ['name' => 'temporary'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['confirm']);
+    }
+
+    public function test_super_admin_can_create_update_and_delete_unused_role(): void
+    {
+        $actor = $this->makeSuperAdmin();
+
+        $response = $this->actingAs($actor)
+            ->postJson(route('api.role_manage.roles.store'), ['name' => 'temporary', 'confirm' => true])
+            ->assertCreated()
+            ->assertJsonFragment(['name' => 'temporary']);
+
+        $roleId = $response->json('id');
+        $role = Role::findOrFail($roleId);
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.roles.update', $role), ['name' => 'temporary_updated', 'confirm' => true])
+            ->assertOk()
+            ->assertJsonFragment(['name' => 'temporary_updated']);
+
+        $role = $role->fresh();
+        $this->assertSame('temporary_updated', $role->name);
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.roles.destroy', $role), ['confirm' => true])
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('roles', ['id' => $roleId]);
+    }
+
+    public function test_core_and_used_roles_cannot_be_updated_or_deleted(): void
+    {
+        $actor = $this->makeSuperAdmin();
+        $admin = Role::findByName('admin', 'web');
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.roles.update', $admin), ['name' => 'admin2', 'confirm' => true])
+            ->assertUnprocessable();
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.roles.destroy', $admin), ['confirm' => true])
+            ->assertUnprocessable();
+
+        $used = Role::create(['name' => 'used_role', 'guard_name' => 'web']);
+        $this->makeGeneral()->assignRole($used);
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.roles.update', $used), ['name' => 'used_role2', 'confirm' => true])
+            ->assertUnprocessable();
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.roles.destroy', $used), ['confirm' => true])
+            ->assertUnprocessable();
+    }
+
+    public function test_super_admin_can_create_update_and_delete_unused_permission(): void
+    {
+        $actor = $this->makeSuperAdmin();
+
+        $response = $this->actingAs($actor)
+            ->postJson(route('api.role_manage.permissions.store'), ['name' => 'custom.permission', 'confirm' => true])
+            ->assertCreated()
+            ->assertJsonFragment(['name' => 'custom.permission']);
+
+        $permission = Permission::findOrFail($response->json('id'));
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.permissions.update', $permission), ['name' => 'custom.permission2', 'confirm' => true])
+            ->assertOk()
+            ->assertJsonFragment(['name' => 'custom.permission2']);
+
+        $permission = $permission->fresh();
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.permissions.destroy', $permission), ['confirm' => true])
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('permissions', ['id' => $permission->id]);
+    }
+
+    public function test_code_and_used_permissions_cannot_be_updated_or_deleted(): void
+    {
+        $actor = $this->makeSuperAdmin();
+        $codePermission = Permission::firstOrCreate(['name' => 'schedule.viewAll', 'guard_name' => 'web']);
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.permissions.update', $codePermission), ['name' => 'schedule.all', 'confirm' => true])
+            ->assertUnprocessable();
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.permissions.destroy', $codePermission), ['confirm' => true])
+            ->assertUnprocessable();
+
+        $usedPermission = Permission::create(['name' => 'used.permission', 'guard_name' => 'web']);
+        Role::create(['name' => 'permission_holder', 'guard_name' => 'web'])->givePermissionTo($usedPermission);
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.permissions.update', $usedPermission), ['name' => 'used.permission2', 'confirm' => true])
+            ->assertUnprocessable();
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.permissions.destroy', $usedPermission), ['confirm' => true])
+            ->assertUnprocessable();
+    }
+
+    public function test_super_admin_can_add_update_and_delete_role_permission_relation(): void
+    {
+        $actor = $this->makeSuperAdmin();
+        $role = Role::create(['name' => 'relation_role', 'guard_name' => 'web']);
+        $first = Permission::create(['name' => 'relation.first', 'guard_name' => 'web']);
+        $second = Permission::create(['name' => 'relation.second', 'guard_name' => 'web']);
+
+        $this->actingAs($actor)
+            ->postJson(route('api.role_manage.role_permissions.store'), [
+                'role_id' => $role->id,
+                'permission_id' => $first->id,
+                'confirm' => true,
+            ])
+            ->assertCreated();
+
+        $this->assertTrue($role->fresh()->hasPermissionTo($first));
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.role_permissions.update', [$role, $first]), [
+                'permission_id' => $second->id,
+                'confirm' => true,
+            ])
+            ->assertOk();
+
+        $role = $role->fresh();
+        $this->assertFalse($role->hasPermissionTo($first));
+        $this->assertTrue($role->hasPermissionTo($second));
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.role_permissions.destroy', [$role, $second]), ['confirm' => true])
+            ->assertNoContent();
+
+        $this->assertFalse($role->fresh()->hasPermissionTo($second));
+    }
+
+    public function test_super_admin_can_add_update_and_delete_user_role_relation(): void
+    {
+        $actor = $this->makeSuperAdmin();
+        $target = $this->makeGeneral();
+        $first = Role::create(['name' => 'user_role_first', 'guard_name' => 'web']);
+        $second = Role::create(['name' => 'user_role_second', 'guard_name' => 'web']);
+
+        $this->actingAs($actor)
+            ->postJson(route('api.role_manage.model_roles.store'), [
+                'user_id' => $target->id,
+                'role_id' => $first->id,
+                'confirm' => true,
+            ])
+            ->assertCreated();
+
+        $this->assertTrue($target->fresh()->hasRole($first));
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.model_roles.update', [$target->id, $first]), [
+                'role_id' => $second->id,
+                'confirm' => true,
+            ])
+            ->assertOk();
+
+        $target = $target->fresh();
+        $this->assertFalse($target->hasRole($first));
+        $this->assertTrue($target->hasRole($second));
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.model_roles.destroy', [$target->id, $second]), ['confirm' => true])
+            ->assertNoContent();
+
+        $this->assertFalse($target->fresh()->hasRole($second));
+    }
+
+    public function test_super_admin_cannot_remove_super_admin_from_self(): void
+    {
+        $actor = $this->makeSuperAdmin();
+        $role = Role::findByName('super_admin', 'web');
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.model_roles.destroy', [$actor->id, $role]), ['confirm' => true])
+            ->assertUnprocessable();
+
+        $this->assertTrue($actor->fresh()->hasRole('super_admin'));
+    }
+
+    public function test_super_admin_can_add_update_and_delete_direct_user_permission_relation(): void
+    {
+        $actor = $this->makeSuperAdmin();
+        $target = $this->makeGeneral();
+        $first = Permission::create(['name' => 'direct.first', 'guard_name' => 'web']);
+        $second = Permission::create(['name' => 'direct.second', 'guard_name' => 'web']);
+
+        $this->actingAs($actor)
+            ->postJson(route('api.role_manage.model_permissions.store'), [
+                'user_id' => $target->id,
+                'permission_id' => $first->id,
+                'confirm' => true,
+            ])
+            ->assertCreated();
+
+        $this->assertTrue($target->fresh()->hasDirectPermission($first));
+
+        $this->actingAs($actor)
+            ->putJson(route('api.role_manage.model_permissions.update', [$target->id, $first]), [
+                'permission_id' => $second->id,
+                'confirm' => true,
+            ])
+            ->assertOk();
+
+        $target = $target->fresh();
+        $this->assertFalse($target->hasDirectPermission($first));
+        $this->assertTrue($target->hasDirectPermission($second));
+
+        $this->actingAs($actor)
+            ->deleteJson(route('api.role_manage.model_permissions.destroy', [$target->id, $second]), ['confirm' => true])
+            ->assertNoContent();
+
+        $this->assertFalse($target->fresh()->hasDirectPermission($second));
+    }
+}

--- a/tests/Feature/RoleManageControllerTest.php
+++ b/tests/Feature/RoleManageControllerTest.php
@@ -79,6 +79,7 @@ class RoleManageControllerTest extends TestCase
                 'model_permissions',
             ])
             ->assertJsonFragment(['name' => 'feature.test'])
+            ->assertJsonFragment(['description' => 'コード側で定義された権限です。利用前にmiddleware / policy / view条件を確認してください。'])
             ->assertJsonFragment(['permission_name' => 'feature.test']);
     }
 
@@ -142,54 +143,22 @@ class RoleManageControllerTest extends TestCase
             ->assertUnprocessable();
     }
 
-    public function test_super_admin_can_create_update_and_delete_unused_permission(): void
+    public function test_code_permissions_include_descriptions(): void
     {
-        $actor = $this->makeSuperAdmin();
+        Permission::firstOrCreate(['name' => 'schedule.viewAll', 'guard_name' => 'web']);
+        Permission::firstOrCreate(['name' => 'teacher.viewAll', 'guard_name' => 'web']);
 
-        $response = $this->actingAs($actor)
-            ->postJson(route('api.role_manage.permissions.store'), ['name' => 'custom.permission', 'confirm' => true])
-            ->assertCreated()
-            ->assertJsonFragment(['name' => 'custom.permission']);
-
-        $permission = Permission::findOrFail($response->json('id'));
-
-        $this->actingAs($actor)
-            ->putJson(route('api.role_manage.permissions.update', $permission), ['name' => 'custom.permission2', 'confirm' => true])
+        $this->actingAs($this->makeSuperAdmin())
+            ->getJson(route('api.role_manage.snapshot'))
             ->assertOk()
-            ->assertJsonFragment(['name' => 'custom.permission2']);
-
-        $permission = $permission->fresh();
-
-        $this->actingAs($actor)
-            ->deleteJson(route('api.role_manage.permissions.destroy', $permission), ['confirm' => true])
-            ->assertNoContent();
-
-        $this->assertDatabaseMissing('permissions', ['id' => $permission->id]);
-    }
-
-    public function test_code_and_used_permissions_cannot_be_updated_or_deleted(): void
-    {
-        $actor = $this->makeSuperAdmin();
-        $codePermission = Permission::firstOrCreate(['name' => 'schedule.viewAll', 'guard_name' => 'web']);
-
-        $this->actingAs($actor)
-            ->putJson(route('api.role_manage.permissions.update', $codePermission), ['name' => 'schedule.all', 'confirm' => true])
-            ->assertUnprocessable();
-
-        $this->actingAs($actor)
-            ->deleteJson(route('api.role_manage.permissions.destroy', $codePermission), ['confirm' => true])
-            ->assertUnprocessable();
-
-        $usedPermission = Permission::create(['name' => 'used.permission', 'guard_name' => 'web']);
-        Role::create(['name' => 'permission_holder', 'guard_name' => 'web'])->givePermissionTo($usedPermission);
-
-        $this->actingAs($actor)
-            ->putJson(route('api.role_manage.permissions.update', $usedPermission), ['name' => 'used.permission2', 'confirm' => true])
-            ->assertUnprocessable();
-
-        $this->actingAs($actor)
-            ->deleteJson(route('api.role_manage.permissions.destroy', $usedPermission), ['confirm' => true])
-            ->assertUnprocessable();
+            ->assertJsonFragment([
+                'name' => 'schedule.viewAll',
+                'description' => '自分以外のScheduleの観覧権限',
+            ])
+            ->assertJsonFragment([
+                'name' => 'teacher.viewAll',
+                'description' => 'Master List の観覧権限',
+            ]);
     }
 
     public function test_super_admin_can_add_update_and_delete_role_permission_relation(): void


### PR DESCRIPTION
## 概要

Spatie Laravel Permission の `role` / `permission` / pivot relation を確認・管理できる **Role Management** 画面を追加しました。

`super_admin` のみアクセス可能とし、誤操作による権限破壊を防ぐため、以下の保護を入れています。

* 変更前の確認必須化
* 利用中データの更新・削除制限
* core role の rename / delete 保護
* コード参照 permission の rename / delete 保護
* Spatie permission cache のクリア

---

## 追加・変更ファイル

### `app/Http/Controllers/RoleManageController.php`

Role Management の画面表示、一覧取得、作成・更新・削除 API を担当します。

対象データは以下の 5 種類です。

* `roles`
* `permissions`
* `role_has_permissions`
* `model_has_roles`
* `model_has_permissions`

主な実装内容：

* 全 mutation API で `confirm: true` を必須化
* 使用中 role / permission の破壊的変更を拒否
* core role の rename / delete を拒否
* コード参照 permission の rename / delete を拒否
* 変更後に `PermissionRegistrar::forgetCachedPermissions()` で Spatie permission cache をクリア

---

### `resources/views/data/role_manage.blade.php`

Role Management ページ本体を追加しました。

Vue コンポーネントに API URL を渡すための Blade view です。

---

### `resources/js/components/RoleManageEditor.vue`

role list / permission list / 3 種類の relation を表示・編集する UI を追加しました。

対応内容：

* role 一覧表示
* permission 一覧表示
* `role_has_permissions` の表示・編集
* `model_has_roles` の表示・編集
* `model_has_permissions` の表示・編集
* Bootstrap modal による変更内容確認
* Confirm 後のみ API 実行
* lock 状態の行は編集・削除ボタンを disabled 化

---

### `resources/js/app.js`

`RoleManageEditor` を import し、`#roleManageEditor` に mount する処理を追加しました。

---

### `resources/views/data/data_list.blade.php`

`super_admin` のみに Role Management リンクを表示するよう追加しました。

---

### `routes/web.php`

Role Management 用の画面ルートと API ルートを追加しました。

追加ルート：

* `/data/role-manage`
* `/api/role-manage/*`

すべて `auth` + `role:super_admin` middleware 配下です。

---

### `tests/Feature/RoleManageControllerTest.php`

Role Management の Feature Test を追加しました。

主なテスト内容：

* アクセス制御
* 一覧取得
* `confirm: true` 必須
* role / permission CRUD
* relation 更新
* 利用中データ保護
* core role 保護
* 自己 `super_admin` 削除防止

---

## 技術実装概要

Spatie の `Role`, `Permission`, `HasRoles` API を使用して、role / permission の付与・解除を実行しています。

一覧表示用には Spatie の pivot table を read-only 集約し、以下の関係をまとめて返却します。

* role と permission の関係
* user と role の関係
* user と permission の関係

変更後は以下を実行し、Spatie permission cache をクリアします。

```php
PermissionRegistrar::forgetCachedPermissions();
```

---

## 保護対象

### Core role

以下の role は core role として rename / delete 不可にしています。

* `super_admin`
* `admin`
* `general`
* `trainer`

### コード参照 permission

以下の permission はコード参照 permission として rename / delete 不可にしています。

* `schedule.viewAll`
* `teacher.viewAll`

### 使用中データ

使用中の role / permission は update / delete 不可にしています。

### 確認必須

全 mutation API は `confirm: true` が無い場合、`422` を返します。

---

## 確認済み

```bash
npm run build
php -l app/Http/Controllers/RoleManageController.php
php artisan test --filter=RoleManageControllerTest
php artisan test --filter=DistrictDepartmentControllerTest
php artisan route:list --name=role_manage
```

## その他

[PermissionのCRUDを削除、代わりに役割表示を追加](https://github.com/Jin6hara/LaravelSprout/pull/124/commits/88c17e23d23df2848aa9af5336b8652e16a1fc80)
