### PR TITLE
DB enum定義をstring化し、Enum管理へ集約

### DIFF
--- a/app/Enums/Concerns/HasValues.php
+++ b/app/Enums/Concerns/HasValues.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums\Concerns;
+
+trait HasValues
+{
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/DayOfWeek.php
+++ b/app/Enums/DayOfWeek.php
@@ -2,8 +2,12 @@
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasValues;
+
 enum DayOfWeek: string
 {
+    use HasValues;
+
     case Mon = 'Mon';
     case Tue = 'Tue';
     case Wed = 'Wed';
@@ -12,8 +16,4 @@ enum DayOfWeek: string
     case Sat = 'Sat';
     case Sun = 'Sun';
 
-    public static function values(): array
-    {
-        return array_map(fn($c) => $c->value, self::cases());
-    }
 }

--- a/app/Enums/EventStatus.php
+++ b/app/Enums/EventStatus.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum EventStatus: string
+{
+    use HasValues;
+
+    case Pending = 'pending';
+    case Fixed = 'fixed';
+    case Filled = 'filled';
+    case InProcess = 'in_process';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Fixed => 'Fixed',
+            self::Filled => 'Filled',
+            self::InProcess => 'In Process',
+        };
+    }
+
+    public static function assignedValues(): array
+    {
+        return [
+            self::Pending->value,
+            self::InProcess->value,
+        ];
+    }
+
+    public static function fixedValues(): array
+    {
+        return [
+            self::Fixed->value,
+            self::Filled->value,
+        ];
+    }
+}

--- a/app/Enums/ExpenseCategory.php
+++ b/app/Enums/ExpenseCategory.php
@@ -2,13 +2,12 @@
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasValues;
+
 enum ExpenseCategory: string
 {
+    use HasValues;
+
     case REGULAR   = 'regular';
     case IRREGULAR = 'irregular';
-
-    public static function values(): array
-    {
-        return array_column(self::cases(), 'value');
-    }
 }

--- a/app/Enums/ExpenseReportStatus.php
+++ b/app/Enums/ExpenseReportStatus.php
@@ -2,15 +2,14 @@
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasValues;
+
 enum ExpenseReportStatus: string
 {
+    use HasValues;
+
     case DRAFT     = 'draft';
     case SUBMITTED = 'submitted';
     case APPROVED  = 'approved';
     case PAID      = 'paid';
-
-    public static function values(): array
-    {
-        return array_column(self::cases(), 'value');
-    }
 }

--- a/app/Enums/ExpenseReportStatus.php
+++ b/app/Enums/ExpenseReportStatus.php
@@ -8,8 +8,18 @@ enum ExpenseReportStatus: string
 {
     use HasValues;
 
-    case DRAFT     = 'Draft';
-    case SUBMITTED = 'Submitted';
-    case APPROVED  = 'Approved';
-    case PAID      = 'Paid';
+    case DRAFT     = 'draft';
+    case SUBMITTED = 'submitted';
+    case APPROVED  = 'approved';
+    case PAID      = 'paid';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DRAFT => 'Draft',
+            self::SUBMITTED => 'Submitted',
+            self::APPROVED => 'Approved',
+            self::PAID => 'Paid',
+        };
+    }
 }

--- a/app/Enums/ExpenseReportStatus.php
+++ b/app/Enums/ExpenseReportStatus.php
@@ -8,8 +8,8 @@ enum ExpenseReportStatus: string
 {
     use HasValues;
 
-    case DRAFT     = 'draft';
-    case SUBMITTED = 'submitted';
-    case APPROVED  = 'approved';
-    case PAID      = 'paid';
+    case DRAFT     = 'Draft';
+    case SUBMITTED = 'Submitted';
+    case APPROVED  = 'Approved';
+    case PAID      = 'Paid';
 }

--- a/app/Enums/ExpenseTripType.php
+++ b/app/Enums/ExpenseTripType.php
@@ -2,13 +2,12 @@
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasValues;
+
 enum ExpenseTripType: string
 {
+    use HasValues;
+
     case ROUND_TRIP = 'round_trip';
     case ONE_WAY    = 'one_way';
-
-    public static function values(): array
-    {
-        return array_column(self::cases(), 'value');
-    }
 }

--- a/app/Enums/ExpenseTripType.php
+++ b/app/Enums/ExpenseTripType.php
@@ -8,6 +8,14 @@ enum ExpenseTripType: string
 {
     use HasValues;
 
-    case ROUND_TRIP = 'Round trip';
-    case ONE_WAY    = 'One way';
+    case ROUND_TRIP = 'round_trip';
+    case ONE_WAY    = 'one_way';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ROUND_TRIP => 'Round trip',
+            self::ONE_WAY => 'One way',
+        };
+    }
 }

--- a/app/Enums/ExpenseTripType.php
+++ b/app/Enums/ExpenseTripType.php
@@ -8,6 +8,6 @@ enum ExpenseTripType: string
 {
     use HasValues;
 
-    case ROUND_TRIP = 'round_trip';
-    case ONE_WAY    = 'one_way';
+    case ROUND_TRIP = 'Round trip';
+    case ONE_WAY    = 'One way';
 }

--- a/app/Enums/Gender.php
+++ b/app/Enums/Gender.php
@@ -16,10 +16,10 @@ enum Gender: string
     public function label(): string
     {
         return match ($this) {
-            self::Male => '男性',
-            self::Female => '女性',
-            self::Other => 'その他',
-            self::Unknown => '未選択',
+            self::Male => 'Male',
+            self::Female => 'Female',
+            self::Other => 'Other',
+            self::Unknown => 'Unknown',
         };
     }
 }

--- a/app/Enums/Gender.php
+++ b/app/Enums/Gender.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum Gender: string
+{
+    use HasValues;
+
+    case Male = 'male';
+    case Female = 'female';
+    case Other = 'other';
+    case Unknown = 'unknown';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Male => '男性',
+            self::Female => '女性',
+            self::Other => 'その他',
+            self::Unknown => '未選択',
+        };
+    }
+}

--- a/app/Enums/LeaveCreditTransactionType.php
+++ b/app/Enums/LeaveCreditTransactionType.php
@@ -8,8 +8,8 @@ enum LeaveCreditTransactionType: string
 {
     use HasValues;
 
-    case Grant = 'grant';
-    case Consume = 'consume';
-    case Revert = 'revert';
-    case Adjust = 'adjust';
+    case Grant = 'Grant';
+    case Consume = 'Consume';
+    case Revert = 'Revert';
+    case Adjust = 'Adjust';
 }

--- a/app/Enums/LeaveCreditTransactionType.php
+++ b/app/Enums/LeaveCreditTransactionType.php
@@ -8,8 +8,18 @@ enum LeaveCreditTransactionType: string
 {
     use HasValues;
 
-    case Grant = 'Grant';
-    case Consume = 'Consume';
-    case Revert = 'Revert';
-    case Adjust = 'Adjust';
+    case Grant = 'grant';
+    case Consume = 'consume';
+    case Revert = 'revert';
+    case Adjust = 'adjust';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Grant => 'Grant',
+            self::Consume => 'Consume',
+            self::Revert => 'Revert',
+            self::Adjust => 'Adjust',
+        };
+    }
 }

--- a/app/Enums/LeaveCreditTransactionType.php
+++ b/app/Enums/LeaveCreditTransactionType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum LeaveCreditTransactionType: string
+{
+    use HasValues;
+
+    case Grant = 'grant';
+    case Consume = 'consume';
+    case Revert = 'revert';
+    case Adjust = 'adjust';
+}

--- a/app/Enums/LeaveExcused.php
+++ b/app/Enums/LeaveExcused.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum LeaveExcused: string
+{
+    use HasValues;
+
+    case Excused = 'excused';
+    case Unexcused = 'unexcused';
+    case Unknown = 'unknown';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Excused => 'Excused',
+            self::Unexcused => 'Unexcused',
+            self::Unknown => 'Unknown',
+        };
+    }
+
+    public static function managedValues(): array
+    {
+        return [
+            self::Excused->value,
+            self::Unexcused->value,
+        ];
+    }
+
+    public static function managedLabels(): array
+    {
+        return [
+            self::Excused->value => self::Excused->label(),
+            self::Unexcused->value => self::Unexcused->label(),
+        ];
+    }
+}

--- a/app/Enums/LeaveKind.php
+++ b/app/Enums/LeaveKind.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum LeaveKind: string
+{
+    use HasValues;
+
+    case Paid = 'paid';
+    case AbsenceToPaid = 'absence_to_paid';
+    case Special = 'special';
+    case Absence = 'absence';
+    case Adjustment = 'adjustment';
+    case LeftEarly = 'left_early';
+    case Late = 'late';
+    case Other = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Paid => 'ALP',
+            self::AbsenceToPaid => 'MT to ALP',
+            self::Special => 'Special',
+            self::Absence => 'MT',
+            self::Adjustment => 'Adjustment',
+            self::LeftEarly => 'Left Early',
+            self::Late => 'Late',
+            self::Other => 'Other',
+        };
+    }
+
+    public function absenceReportLabel(): string
+    {
+        return match ($this) {
+            self::Absence => 'Unpaid Leave',
+            self::AbsenceToPaid => 'ALP',
+            self::Other => 'Others',
+            default => $this->label(),
+        };
+    }
+
+    public function calendarTitle(?string $specialType = null): string
+    {
+        return match ($this) {
+            self::Paid, self::AbsenceToPaid => 'ALP',
+            self::Special => $specialType ? "Special Leave（{$specialType}）" : 'Special Leave',
+            self::Absence => 'Absence',
+            self::Late => 'Late',
+            self::LeftEarly => 'Left Early',
+            self::Adjustment => 'Adjustment',
+            self::Other => $specialType ?: 'Other',
+        };
+    }
+
+    public static function storeValues(): array
+    {
+        return [
+            self::Paid->value,
+            self::Special->value,
+            self::Absence->value,
+            self::Late->value,
+            self::Other->value,
+        ];
+    }
+
+    public static function applicationValues(): array
+    {
+        return [
+            self::Paid->value,
+            self::Special->value,
+        ];
+    }
+
+    public static function labels(): array
+    {
+        return array_reduce(
+            self::cases(),
+            fn (array $labels, self $case) => $labels + [$case->value => $case->label()],
+            []
+        );
+    }
+
+    public static function absenceReportValues(): array
+    {
+        return [
+            self::Absence->value,
+            self::AbsenceToPaid->value,
+            self::Other->value,
+        ];
+    }
+
+    public static function absenceReportLabels(): array
+    {
+        return array_reduce(
+            [self::Absence, self::AbsenceToPaid, self::Other],
+            fn (array $labels, self $case) => $labels + [$case->value => $case->absenceReportLabel()],
+            []
+        );
+    }
+}

--- a/app/Enums/LeaveStatus.php
+++ b/app/Enums/LeaveStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum LeaveStatus: string
+{
+    use HasValues;
+
+    case Draft = 'draft';
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+    case Cancelled = 'cancelled';
+    case Archived = 'archived';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft => 'Draft',
+            self::Pending => 'Pending',
+            self::Approved => 'Approved',
+            self::Rejected => 'Rejected',
+            self::Cancelled => 'Cancelled',
+            self::Archived => 'Archived',
+        };
+    }
+
+    public static function manageLabels(): array
+    {
+        return [
+            self::Approved->value => self::Approved->label(),
+            self::Pending->value => self::Pending->label(),
+            self::Rejected->value => self::Rejected->label(),
+            self::Cancelled->value => self::Cancelled->label(),
+        ];
+    }
+
+    public static function storeValues(): array
+    {
+        return [
+            self::Approved->value,
+            self::Pending->value,
+            self::Rejected->value,
+        ];
+    }
+
+    public static function snapshotValues(): array
+    {
+        return [
+            self::Approved->value,
+            self::Pending->value,
+        ];
+    }
+}

--- a/app/Enums/PostType.php
+++ b/app/Enums/PostType.php
@@ -2,14 +2,29 @@
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasValues;
+
 enum PostType: string
 {
+    use HasValues;
+
     case Announcement  = 'announcement';
     case Inquiry       = 'inquiry';
     case DirectMessage = 'dm';
     case NoticeUrgent  = 'notice_urgent';
     case Maintenance   = 'maintenance';
     case Other         = 'other';
+
+    public static function sendValues(): array
+    {
+        return [
+            self::Announcement->value,
+            self::Inquiry->value,
+            self::DirectMessage->value,
+            self::NoticeUrgent->value,
+            self::Maintenance->value,
+        ];
+    }
 
     // タイプ別の既定値（UI/保存時の既定）
     public function defaultAllowReplies(): bool

--- a/app/Enums/RestPatternAdjustmentKind.php
+++ b/app/Enums/RestPatternAdjustmentKind.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum RestPatternAdjustmentKind: string
+{
+    use HasValues;
+
+    case AddOff = 'add_off';
+    case WorkInstead = 'work_instead';
+
+    public function code(): string
+    {
+        return match ($this) {
+            self::AddOff => 'ORD',
+            self::WorkInstead => 'RWD',
+        };
+    }
+}

--- a/app/Enums/RestPatternRuleKind.php
+++ b/app/Enums/RestPatternRuleKind.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Concerns\HasValues;
+
+enum RestPatternRuleKind: string
+{
+    use HasValues;
+
+    case Work = 'work';
+    case PrescribedOff = 'prescribed_off';
+    case StatutoryOff = 'statutory_off';
+
+    public function title(): string
+    {
+        return match ($this) {
+            self::Work => '',
+            self::PrescribedOff => 'ORD',
+            self::StatutoryOff => 'LRD',
+        };
+    }
+}

--- a/app/Enums/ShiftType.php
+++ b/app/Enums/ShiftType.php
@@ -33,12 +33,12 @@ enum ShiftType: string
     public function calendarLabel(): string
     {
         return match ($this) {
-            self::Overtime => '残業',
-            self::RegularTime => '通常勤務',
-            self::Special => '特別イベント',
-            self::ScheduleChange => '時間変更',
-            self::RosteredWorkingDay => '振替出勤',
-            self::NoneRequired => '勤務不要',
+            self::Overtime => 'OT (No title)',
+            self::RegularTime => 'RT (No title)',
+            self::Special => 'SP (No title)',
+            self::ScheduleChange => 'SC (No title)',
+            self::RosteredWorkingDay => 'RWD (No title)',
+            self::NoneRequired => 'NS (No title)',
         };
     }
 

--- a/app/Enums/ShiftType.php
+++ b/app/Enums/ShiftType.php
@@ -5,8 +5,12 @@
 
 namespace App\Enums;
 
+use App\Enums\Concerns\HasValues;
+
 enum ShiftType: string
 {
+    use HasValues;
+
     case RegularTime        = 'regular_time';
     case Overtime           = 'overtime';
     case ScheduleChange     = 'schedule_change';
@@ -23,6 +27,30 @@ enum ShiftType: string
             self::Special            => 'SP',
             self::RosteredWorkingDay => 'RWD',
             self::NoneRequired       => 'NS',
+        };
+    }
+
+    public function calendarLabel(): string
+    {
+        return match ($this) {
+            self::Overtime => '残業',
+            self::RegularTime => '通常勤務',
+            self::Special => '特別イベント',
+            self::ScheduleChange => '時間変更',
+            self::RosteredWorkingDay => '振替出勤',
+            self::NoneRequired => '勤務不要',
+        };
+    }
+
+    public function sortOrder(): int
+    {
+        return match ($this) {
+            self::Overtime => 10,
+            self::RegularTime => 20,
+            self::Special => 30,
+            self::ScheduleChange => 40,
+            self::RosteredWorkingDay => 45,
+            self::NoneRequired => 50,
         };
     }
 }

--- a/app/Http/Controllers/ApprovalController.php
+++ b/app/Http/Controllers/ApprovalController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\LeaveKind;
 use App\Models\ApprovalRequest;
 use App\Models\Leave;
 use App\Services\Approval\ApprovalService;
@@ -27,7 +28,7 @@ class ApprovalController extends Controller
         if ($approvable instanceof Leave) {
             $kind = $meta['kind'] ?? $approvable->kind ?? null;
 
-            if ($kind === 'special') {
+            if ($kind === LeaveKind::Special->value) {
                 // ★ 特別休暇 → 期間表示（from〜to）
                 $from = $meta['date_from'] ?? optional($approvable->start_date)->format('Y-m-d');
                 $to   = $meta['date_to']   ?? optional($approvable->end_date)->format('Y-m-d');
@@ -37,7 +38,7 @@ class ApprovalController extends Controller
                 } else {
                     $dateSummary = $from ?: $to ?: '-';
                 }
-            } elseif ($kind === 'paid') {
+            } elseif ($kind === LeaveKind::Paid->value) {
                 // ★ 有給 → 同じバッチの全日を「日, 日, 日」で表示
                 $batchId = $meta['batch_id'] ?? null;
 

--- a/app/Http/Controllers/CalendarPatternEditorController.php
+++ b/app/Http/Controllers/CalendarPatternEditorController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\RestPatternAdjustmentKind;
+use App\Enums\RestPatternRuleKind;
 use App\Models\CompanyClosure;
 use App\Models\Holiday;
 use App\Models\RestPattern;
@@ -9,6 +11,7 @@ use App\Models\RestPatternAdjustment;
 use App\Models\RestPatternRule;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class CalendarPatternEditorController extends Controller
 {
@@ -88,11 +91,12 @@ class CalendarPatternEditorController extends Controller
             while ($cur->lte($endCar)) {
                 $ymd  = $cur->toDateString();
                 $rule = $rules->get($cur->dayOfWeek);
-                if ($rule && $rule->kind !== 'work' && !isset($adjMap[$ymd])) {
+                $ruleKind = $rule ? RestPatternRuleKind::tryFrom($rule->kind) : null;
+                if ($ruleKind && $ruleKind !== RestPatternRuleKind::Work && !isset($adjMap[$ymd])) {
                     $result[] = [
                         'start' => $ymd,
-                        'title' => $rule->kind === 'statutory_off' ? 'LRD' : 'ORD',
-                        'kind'  => $rule->kind,
+                        'title' => $ruleKind->title(),
+                        'kind'  => $ruleKind->value,
                         '_type' => 'offday',
                     ];
                 }
@@ -100,11 +104,12 @@ class CalendarPatternEditorController extends Controller
             }
 
             foreach ($adjs as $a) {
+                $adjustmentKind = RestPatternAdjustmentKind::tryFrom($a->kind);
                 $result[] = [
                     'id'    => $a->id,
                     'start' => $a->date->toDateString(),
                     'kind'  => $a->kind,
-                    'title' => $a->title ?: ($a->kind === 'add_off' ? 'ORD' : 'RWD'),
+                    'title' => $a->title ?: ($adjustmentKind?->code() ?? $a->kind),
                     '_type' => 'adjusting',
                 ];
             }
@@ -133,7 +138,7 @@ class CalendarPatternEditorController extends Controller
         $data = $request->validate([
             'rest_pattern_id' => 'required|integer|exists:rest_patterns,id',
             'rules'           => 'required|array',
-            'rules.*'         => 'required|in:statutory_off,prescribed_off,work',
+            'rules.*'         => ['required', Rule::in(RestPatternRuleKind::values())],
         ]);
         $pid = $data['rest_pattern_id'];
         foreach ($data['rules'] as $weekday => $kind) {
@@ -253,12 +258,12 @@ class CalendarPatternEditorController extends Controller
         $data = $request->validate([
             'rest_pattern_id' => 'required|integer|exists:rest_patterns,id',
             'date'            => 'required|date',
-            'kind'            => 'required|in:add_off,work_instead',
+            'kind'            => ['required', Rule::in(RestPatternAdjustmentKind::values())],
             'title'           => 'nullable|string|max:100',
             'is_active'       => 'boolean',
             'note'            => 'nullable|string|max:500',
         ]);
-        $data['code'] = $data['kind'] === 'add_off' ? 'ORD' : 'RWD';
+        $data['code'] = RestPatternAdjustmentKind::from($data['kind'])->code();
 
         $row = RestPatternAdjustment::create($data);
 
@@ -278,12 +283,12 @@ class CalendarPatternEditorController extends Controller
         $data = $request->validate([
             'rest_pattern_id' => 'required|integer|exists:rest_patterns,id',
             'date'            => 'required|date',
-            'kind'            => 'required|in:add_off,work_instead',
+            'kind'            => ['required', Rule::in(RestPatternAdjustmentKind::values())],
             'title'           => 'nullable|string|max:100',
             'is_active'       => 'boolean',
             'note'            => 'nullable|string|max:500',
         ]);
-        $data['code'] = $data['kind'] === 'add_off' ? 'ORD' : 'RWD';
+        $data['code'] = RestPatternAdjustmentKind::from($data['kind'])->code();
         $adjustment->update($data);
 
         return response()->json([

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use App\Http\Requests\EventAssign\BulkUpdateEventRequest;
 use App\Http\Requests\EventAssign\CopyEventRequest;
 use App\Http\Requests\EventAssign\UpdateEventRequest;
@@ -117,18 +119,18 @@ class EventAssignController extends Controller
             ->withQueryString();
 
         $statusOptions = [
-            'filled'     => 'Filled',
-            'fixed'      => 'Fixed',
-            'pending'    => 'Pending',
-            'in_process' => 'In Process',
+            EventStatus::Filled->value => EventStatus::Filled->label(),
+            EventStatus::Fixed->value => EventStatus::Fixed->label(),
+            EventStatus::Pending->value => EventStatus::Pending->label(),
+            EventStatus::InProcess->value => EventStatus::InProcess->label(),
         ];
         $typeOptions = [
-            'regular_time'         => 'RT',
-            'overtime'             => 'OT',
-            'schedule_change'      => 'SC',
-            'special'              => 'SP',
-            'rostered_working_day' => 'RWD',
-            'none_required'        => 'NS',
+            ShiftType::RegularTime->value => ShiftType::RegularTime->short(),
+            ShiftType::Overtime->value => ShiftType::Overtime->short(),
+            ShiftType::ScheduleChange->value => ShiftType::ScheduleChange->short(),
+            ShiftType::Special->value => ShiftType::Special->short(),
+            ShiftType::RosteredWorkingDay->value => ShiftType::RosteredWorkingDay->short(),
+            ShiftType::NoneRequired->value => ShiftType::NoneRequired->short(),
         ];
 
         // $schoolNames を view に渡す
@@ -186,8 +188,8 @@ class EventAssignController extends Controller
         // 空白イベントを作成
         $event = Event::create([
             'event_date'    => $date,
-            'status'        => 'pending',
-            'type'          => 'regular_time',
+            'status'        => EventStatus::Pending->value,
+            'type'          => ShiftType::RegularTime->value,
             'district_id'   => $this->scopeService->currentDistrictId(),
             'department_id' => $this->scopeService->currentDepartmentId(),
         ]);

--- a/app/Http/Controllers/ExpenseReportController.php
+++ b/app/Http/Controllers/ExpenseReportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\ExpenseReportStatus;
 use App\Http\Requests\ExpenseReport\ShowExpenseReportRequest;
 use App\Models\ExpenseReport;
 use App\Services\CurrentScopeService;
@@ -61,7 +62,10 @@ class ExpenseReportController extends Controller
         $sum_submitted = (int) $reports->whereNotNull('submitted_at')->sum('total_amount');
         $sum_approved  = (int) $reports->filter(function ($r) {
             $v = $r->status instanceof \BackedEnum ? $r->status->value : (string)$r->status;
-            return in_array(strtolower($v), ['approved', 'paid'], true);
+            return in_array(strtolower($v), [
+                ExpenseReportStatus::APPROVED->value,
+                ExpenseReportStatus::PAID->value,
+            ], true);
         })->sum('total_amount');
 
         $summary = [

--- a/app/Http/Controllers/LeaveApplyController.php
+++ b/app/Http/Controllers/LeaveApplyController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\LeaveKind;
 use App\Http\Requests\LeaveApply\LeaveApplyRequest;
 use App\Models\LeaveCredit;
 use App\Models\User;
@@ -35,7 +36,7 @@ class LeaveApplyController extends Controller
      */
     public function store(LeaveApplyRequest $request): RedirectResponse
     {
-        $type           = (string) $request->input('type', 'paid');
+        $type           = (string) $request->input('type', LeaveKind::Paid->value);
         $specialType    = (string) $request->input('special_type', '');
         $attachmentMeta = $this->handleAttachment($type, $request);
 
@@ -72,7 +73,7 @@ class LeaveApplyController extends Controller
     {
         $this->authorize('manage', $user);
 
-        $type           = (string) $request->input('type', 'paid');
+        $type           = (string) $request->input('type', LeaveKind::Paid->value);
         $specialType    = (string) $request->input('special_type', '');
         $attachmentMeta = $this->handleAttachment($type, $request);
 
@@ -95,7 +96,7 @@ class LeaveApplyController extends Controller
      */
     private function handleAttachment(string $type, LeaveApplyRequest $request): ?array
     {
-        if ($type !== 'special' || !$request->hasFile('attachment')) {
+        if ($type !== LeaveKind::Special->value || !$request->hasFile('attachment')) {
             return null;
         }
 

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use App\Http\Requests\Leave\AllReportRequest;
 use App\Http\Requests\Leave\ReportLeaveRequest;
 use App\Http\Requests\Leave\StoreLeaveRequest;
@@ -45,12 +48,12 @@ class LeaveController extends Controller
             'start_date'    => $request->date('start_date'),
             'end_date'      => $request->input('end_date') ? $request->date('end_date') : null,
             'kind'          => $request->input('kind'),
-            'excused'       => $request->input('excused', 'unexcused'),
+            'excused'       => $request->input('excused', LeaveExcused::Unexcused->value),
             'special_type'  => $request->input('special_type'),
             'reason'        => $request->input('reason'),
             'time_start'    => $request->input('time_start'),
             'time_end'      => $request->input('time_end'),
-            'status'        => $request->input('status', 'approved'),
+            'status'        => $request->input('status', LeaveStatus::Approved->value),
             'approved_by'   => auth()->id(), // 簡易に自分で承認した体
             'district_id'   => $targetUser?->district_id,
             'department_id' => $targetUser?->department_id,
@@ -74,9 +77,9 @@ class LeaveController extends Controller
         $this->authorize('cancel', $leave);
 
         DB::transaction(function () use ($leave) {
-            $wasApproved = $leave->status === 'approved';
+            $wasApproved = $leave->status === LeaveStatus::Approved->value;
 
-            $leave->update(['status' => 'cancelled']);
+            $leave->update(['status' => LeaveStatus::Cancelled->value]);
 
             if ($wasApproved) {
                 app(LeaveBalanceService::class)->revert($leave);
@@ -98,16 +101,12 @@ class LeaveController extends Controller
         // 表示するレコード
         $leaves = Leave::query()
             ->where('user_id', $user->id)
-            ->whereIn('kind', ['absence', 'absence_to_paid', 'other'])
+            ->whereIn('kind', LeaveKind::absenceReportValues())
             ->orderByDesc('start_date')
             ->get();
 
         // ラベル
-        $kindLabels = [
-            'absence'         => 'Unpaid Leave',
-            'absence_to_paid' => 'ALP',
-            'other'           => 'Others',
-        ];
+        $kindLabels = LeaveKind::absenceReportLabels();
 
         // Handle Type 選択肢（キー＝保存値、値＝表示文言）
         $handleTypeOptions = [
@@ -121,12 +120,12 @@ class LeaveController extends Controller
 
         // ★ ビューに渡す「行用のビューモデル」を生成
         $rows = $leaves->map(function (Leave $leave) use ($kindLabels, $handleTypeOptions) {
-            $kindLabel = $leave->kind === 'other'
+            $kindLabel = $leave->kind === LeaveKind::Other->value
                 ? ($leave->special_type ?: 'Others')
                 : ($kindLabels[$leave->kind] ?? ucfirst($leave->kind));
 
             // reason の null 判定は外す：kind=absence かつ handle_type が null のとき入力可
-            $needsReport = ($leave->kind === 'absence') && is_null($leave->handle_type);
+            $needsReport = ($leave->kind === LeaveKind::Absence->value) && is_null($leave->handle_type);
 
             $statusText = ($leave->handle_type)
                 ? 'Submitted'
@@ -173,7 +172,7 @@ class LeaveController extends Controller
     {
         $this->authorize('report', $leave);
 
-        if ($leave->kind !== 'absence') {
+            if ($leave->kind !== LeaveKind::Absence->value) {
             return back()->with('toast_errors', ['This leave is not target for absence self-report.']);
         }
         if (!is_null($leave->handle_type)) {
@@ -222,13 +221,13 @@ class LeaveController extends Controller
         $validated = $request->validated();
 
         $status  = $validated['status'] ?? 'all';
-        $kind    = $validated['kind']   ?? 'absence'; // 既定は absence のみ
+        $kind    = $validated['kind']   ?? LeaveKind::Absence->value; // 既定は absence のみ
         $from    = $validated['from']   ?? null;
         $to      = $validated['to']     ?? null;
         $userId  = $validated['user_id'] ?? null;
 
         // 基本クエリ
-        $kinds = $kind === 'all' ? ['absence', 'absence_to_paid', 'other'] : [$kind];
+        $kinds = $kind === 'all' ? LeaveKind::absenceReportValues() : [$kind];
 
         $q = Leave::query()
             ->with(['user:id,first_name,family_name,name,employee_code'])
@@ -242,7 +241,7 @@ class LeaveController extends Controller
         // status フィルタ
         // needsReport = kind=absence && handle_type IS NULL
         if ($status === 'required') {
-            $q->where('kind', 'absence')->whereNull('handle_type');
+            $q->where('kind', LeaveKind::Absence->value)->whereNull('handle_type');
         } elseif ($status === 'submitted') {
             $q->whereNotNull('handle_type');
         }
@@ -250,11 +249,7 @@ class LeaveController extends Controller
         $leaves = $q->orderByDesc('start_date')->paginate(20)->appends($request->query());
 
         // ラベル
-        $kindLabels = [
-            'absence'         => 'Unpaid Leave',
-            'absence_to_paid' => 'ALP',
-            'other'           => 'Others',
-        ];
+        $kindLabels = LeaveKind::absenceReportLabels();
 
         // Handle Type の候補（ラベル=保存値運用にも対応）
         $handleTypeOptions = [
@@ -269,11 +264,11 @@ class LeaveController extends Controller
 
         // 行ビュー用の派生値を付与
         $rows = $leaves->getCollection()->map(function (Leave $leave) use ($kindLabels, $handleTypeDict) {
-            $kindLabel = $leave->kind === 'other'
+            $kindLabel = $leave->kind === LeaveKind::Other->value
                 ? ($leave->special_type ?: 'Others')
                 : ($kindLabels[$leave->kind] ?? ucfirst($leave->kind));
 
-            $needsReport = ($leave->kind === 'absence') && is_null($leave->handle_type);
+            $needsReport = ($leave->kind === LeaveKind::Absence->value) && is_null($leave->handle_type);
 
             $statusText = $leave->handle_type
                 ? 'Submitted'

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use App\Http\Requests\LeaveManage\BulkUpdateLeaveManageRequest;
 use App\Http\Requests\LeaveManage\StoreLeaveManageRequest;
 use App\Http\Requests\LeaveManage\UpdateLeaveManageRequest;
@@ -93,26 +96,9 @@ class LeaveManageController extends Controller
             ->withQueryString();
 
         // 5) オプション
-        $statusOptions = [
-            'approved' => 'Approved',
-            'pending'  => 'Pending',
-            'rejected' => 'Rejected',
-            'cancelled'    => 'Cancelled',
-        ];
-        $kindOptions = [
-            'paid'            => 'ALP',
-            'absence_to_paid' => 'MT to ALP',
-            'special'         => 'Special',
-            'absence'         => 'MT',
-            'adjustment'      => 'Adjustment',
-            'left_early'      => 'Left Early',
-            'late'            => 'Late',
-            'other'           => 'Other',
-        ];
-        $excusedOptions = [
-            'excused'   => 'Excused',
-            'unexcused' => 'Unexcused',
-        ];
+        $statusOptions = LeaveStatus::manageLabels();
+        $kindOptions = LeaveKind::labels();
+        $excusedOptions = LeaveExcused::managedLabels();
 
         // 6) 表示
         return view('calendar.leaveEdit', compact(
@@ -141,12 +127,12 @@ class LeaveManageController extends Controller
             'start_date'    => $data['start_date'],
             'end_date'      => null,
             'reason'        => null,
-            'kind'          => 'special',
-            'excused'       => 'excused',
+            'kind'          => LeaveKind::Special->value,
+            'excused'       => LeaveExcused::Excused->value,
             'time_start'    => null,
             'time_end'      => null,
             'handle_type'   => null,
-            'status'        => 'approved',
+            'status'        => LeaveStatus::Approved->value,
             'district_id'   => $this->scopeService->currentDistrictId(),
             'department_id' => $this->scopeService->currentDepartmentId(),
         ]);

--- a/app/Http/Controllers/OverTimeController.php
+++ b/app/Http/Controllers/OverTimeController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use App\Models\Event;
 use App\Services\CurrentScopeService;
 
@@ -18,8 +20,8 @@ class OverTimeController extends Controller
         $districtId = $this->scopeService->currentDistrictId();
 
         $events = Event::query()
-            ->where('type', 'overtime')
-            ->where('status', 'in_process')
+            ->where('type', ShiftType::Overtime->value)
+            ->where('status', EventStatus::InProcess->value)
             ->whereHas('originalUser', fn($q) => $q->where('district_id', $districtId))
             ->orderBy('event_date')
             ->orderBy('start_time')

--- a/app/Http/Controllers/RouteDeclarationController.php
+++ b/app/Http/Controllers/RouteDeclarationController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\DayOfWeek;
+use App\Enums\ExpenseTripType;
 use App\Models\User;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
@@ -11,6 +13,7 @@ use Illuminate\Http\RedirectResponse;
 use App\Models\RouteDeclaration;
 use App\Models\EmploymentTerm;
 use App\Models\ScheduleLine;
+use Illuminate\Validation\Rule;
 
 class RouteDeclarationController extends Controller
 {
@@ -123,10 +126,10 @@ class RouteDeclarationController extends Controller
             'reason'          => ['nullable', 'string'],
 
             'details'                => ['required', 'array', 'min:1'],
-            'details.*.dow'          => ['required', 'in:Mon,Tue,Wed,Thu,Fri,Sat,Sun'],
+            'details.*.dow'          => ['required', Rule::in(DayOfWeek::values())],
             'details.*.from_station' => ['required', 'string', 'max:255'],
             'details.*.to_station'   => ['required', 'string', 'max:255'],
-            'details.*.trip_type'    => ['required', 'in:round_trip,one_way'],
+            'details.*.trip_type'    => ['required', Rule::in(ExpenseTripType::values())],
             'details.*.amount'       => ['required', 'integer', 'min:0'],
             'details.*.route_text'   => ['nullable', 'string'],
             'details.*.note'         => ['nullable', 'string'],

--- a/app/Http/Controllers/UserCsvController.php
+++ b/app/Http/Controllers/UserCsvController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\Gender;
 use App\Models\Department;
 use App\Models\District;
 use App\Models\EmploymentTerm;
@@ -10,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -184,7 +186,7 @@ class UserCsvController extends Controller
                 'name_in_kana'          => ['nullable', 'string', 'max:255'],
                 'email'                 => ['required', 'email', 'max:255'],
                 'employee_code'         => ['required', 'string', 'size:6'],
-                'gender'                => ['nullable', 'in:male,female,other,unknown'],
+                'gender'                => ['nullable', Rule::in(Gender::values())],
                 'note'                  => ['nullable', 'string'],
                 'address'               => ['nullable', 'string', 'max:255'],
                 'phone_number'          => ['nullable', 'string', 'max:255'],
@@ -273,7 +275,7 @@ class UserCsvController extends Controller
                     'name_in_kana'  => $data['name_in_kana'] ?? null,
                     'email'         => $data['email'],
                     'employee_code' => $data['employee_code'],
-                    'gender'        => $data['gender'] ?? 'unknown',
+                    'gender'        => $data['gender'] ?? Gender::Unknown->value,
                     'note'          => $data['note'] ?? null,
                     'address'       => $data['address'] ?? null,
                     'phone_number'  => $data['phone_number'] ?? null,

--- a/app/Http/Requests/Admin/UserRequest.php
+++ b/app/Http/Requests/Admin/UserRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Enums\Gender;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UserRequest extends FormRequest
 {
@@ -19,7 +21,7 @@ class UserRequest extends FormRequest
             'name_in_kana'  => ['nullable', 'string', 'max:255'],
             'email'         => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password'      => ['required', 'string', 'min:8', 'confirmed'],
-            'gender'        => ['required', 'in:male,female,other,unknown'],
+            'gender'        => ['required', Rule::in(Gender::values())],
             'employee_code' => ['required', 'digits:6', 'unique:users'],
             'phone_number'  => ['nullable', 'string', 'max:15'],
             'address'       => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/EventAssign/BulkUpdateEventRequest.php
+++ b/app/Http/Requests/EventAssign/BulkUpdateEventRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\EventAssign;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -33,8 +35,8 @@ class BulkUpdateEventRequest extends FormRequest
             'total_duration'   => ['nullable', 'regex:/^\d{1,2}:\d{2}$/'],
             'Lesson'           => ['nullable', 'string'],
             'assigned_user_id' => ['nullable', 'exists:users,id'],
-            'status'           => ['required', Rule::in(['pending', 'fixed', 'filled', 'in_process'])],
-            'type'             => ['required', Rule::in(['regular_time', 'none_required', 'overtime', 'schedule_change', 'rostered_working_day', 'special'])],
+            'status'           => ['required', Rule::in(EventStatus::values())],
+            'type'             => ['required', Rule::in(ShiftType::values())],
             'notes'            => ['nullable', 'string'],
         ];
     }

--- a/app/Http/Requests/EventAssign/CopyEventRequest.php
+++ b/app/Http/Requests/EventAssign/CopyEventRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\EventAssign;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -25,8 +27,8 @@ class CopyEventRequest extends FormRequest
             'total_duration'   => ['nullable', 'regex:/^\d{1,2}:\d{2}$/'],
             'Lesson'           => ['nullable', 'string'],
             'assigned_user_id' => ['nullable', 'exists:users,id'],
-            'status'           => ['required', Rule::in(['pending', 'fixed', 'filled', 'in_process'])],
-            'type'             => ['required', Rule::in(['regular_time', 'none_required', 'overtime', 'schedule_change', 'rostered_working_day', 'special'])],
+            'status'           => ['required', Rule::in(EventStatus::values())],
+            'type'             => ['required', Rule::in(ShiftType::values())],
             'notes'            => ['nullable', 'string'],
         ];
     }

--- a/app/Http/Requests/EventAssign/UpdateEventRequest.php
+++ b/app/Http/Requests/EventAssign/UpdateEventRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\EventAssign;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -25,8 +27,8 @@ class UpdateEventRequest extends FormRequest
             'total_duration'   => ['nullable', 'regex:/^\d{1,2}:\d{2}$/'],
             'Lesson'           => ['nullable', 'string'],
             'assigned_user_id' => ['nullable', 'exists:users,id'],
-            'status'           => ['required', Rule::in(['pending', 'fixed', 'filled', 'in_process'])],
-            'type'             => ['required', Rule::in(['regular_time', 'none_required', 'overtime', 'schedule_change', 'rostered_working_day', 'special'])],
+            'status'           => ['required', Rule::in(EventStatus::values())],
+            'type'             => ['required', Rule::in(ShiftType::values())],
             'notes'            => ['nullable', 'string'],
         ];
     }

--- a/app/Http/Requests/ExpenseApi/BatchSaveExpenseRequest.php
+++ b/app/Http/Requests/ExpenseApi/BatchSaveExpenseRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\ExpenseApi;
 
+use App\Enums\ExpenseCategory;
+use App\Enums\ExpenseTripType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -23,7 +25,7 @@ class BatchSaveExpenseRequest extends FormRequest
             'updates.*.station_to'     => ['nullable', 'string', 'max:255'],
             'updates.*.note'           => ['nullable', 'string'],
             'updates.*.cost'           => ['nullable', 'integer', 'min:0'],
-            'updates.*.trip_type'      => ['nullable', Rule::in(['round_trip', 'one_way'])],
+            'updates.*.trip_type'      => ['nullable', Rule::in(ExpenseTripType::values())],
             'updates.*.seq'            => ['nullable', 'integer', 'min:0'],
 
             'creates'                  => ['present', 'array'],
@@ -33,8 +35,8 @@ class BatchSaveExpenseRequest extends FormRequest
             'creates.*.station_to'     => ['nullable', 'string', 'max:255'],
             'creates.*.note'           => ['nullable', 'string'],
             'creates.*.cost'           => ['nullable', 'integer', 'min:0'],
-            'creates.*.trip_type'      => ['required', Rule::in(['round_trip', 'one_way'])],
-            'creates.*.category'       => ['required', Rule::in(['regular', 'irregular'])],
+            'creates.*.trip_type'      => ['required', Rule::in(ExpenseTripType::values())],
+            'creates.*.category'       => ['required', Rule::in(ExpenseCategory::values())],
         ];
     }
 }

--- a/app/Http/Requests/ExpenseApi/StoreExpenseRequest.php
+++ b/app/Http/Requests/ExpenseApi/StoreExpenseRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\ExpenseApi;
 
+use App\Enums\ExpenseCategory;
+use App\Enums\ExpenseTripType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -22,8 +24,8 @@ class StoreExpenseRequest extends FormRequest
             'station_to'        => ['nullable', 'string', 'max:255'],
             'note'              => ['nullable', 'string'],
             'cost'              => ['nullable', 'integer', 'min:0'],
-            'trip_type'         => ['required', Rule::in(['round_trip', 'one_way'])],
-            'category'          => ['required', Rule::in(['regular', 'irregular'])],
+            'trip_type'         => ['required', Rule::in(ExpenseTripType::values())],
+            'category'          => ['required', Rule::in(ExpenseCategory::values())],
             'commuter_pass_id'  => ['nullable', 'exists:commuter_passes,id'],
         ];
     }

--- a/app/Http/Requests/ExpenseApi/UpdateExpenseRequest.php
+++ b/app/Http/Requests/ExpenseApi/UpdateExpenseRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\ExpenseApi;
 
+use App\Enums\ExpenseCategory;
+use App\Enums\ExpenseTripType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -19,8 +21,8 @@ class UpdateExpenseRequest extends FormRequest
             'station_to'       => ['nullable', 'string', 'max:255'],
             'note'             => ['nullable', 'string'],
             'cost'             => ['nullable', 'integer', 'min:0'],
-            'trip_type'        => ['nullable', Rule::in(['round_trip', 'one_way'])],
-            'category'         => ['nullable', Rule::in(['regular', 'irregular'])],
+            'trip_type'        => ['nullable', Rule::in(ExpenseTripType::values())],
+            'category'         => ['nullable', Rule::in(ExpenseCategory::values())],
             'commuter_pass_id' => ['nullable', 'exists:commuter_passes,id'],
             'seq'              => ['nullable', 'integer', 'min:0'],
         ];

--- a/app/Http/Requests/Leave/AllReportRequest.php
+++ b/app/Http/Requests/Leave/AllReportRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Leave;
 
+use App\Enums\LeaveKind;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -16,7 +17,7 @@ class AllReportRequest extends FormRequest
     {
         return [
             'status'  => ['nullable', Rule::in(['required', 'submitted', 'all'])],
-            'kind'    => ['nullable', Rule::in(['absence', 'absence_to_paid', 'other', 'all'])],
+            'kind'    => ['nullable', Rule::in([...LeaveKind::absenceReportValues(), 'all'])],
             'from'    => ['nullable', 'date'],
             'to'      => ['nullable', 'date', 'after_or_equal:from'],
             'user_id' => ['nullable', 'integer', 'exists:users,id'],

--- a/app/Http/Requests/Leave/StoreLeaveRequest.php
+++ b/app/Http/Requests/Leave/StoreLeaveRequest.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Requests\Leave;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreLeaveRequest extends FormRequest
 {
@@ -17,13 +21,13 @@ class StoreLeaveRequest extends FormRequest
             'user_id'      => ['required', 'exists:users,id'],
             'start_date'   => ['required', 'date'],
             'end_date'     => ['nullable', 'date', 'after_or_equal:start_date'],
-            'kind'         => ['required', 'in:paid,special,absence,late,other'],
-            'excused'      => ['nullable', 'in:excused,unexcused,unknown'],
+            'kind'         => ['required', Rule::in(LeaveKind::storeValues())],
+            'excused'      => ['nullable', Rule::in(LeaveExcused::values())],
             'special_type' => ['nullable', 'string', 'max:100'],
             'reason'       => ['nullable', 'string'],
             'time_start'   => ['nullable', 'date_format:H:i'],
             'time_end'     => ['nullable', 'date_format:H:i', 'after:time_start'],
-            'status'       => ['nullable', 'in:approved,pending,rejected'],
+            'status'       => ['nullable', Rule::in(LeaveStatus::storeValues())],
         ];
     }
 }

--- a/app/Http/Requests/LeaveApply/LeaveApplyRequest.php
+++ b/app/Http/Requests/LeaveApply/LeaveApplyRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\LeaveApply;
 
+use App\Enums\LeaveKind;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class LeaveApplyRequest extends FormRequest
 {
@@ -18,6 +20,8 @@ class LeaveApplyRequest extends FormRequest
             'dates'   => ['required', 'array', 'min:1'],
             'dates.*' => ['required', 'date'],
             'reason'  => ['nullable', 'string'],
+            'type'    => ['nullable', Rule::in(LeaveKind::applicationValues())],
+            'special_type' => ['nullable', 'string', 'max:100'],
         ];
     }
 

--- a/app/Http/Requests/LeaveManage/BulkUpdateLeaveManageRequest.php
+++ b/app/Http/Requests/LeaveManage/BulkUpdateLeaveManageRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Requests\LeaveManage;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -22,13 +25,13 @@ class BulkUpdateLeaveManageRequest extends FormRequest
             'items.*.start_date'   => ['required', 'date'],
             'items.*.end_date'     => ['nullable', 'date', 'after_or_equal:items.*.start_date'],
             'items.*.reason'       => ['nullable', 'string'],
-            'items.*.kind'         => ['required', Rule::in(['paid', 'absence_to_paid', 'special', 'absence', 'adjustment', 'left_early', 'late', 'other'])],
-            'items.*.excused'      => ['required', Rule::in(['excused', 'unexcused'])],
+            'items.*.kind'         => ['required', Rule::in(LeaveKind::values())],
+            'items.*.excused'      => ['required', Rule::in(LeaveExcused::managedValues())],
             'items.*.special_type' => ['nullable', 'string', 'max:100'],
             'items.*.time_start'   => ['nullable', 'date_format:H:i', 'required_with:items.*.time_end'],
             'items.*.time_end'     => ['nullable', 'date_format:H:i', 'required_with:items.*.time_start'],
             'items.*.handle_type'  => ['nullable', 'string'],
-            'items.*.status'       => ['required', Rule::in(['approved', 'pending', 'rejected', 'draft', 'cancelled', 'archived'])],
+            'items.*.status'       => ['required', Rule::in(LeaveStatus::values())],
         ];
     }
 

--- a/app/Http/Requests/LeaveManage/UpdateLeaveManageRequest.php
+++ b/app/Http/Requests/LeaveManage/UpdateLeaveManageRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Requests\LeaveManage;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -20,13 +23,13 @@ class UpdateLeaveManageRequest extends FormRequest
             'start_date'   => ['required', 'date'],
             'end_date'     => ['nullable', 'date', 'after_or_equal:start_date'],
             'reason'       => ['nullable', 'string'],
-            'kind'         => ['required', Rule::in(['paid', 'absence_to_paid', 'special', 'absence', 'adjustment', 'left_early', 'late', 'other'])],
-            'excused'      => ['required', Rule::in(['excused', 'unexcused'])],
+            'kind'         => ['required', Rule::in(LeaveKind::values())],
+            'excused'      => ['required', Rule::in(LeaveExcused::managedValues())],
             'special_type' => ['nullable', 'string', 'max:100'],
             'time_start'   => ['nullable', 'date_format:H:i', 'required_with:time_end'],
             'time_end'     => ['nullable', 'date_format:H:i', 'required_with:time_start'],
             'handle_type'  => ['nullable', 'string'],
-            'status'       => ['required', Rule::in(['approved', 'pending', 'rejected', 'draft', 'cancelled', 'archived'])],
+            'status'       => ['required', Rule::in(LeaveStatus::values())],
         ];
     }
 

--- a/app/Http/Requests/Post/PostSendRequest.php
+++ b/app/Http/Requests/Post/PostSendRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\Post;
 
+use App\Enums\PostType;
 use App\Models\Post;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PostSendRequest extends FormRequest
 {
@@ -15,7 +17,7 @@ class PostSendRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'type'          => ['required', 'string', 'in:announcement,inquiry,dm,notice_urgent,maintenance'],
+            'type'          => ['required', 'string', Rule::in(PostType::sendValues())],
             'title'         => ['nullable', 'string', 'max:255'],
             'body'          => ['required', 'string'],
             'recipients'    => ['required', 'array', 'min:1'],

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -41,16 +41,9 @@ class Event extends Model
 
     public function getTypeLabelAttribute(): string
     {
-        $map = [
-            'regular_time'         => 'RT',
-            'overtime'             => 'OT',
-            'schedule_change'      => 'SC',
-            'special'              => 'SP',
-            'rostered_working_day' => 'RWD',
-            'none_required'        => 'NS',
-        ];
         $key = (string) ($this->attributes['type'] ?? '');
-        return $map[$key] ?? strtoupper($key ?: '');
+
+        return ShiftType::tryFrom($key)?->short() ?? strtoupper($key ?: '');
     }
 
     protected $appends = ['total_duration']; //API/Bladeで見える

--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Carbon\Carbon;
@@ -45,7 +47,7 @@ class Leave extends Model
 
     public function scopeApproved(Builder $q): Builder
     {
-        return $q->where('status', 'approved');
+        return $q->where('status', LeaveStatus::Approved->value);
     }
 
     public function scopeBetween(Builder $q, Carbon $start, Carbon $end): Builder
@@ -73,17 +75,7 @@ class Leave extends Model
 
     public function displayTitle(): string //表示タイトルは再利用のためモデルに置くのが推奨される
     {
-        return match ($this->kind) {
-            'paid'    => 'ALP',
-            'special' => $this->special_type ? "Special Leave（{$this->special_type}）" : 'Special Leave',
-            'absence' => 'Absence',
-            'late'    => 'Late',
-            'left_early' => 'Left Early',
-            'adjustment' => 'Adjustment',
-            'absence_to_paid' => 'ALP',
-            'other'   => $this->special_type ? "{$this->special_type}" : 'Other',
-            default   => 'Absence',
-        };
+        return LeaveKind::tryFrom((string) $this->kind)?->calendarTitle($this->special_type) ?? 'Absence';
     }
 
     public function approvalRequest(): MorphOne

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\Gender;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -122,12 +123,7 @@ class User extends Authenticatable
 
     public function getGenderLabelAttribute(): string
     {
-        return match ($this->gender) {
-            'male' => '男性',
-            'female' => '女性',
-            'other' => 'その他',
-            default => '未選択',
-        };
+        return Gender::tryFrom((string) $this->gender)?->label() ?? Gender::Unknown->label();
     }
 
     public function isAdmin(): bool

--- a/app/Services/Approval/ApprovalService.php
+++ b/app/Services/Approval/ApprovalService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Approval;
 
+use App\Enums\LeaveStatus;
 use App\Models\ApprovalRequest;
 use App\Models\Leave;
 use App\Services\LeaveBalanceService;
@@ -28,7 +29,9 @@ class ApprovalService
                 'comment'  => $comment,
             ]);
             $approvalRequest->update(['current_state' => 'approved']);
-            $approvable->update(['status' => 'approved']);
+            $approvable->update([
+                'status' => $approvable instanceof Leave ? LeaveStatus::Approved->value : 'approved',
+            ]);
 
             if (method_exists($approvable, 'applyDomainEffect')) {
                 $approvable->applyDomainEffect();
@@ -58,7 +61,9 @@ class ApprovalService
                 'comment'  => $comment,
             ]);
             $approvalRequest->update(['current_state' => 'rejected']);
-            $approvalRequest->approvable->update(['status' => 'rejected']);
+            $approvalRequest->approvable->update([
+                'status' => $approvable instanceof Leave ? LeaveStatus::Rejected->value : 'rejected',
+            ]);
         });
     }
 
@@ -78,7 +83,7 @@ class ApprovalService
 
             $req->actions()->create(['actor_id' => $actorId, 'action' => 'approved', 'comment' => $comment]);
             $req->update(['current_state' => 'approved']);
-            $leave->update(['status' => 'approved', 'approved_by' => $actorId]);
+            $leave->update(['status' => LeaveStatus::Approved->value, 'approved_by' => $actorId]);
             $this->leaveBalanceService->consume($leave);
         }
     }
@@ -99,7 +104,7 @@ class ApprovalService
 
             $req->actions()->create(['actor_id' => $actorId, 'action' => 'rejected', 'comment' => $comment]);
             $req->update(['current_state' => 'rejected']);
-            $leave->update(['status' => 'rejected']);
+            $leave->update(['status' => LeaveStatus::Rejected->value]);
         }
     }
 }

--- a/app/Services/Calendar/LeaveSnapshotService.php
+++ b/app/Services/Calendar/LeaveSnapshotService.php
@@ -2,6 +2,9 @@
 // app/Services/Calendar/LeaveSnapshotService.php
 namespace App\Services\Calendar;
 
+use App\Enums\EventStatus;
+use App\Enums\LeaveStatus;
+use App\Enums\ShiftType;
 use App\Models\Event;
 use App\Models\EventDetail;
 use App\Models\Leave;
@@ -22,7 +25,7 @@ class LeaveSnapshotService
             $this->deleteSnapshotsForLeave($leave);
 
             // Approved, Pendingの場合生成（ポリシーは要件に合わせて）
-            if (!in_array($leave->status, ['approved', 'pending'], true)) return;
+            if (!in_array($leave->status, LeaveStatus::snapshotValues(), true)) return;
 
             // 期間生成（end_date が null の場合は単日）
             $start = Carbon::parse($leave->start_date);
@@ -109,13 +112,13 @@ class LeaveSnapshotService
                 'school_name'             => $line->school_name,
                 'start_time'              => substr($line->start_time, 0, 8),
                 'end_time'                => substr($line->end_time,   0, 8),
-                'type'                    => 'regular_time',
+                'type'                    => ShiftType::RegularTime->value,
                 'assigned_user_id'        => null,
                 'original_user_id'        => $userId,
                 'Leave_type'              => (string) $leave->kind,
                 'source_schedule_line_id' => $line->id,
                 'source_leave_id'         => $leave->id,
-                'status'                  => 'pending',
+                'status'                  => EventStatus::Pending->value,
                 'notes'                   => null,
                 'district_id'             => $districtId,
                 'department_id'           => $departmentId,

--- a/app/Services/Calendar/Providers/AdjustingProvider.php
+++ b/app/Services/Calendar/Providers/AdjustingProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\RestPatternAdjustmentKind;
 use App\Models\RestPatternAdjustment;
 use App\Models\User;
 use App\Models\UserRestPattern;
@@ -33,26 +34,26 @@ class AdjustingProvider implements CalendarEventProvider
                 /** @var \App\Models\RestPatternAdjustment|null $adj */
                 $adj = data_get($adjs, "{$assign->rest_pattern_id}.{$ymd}.0");
                 if ($adj) {
-                    if ($adj->kind === 'add_off') {
+                    if ($adj->kind === RestPatternAdjustmentKind::AddOff->value) {
                         // 調整休日（所定追加）
                         $events[] = new CandidateEvent([
-                            'title' => $adj->title ?: 'ORD',
+                            'title' => $adj->title ?: RestPatternAdjustmentKind::AddOff->code(),
                             'start' => $ymd,
                             'allDay' => true,
                             'classNames' => ['fc-off-prescribed'],
-                            'extendedProps' => ['category' => '1_off', 'code' => 'ORD'],
+                            'extendedProps' => ['category' => '1_off', 'code' => RestPatternAdjustmentKind::AddOff->code()],
                             'level' => 2,
                             'type' => EventType::BACKGROUND,
                             'planGroup' => PlanGroup::REGULAR_PLAN,
                         ]);
-                    } elseif ($adj->kind === 'work_instead') {
+                    } elseif ($adj->kind === RestPatternAdjustmentKind::WorkInstead->value) {
                         // 調整出勤（黄・ON）
                         $events[] = new CandidateEvent([
                             'title' => $adj->title ?: '調整出勤（RWD）',
                             'start' => $ymd,
                             'allDay' => true,
                             'classNames' => ['fc-rwd'],
-                            'extendedProps' => ['category' => '1_off', 'code' => 'RWD'],
+                            'extendedProps' => ['category' => '1_off', 'code' => RestPatternAdjustmentKind::WorkInstead->code()],
                             'level' => 2,
                             'type' => EventType::ON,
                             'planGroup' => PlanGroup::REGULAR_PLAN,

--- a/app/Services/Calendar/Providers/AllEventProvider.php
+++ b/app/Services/Calendar/Providers/AllEventProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use App\Models\Event;
 use App\Models\User;
 use App\Services\Calendar\{CandidateEvent, EventType, PlanGroup};
@@ -89,16 +91,16 @@ class AllEventProvider implements CalendarEventProvider
 
             // 追加：緑にしてよい “資格あり” 条件
             $qualifiedGreen = (
-                ($e->type === 'none_required') ||
-                (!empty($e->assigned_user_id) && $e->type !== 'none_required')
+                ($e->type === ShiftType::NoneRequired->value) ||
+                (!empty($e->assigned_user_id) && $e->type !== ShiftType::NoneRequired->value)
             );
-            if (in_array($e->status, ['fixed', 'filled'], true) && $qualifiedGreen) {
+            if (in_array($e->status, EventStatus::fixedValues(), true) && $qualifiedGreen) {
                 $classNames[] = 'is-qualified'; // 緑にして良いときだけ付与
             }
 
             // 既存の「pending/in_process + assignedあり → 黄色枠」
             if (
-                in_array($e->status, ['pending', 'in_process'], true) &&
+                in_array($e->status, EventStatus::assignedValues(), true) &&
                 !empty($e->assigned_user_id)
             ) {
                 $classNames[] = 'status-assigned'; // 黄色枠専用クラス
@@ -167,23 +169,11 @@ class AllEventProvider implements CalendarEventProvider
         if ($schoolName)          return $schoolName;
         if ($time)                return $time;
         if ($title)               return $title;
-        return match ($type) {
-            'overtime'        => '残業',
-            'regular_time'    => '通常勤務',
-            'special'         => '特別イベント',
-            'schedule_change' => '時間変更',
-            default           => 'イベント',
-        };
+        return ShiftType::tryFrom((string) $type)?->calendarLabel() ?? 'イベント';
     }
 
     private function sortOrderForType(string $type): int
     {
-        return match ($type) {
-            'overtime'        => 10,
-            'regular_time'    => 20,
-            'special'         => 30,
-            'schedule_change' => 40,
-            default           => 50,
-        };
+        return ShiftType::tryFrom($type)?->sortOrder() ?? 50;
     }
 }

--- a/app/Services/Calendar/Providers/AllLeaveProvider.php
+++ b/app/Services/Calendar/Providers/AllLeaveProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use App\Models\Leave;
 use App\Models\User;
 use App\Models\Event;
@@ -78,7 +81,7 @@ class AllLeaveProvider
                 // CSS クラス（既存 LeaveProvider と揃える）
                 $classes = ['fc-leave', "fc-leave-{$leave->kind}"];
 
-                if ($leave->excused !== 'unknown') {
+                if ($leave->excused !== LeaveExcused::Unknown->value) {
                     $classes[] = "fc-leave-{$leave->excused}";
                 }
 
@@ -92,13 +95,13 @@ class AllLeaveProvider
                  *  1) handle_type = null && status = pending → red
                  *  2) handle_type != null && status = pending → yellow
                  */
-                if ($leave->kind === 'absence') {
+                if ($leave->kind === LeaveKind::Absence->value) {
                     $handled = !empty($leave->handle_type);
 
-                    if (!$handled && $leave->status === 'pending') {
+                    if (!$handled && $leave->status === LeaveStatus::Pending->value) {
                         // 1) 未ハンドル & pending
                         $classes[] = 'absence-unhandled-pending';
-                    } elseif ($handled && $leave->status === 'pending') {
+                    } elseif ($handled && $leave->status === LeaveStatus::Pending->value) {
                         // 2) ハンドル済み & pending
                         $classes[] = 'absence-handled-pending';
                     }

--- a/app/Services/Calendar/Providers/EventProvider.php
+++ b/app/Services/Calendar/Providers/EventProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
 use App\Models\Event;
 use App\Models\User;
 use App\Services\Calendar\{CandidateEvent, EventType, PlanGroup};
@@ -23,7 +25,7 @@ class EventProvider implements CalendarEventProvider
             ->when($districtId,   fn($q) => $q->where('district_id',   $districtId))
             ->when($departmentId, fn($q) => $q->where('department_id', $departmentId))
             // status: fixed/filled のみ対象（cancelled 等はここで除外される）
-            ->whereIn('status', ['fixed', 'filled'])
+            ->whereIn('status', EventStatus::fixedValues())
             // sub 条件を撤去
             ->whereBetween('event_date', [$start->toDateString(), $end->toDateString()])
             ->with(['details.lesson'])
@@ -121,13 +123,7 @@ class EventProvider implements CalendarEventProvider
 
         if ($title) return $title;
 
-        return match ($type) {
-            'overtime'       => '残業',
-            'regular_time'   => '通常勤務',
-            'special'        => '特別イベント',
-            'schedule_change' => '時間変更',
-            default          => 'イベント',
-        };
+        return ShiftType::tryFrom((string) $type)?->calendarLabel() ?? 'イベント';
     }
 
     /**
@@ -136,12 +132,6 @@ class EventProvider implements CalendarEventProvider
      */
     private function sortOrderForType(string $type): int
     {
-        return match ($type) {
-            'overtime'       => 10,
-            'regular_time'   => 20,
-            'special'        => 30,
-            'schedule_change' => 40,
-            default          => 50,
-        };
+        return ShiftType::tryFrom($type)?->sortOrder() ?? 50;
     }
 }

--- a/app/Services/Calendar/Providers/LeaveProvider.php
+++ b/app/Services/Calendar/Providers/LeaveProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\LeaveExcused;
 use App\Models\Leave;
 use App\Models\User;
 use App\Services\Calendar\EventType;
@@ -48,7 +49,7 @@ class LeaveProvider
                     : $this->mergeDateAndTime($date, $leave->time_end)->toIso8601String();
 
                 $classes = ['fc-leave', "fc-leave-{$leave->kind}"];
-                if ($leave->excused !== 'unknown') $classes[] = "fc-leave-{$leave->excused}";
+                if ($leave->excused !== LeaveExcused::Unknown->value) $classes[] = "fc-leave-{$leave->excused}";
 
                 $events->push([
                     'title'   => $leave->displayTitle(),

--- a/app/Services/Calendar/Providers/OffDayProvider.php
+++ b/app/Services/Calendar/Providers/OffDayProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\RestPatternRuleKind;
 use App\Models\User;
 use App\Models\UserRestPattern;
 use App\Services\Calendar\{CandidateEvent, EventType, PlanGroup};
@@ -25,10 +26,11 @@ class OffDayProvider implements CalendarEventProvider
             if ($assign && $assign->pattern) {
                 $w = (int)$cur->dayOfWeek;
                 $rule = $assign->pattern->rules->firstWhere('weekday', $w);
-                if ($rule && $rule->kind !== 'work') {
-                    $isStat = $rule->kind === 'statutory_off';
+                $ruleKind = $rule ? RestPatternRuleKind::tryFrom($rule->kind) : null;
+                if ($ruleKind && $ruleKind !== RestPatternRuleKind::Work) {
+                    $isStat = $ruleKind === RestPatternRuleKind::StatutoryOff;
                     $events[] = new CandidateEvent([
-                        'title'  => $isStat ? 'LRD' : 'ORD',
+                        'title'  => $ruleKind->title(),
                         'start'  => $ymd,
                         'allDay' => true,
                         'classNames' => [$isStat ? 'fc-off-statutory' : 'fc-off-prescribed'],

--- a/app/Services/Calendar/Providers/SubCountProvider.php
+++ b/app/Services/Calendar/Providers/SubCountProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Calendar\Providers;
 
+use App\Enums\LeaveStatus;
+use App\Enums\RestPatternAdjustmentKind;
 use App\Models\User;
 use App\Services\CurrentScopeService;
 use Carbon\Carbon;
@@ -34,7 +36,7 @@ class SubCountProvider implements CalendarEventProvider
         $leaveRows = DB::table('leaves')
             ->select('user_id', 'start_date', 'end_date', 'time_start', 'time_end', 'status')
             ->whereIn('user_id', $targetUserIds)
-            ->whereIn('status', ['approved', 'pending'])
+            ->whereIn('status', LeaveStatus::snapshotValues())
             ->whereDate('start_date', '<=', $endDate)
             ->where(function ($q) use ($startDate) {
                 $q->whereNull('end_date')->orWhereDate('end_date', '>=', $startDate);
@@ -58,7 +60,7 @@ class SubCountProvider implements CalendarEventProvider
         $adjRows = DB::table('rest_pattern_adjustments as rpa')
             ->join('user_rest_patterns as urp', 'urp.rest_pattern_id', '=', 'rpa.rest_pattern_id')
             ->whereBetween('rpa.date', [$startDate, $endDate])
-            ->where('rpa.kind', 'work_instead')
+            ->where('rpa.kind', RestPatternAdjustmentKind::WorkInstead->value)
             ->where('rpa.is_active', true)
             ->whereColumn('urp.start_date', '<=', 'rpa.date')
             ->where(function ($q) {

--- a/app/Services/LeaveApply/LeaveApplicationService.php
+++ b/app/Services/LeaveApply/LeaveApplicationService.php
@@ -2,6 +2,9 @@
 
 namespace App\Services\LeaveApply;
 
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
 use App\Models\Leave;
 use App\Models\User;
 use App\Models\ApprovalRequest;
@@ -21,7 +24,7 @@ class LeaveApplicationService
         array $dates,
         string $reason,
         int $requestedByUserId,
-        string $type = 'paid',
+        string $type = LeaveKind::Paid->value,
         ?string $specialType = null,
         ?array $attachmentMeta = null
     ): array {
@@ -38,7 +41,7 @@ class LeaveApplicationService
 
         $batchId = (string) Str::uuid();
 
-        $result = $type === 'special'
+        $result = $type === LeaveKind::Special->value
             ? $this->applySpecial($userId, $dates, $reason, $requestedByUserId, $specialType, $attachmentMeta, $batchId)
             : $this->applyPaid($userId, $dates, $reason, $requestedByUserId, $batchId);
 
@@ -74,8 +77,8 @@ class LeaveApplicationService
             foreach ($dates as $ymd) {
                 $already = Leave::query()
                     ->where('user_id', $userId)
-                    ->where('kind', 'paid')
-                    ->whereIn('status', ['pending', 'approved'])
+                    ->where('kind', LeaveKind::Paid->value)
+                    ->whereIn('status', [LeaveStatus::Pending->value, LeaveStatus::Approved->value])
                     ->whereDate('start_date', $ymd)
                     ->exists();
 
@@ -89,10 +92,10 @@ class LeaveApplicationService
                     'user_id'       => $userId,
                     'start_date'    => $ymd,
                     'end_date'      => null,
-                    'kind'          => 'paid',
-                    'excused'       => 'excused',
+                    'kind'          => LeaveKind::Paid->value,
+                    'excused'       => LeaveExcused::Excused->value,
                     'reason'        => $reason,
-                    'status'        => 'pending',
+                    'status'        => LeaveStatus::Pending->value,
                     'special_type'  => null,
                     'district_id'   => $user?->district_id,
                     'department_id' => $user?->department_id,
@@ -107,7 +110,7 @@ class LeaveApplicationService
                         'leave_id'     => $leave->id,
                         'user_id'      => $userId,
                         'date'         => $ymd,
-                        'kind'         => 'paid',
+                        'kind'         => LeaveKind::Paid->value,
                         'reason'       => $reason,
                         'special_type' => null,
                     ],
@@ -145,8 +148,8 @@ class LeaveApplicationService
 
             $already = Leave::query()
                 ->where('user_id', $userId)
-                ->where('kind', 'special')
-                ->whereIn('status', ['pending', 'approved'])
+                ->where('kind', LeaveKind::Special->value)
+                ->whereIn('status', [LeaveStatus::Pending->value, LeaveStatus::Approved->value])
                 ->where(function ($q) use ($start, $end) {
                     $q->whereBetween('start_date', [$start, $end])
                       ->orWhereBetween('end_date', [$start, $end])
@@ -166,10 +169,10 @@ class LeaveApplicationService
                 'user_id'       => $userId,
                 'start_date'    => $start,
                 'end_date'      => $end,
-                'kind'          => 'special',
-                'excused'       => 'excused',
+                'kind'          => LeaveKind::Special->value,
+                'excused'       => LeaveExcused::Excused->value,
                 'reason'        => $reason,
-                'status'        => 'pending',
+                'status'        => LeaveStatus::Pending->value,
                 'special_type'  => $specialType ?: null,
                 'district_id'   => $user?->district_id,
                 'department_id' => $user?->department_id,
@@ -190,7 +193,7 @@ class LeaveApplicationService
                     'user_id'      => $userId,
                     'date_from'    => $start,
                     'date_to'      => $end,
-                    'kind'         => 'special',
+                    'kind'         => LeaveKind::Special->value,
                     'reason'       => $reason,
                     'special_type' => $specialType ?: null,
                 ],

--- a/app/Services/LeaveBalanceService.php
+++ b/app/Services/LeaveBalanceService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\LeaveCreditTransactionType;
 use App\Models\Leave;
 use App\Models\LeaveCredit;
 use App\Models\Holiday;
@@ -41,7 +42,7 @@ class LeaveBalanceService
             $credit->save();
 
             $credit->transactions()->create([
-                'type'   => 'consume',
+                'type'   => LeaveCreditTransactionType::Consume->value,
                 'days'   => $days,
                 'reason' => "leave#{$leave->id}",
             ]);
@@ -67,7 +68,7 @@ class LeaveBalanceService
             $credit->save();
 
             $credit->transactions()->create([
-                'type'   => 'revert',
+                'type'   => LeaveCreditTransactionType::Revert->value,
                 'days'   => $days,
                 'reason' => "leave#{$leave->id} cancelled",
             ]);
@@ -85,7 +86,7 @@ class LeaveBalanceService
             );
             $credit->increment('granted_days', $days);
             $credit->transactions()->create([
-                'type' => 'grant',
+                'type' => LeaveCreditTransactionType::Grant->value,
                 'days' => $days,
                 'reason' => $reason,
             ]);

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\Gender;
 
 return new class extends Migration
 {
@@ -23,7 +24,7 @@ return new class extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
-            $table->enum('gender', ['male', 'female', 'other', 'unknown'])->default('unknown');
+            $table->string('gender', 20)->default(Gender::Unknown->value);
             $table->string('profile_picture')->nullable();
             $table->text('note')->nullable();
             $table->softDeletes();

--- a/database/migrations/2025_08_26_001453_create_rest_patterns_table.php
+++ b/database/migrations/2025_08_26_001453_create_rest_patterns_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\RestPatternRuleKind;
 
 return new class extends Migration
 {
@@ -22,7 +23,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('rest_pattern_id')->constrained()->cascadeOnDelete();
             $table->tinyInteger('weekday'); // 0(日)〜6(土)
-            $table->enum('kind', ['work', 'prescribed_off', 'statutory_off']);
+            $table->string('kind', 32)->default(RestPatternRuleKind::Work->value);
             $table->timestamps();
             $table->unique(['rest_pattern_id', 'weekday']);
         });

--- a/database/migrations/2025_08_27_003223_create_rest_pattern_adjustments_table.php
+++ b/database/migrations/2025_08_27_003223_create_rest_pattern_adjustments_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\RestPatternAdjustmentKind;
 
 return new class extends Migration
 {
@@ -15,7 +16,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('rest_pattern_id')->constrained()->cascadeOnDelete();
             $table->date('date'); // 調整対象日（年度を跨いでもOK）
-            $table->enum('kind', ['add_off', 'work_instead']); // add_off=ORD, work_instead=RWD
+            $table->string('kind', 32)->default(RestPatternAdjustmentKind::AddOff->value); // add_off=ORD, work_instead=RWD
             $table->string('code')->default('');  // 'ORD' / 'RWD' など
             $table->string('title')->nullable();  // 表示名を上書きしたい場合
             $table->boolean('is_active')->default(true);

--- a/database/migrations/2025_09_02_102158_create_leaves_table.php
+++ b/database/migrations/2025_09_02_102158_create_leaves_table.php
@@ -3,6 +3,8 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveStatus;
 
 return new class extends Migration
 {
@@ -24,10 +26,10 @@ return new class extends Migration
 
             // 休暇の種別
             // paid=有給, absense_to_paid=欠席から有給へ, special=特別休暇(結婚/忌引など), absence=欠席, adjustment=調整, left_early=早退, late=遅刻, other=その他 
-            $table->enum('kind', ['paid', 'absence_to_paid', 'special', 'absence', 'adjustment', 'left_early', 'late', 'other'])->index();
+            $table->string('kind', 32)->index();
 
             // 会社としての扱い（免除/非免除/不明）
-            $table->enum('excused', ['excused', 'unexcused'])->default('unexcused')->index();
+            $table->string('excused', 32)->default(LeaveExcused::Unexcused->value)->index();
 
             // Special、Otherの種類（例: wedding, bereavement, sick child leave 等）
             $table->string('special_type', 100)->nullable();
@@ -40,14 +42,7 @@ return new class extends Migration
             $table->text('handle_type')->nullable();
 
             // ステータス管理
-            $table->enum('status', [
-                'draft',        // 下書き：本人がまだ送信していない
-                'pending',      // 申請済み（承認待ち）
-                'approved',     // 承認済み（確定）
-                'rejected',     // 却下
-                'cancelled',    // 申請者キャンセル
-                'archived',     // 過去データ化（自動クローズ）
-            ])->default('pending')->index();
+            $table->string('status', 32)->default(LeaveStatus::Pending->value)->index();
 
             $table->foreignId('approved_by')->nullable()->constrained('users')->nullOnDelete();
 

--- a/database/migrations/2025_09_03_083736_create_events_table.php
+++ b/database/migrations/2025_09_03_083736_create_events_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\EventStatus;
 
 return new class extends Migration
 {
@@ -23,8 +24,8 @@ return new class extends Migration
             $t->string('total_duration', 5)->nullable(); // "H:MM" 最大 "23:59" を想定
             $t->text('Lesson')->nullable();
             $t->foreignId('assigned_user_id')->nullable()->constrained('users')->nullOnDelete();
-            $t->enum('status', ['pending', 'fixed', 'filled', 'in_process'])->default('pending')->index();
-            $t->enum('type', ['regular_time', 'none_required', 'overtime', 'schedule_change', 'rostered_working_day', 'special'])->index();
+            $t->string('status', 32)->default(EventStatus::Pending->value)->index();
+            $t->string('type', 64)->index();
             $t->text('notes')->nullable();
             // 欠席時コピー元（正規コマ追跡用）
             $t->foreignId('source_schedule_line_id')->nullable()->constrained('schedule_lines')->nullOnDelete();

--- a/database/migrations/2025_09_05_220435_create_leave_credits_table.php
+++ b/database/migrations/2025_09_05_220435_create_leave_credits_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\LeaveCreditTransactionType;
 
 return new class extends Migration
 {
@@ -25,7 +26,7 @@ return new class extends Migration
         Schema::create('leave_credit_transactions', function (Blueprint $t) {
             $t->id();
             $t->foreignId('leave_credit_id')->constrained()->cascadeOnDelete();
-            $t->enum('type', ['grant', 'consume', 'revert', 'adjust'])->index();
+            $t->string('type', 32)->default(LeaveCreditTransactionType::Grant->value)->index();
             $t->decimal('days', 5, 2);       // 0.5 / 0.25 などOK
             $t->string('reason')->nullable(); // 'leave#123', 'annual grant', etc
             $t->timestamps();

--- a/database/migrations/2025_09_17_144321_create_commuting_expenses_table.php
+++ b/database/migrations/2025_09_17_144321_create_commuting_expenses_table.php
@@ -27,7 +27,7 @@ return new class extends Migration
             $t->unsignedSmallInteger('year');
             $t->unsignedTinyInteger('month');
 
-            $t->enum('status', ExpenseReportStatus::values())
+            $t->string('status', 32)
                 ->default(ExpenseReportStatus::DRAFT->value)
                 ->index();
 
@@ -79,10 +79,10 @@ return new class extends Migration
 
             $t->unsignedInteger('cost')->default(0);
 
-            $t->enum('trip_type', ExpenseTripType::values())
+            $t->string('trip_type', 32)
                 ->default(ExpenseTripType::ROUND_TRIP->value);
 
-            $t->enum('category', ExpenseCategory::values())
+            $t->string('category', 32)
                 ->default(ExpenseCategory::REGULAR->value);
 
             $t->foreignId('commuter_pass_id')

--- a/database/migrations/2025_10_31_230559_create_route_declarations_table.php
+++ b/database/migrations/2025_10_31_230559_create_route_declarations_table.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use App\Enums\ExpenseTripType;
 
 return new class extends Migration {
     public function up(): void
@@ -42,7 +43,7 @@ return new class extends Migration {
             $t->string('to_station');      // to
 
             // round/oneway
-            $t->enum('trip_type', ['round_trip', 'one_way'])->default('round_trip');
+            $t->string('trip_type', 32)->default(ExpenseTripType::ROUND_TRIP->value);
 
             // 金額（JPY想定）: 税込片道/往復の合計を記録
             $t->unsignedInteger('amount')->default(0);

--- a/database/migrations/2026_05_29_000001_drop_postgres_enum_check_constraints.php
+++ b/database/migrations/2026_05_29_000001_drop_postgres_enum_check_constraints.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Enums\EventStatus;
+use App\Enums\ExpenseCategory;
+use App\Enums\ExpenseReportStatus;
+use App\Enums\ExpenseTripType;
+use App\Enums\Gender;
+use App\Enums\LeaveCreditTransactionType;
+use App\Enums\LeaveExcused;
+use App\Enums\LeaveKind;
+use App\Enums\LeaveStatus;
+use App\Enums\RestPatternAdjustmentKind;
+use App\Enums\RestPatternRuleKind;
+use App\Enums\ShiftType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private array $columns = [
+        'users' => [
+            'gender' => Gender::class,
+        ],
+        'rest_pattern_rules' => [
+            'kind' => RestPatternRuleKind::class,
+        ],
+        'rest_pattern_adjustments' => [
+            'kind' => RestPatternAdjustmentKind::class,
+        ],
+        'leaves' => [
+            'kind' => LeaveKind::class,
+            'excused' => LeaveExcused::class,
+            'status' => LeaveStatus::class,
+        ],
+        'events' => [
+            'status' => EventStatus::class,
+            'type' => ShiftType::class,
+        ],
+        'leave_credit_transactions' => [
+            'type' => LeaveCreditTransactionType::class,
+        ],
+        'expense_reports' => [
+            'status' => ExpenseReportStatus::class,
+        ],
+        'expenses' => [
+            'trip_type' => ExpenseTripType::class,
+            'category' => ExpenseCategory::class,
+        ],
+        'route_details' => [
+            'trip_type' => ExpenseTripType::class,
+        ],
+    ];
+
+    public function up(): void
+    {
+        if (DB::connection()->getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        foreach ($this->columns as $table => $columns) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            foreach (array_keys($columns) as $column) {
+                if (!Schema::hasColumn($table, $column)) {
+                    continue;
+                }
+
+                foreach ($this->checkConstraintsForColumn($table, $column) as $constraint) {
+                    DB::statement(sprintf(
+                        'alter table %s drop constraint %s',
+                        $this->quoteIdentifier($table),
+                        $this->quoteIdentifier($constraint->conname)
+                    ));
+                }
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if (DB::connection()->getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        foreach ($this->columns as $table => $columns) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            foreach ($columns as $column => $enumClass) {
+                if (!Schema::hasColumn($table, $column)) {
+                    continue;
+                }
+
+                $constraint = "{$table}_{$column}_allowed_check";
+                if ($this->constraintExists($table, $constraint)) {
+                    continue;
+                }
+
+                $values = implode(', ', array_map(
+                    fn (string $value) => DB::getPdo()->quote($value),
+                    $enumClass::values()
+                ));
+
+                DB::statement(sprintf(
+                    'alter table %s add constraint %s check (%s in (%s))',
+                    $this->quoteIdentifier($table),
+                    $this->quoteIdentifier($constraint),
+                    $this->quoteIdentifier($column),
+                    $values
+                ));
+            }
+        }
+    }
+
+    private function checkConstraintsForColumn(string $table, string $column): array
+    {
+        return DB::select(
+            <<<'SQL'
+select distinct con.conname
+from pg_constraint con
+join pg_class rel on rel.oid = con.conrelid
+join pg_namespace nsp on nsp.oid = rel.relnamespace
+join unnest(con.conkey) as cols(attnum) on true
+join pg_attribute att on att.attrelid = rel.oid and att.attnum = cols.attnum
+where con.contype = 'c'
+  and nsp.nspname = current_schema()
+  and rel.relname = ?
+  and att.attname = ?
+SQL,
+            [$table, $column]
+        );
+    }
+
+    private function constraintExists(string $table, string $constraint): bool
+    {
+        return (bool) DB::selectOne(
+            <<<'SQL'
+select 1
+from pg_constraint con
+join pg_class rel on rel.oid = con.conrelid
+join pg_namespace nsp on nsp.oid = rel.relnamespace
+where nsp.nspname = current_schema()
+  and rel.relname = ?
+  and con.conname = ?
+limit 1
+SQL,
+            [$table, $constraint]
+        );
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        return '"' . str_replace('"', '""', $identifier) . '"';
+    }
+};


### PR DESCRIPTION
## 実装概要

DB 定義上の `enum()` を `string()` に変更し、許可値・表示ラベル・補助メソッドを `app/Enums` に集約しました。

これにより、PostgreSQL 側の enum / CHECK 制約に依存せず、Laravel 側の Enum と Request validation で値を一元管理する構成に整理しています。

あわせて、Controller / Model / Service / Provider に散っていた固定文字列やラベル定義を Enum 参照へ移行しました。
Provider の検索条件も Enum ベースにしたため、Enum の値を変更した場合でも関連するクエリ条件が追従しやすくなっています。

---

## 主な変更内容

* DB migration の `$table->enum()` を `$table->string()` に変更
* PostgreSQL の既存 enum 相当 CHECK 制約を削除する migration を追加
* `app/Enums/*.php` に許可値・ラベル・用途別 values を集約
* Request validation を `Rule::in(Xxx::values())` 形式へ変更
* Controller で enum 値を直接扱う箇所のみ `use App\Enums\Xxx;` を追加
* Model / Controller / Service / Provider に散っていたラベル・固定値・検索条件を Enum 参照へ移行
* Leave / Event / Expense / Calendar / User / Post 関連の enum 値管理を整理

---

## 追加・修正ファイルの目的

### `app/Enums/Concerns/HasValues.php`

各 Enum で共通して使う `values()` 取得処理を trait 化しました。
Request validation などで同じ実装を繰り返さないためです。

---

### `app/Enums/*.php`

DB や画面で使う選択値、表示ラベル、用途別の許可値を集約しました。

例：

* `LeaveKind`
* `LeaveStatus`
* `LeaveExcused`
* `EventStatus`
* `Gender`
* `RestPatternRuleKind`
* `RestPatternAdjustmentKind`

---

### 既存 Enum

以下の既存 Enum について、`HasValues` 対応や補助メソッドの追加を行いました。

* `DayOfWeek`
* `ExpenseCategory`
* `ExpenseReportStatus`
* `ExpenseTripType`
* `PostType`
* `ShiftType`

---

### `database/migrations/*`

既存の `$table->enum()` を `$table->string()` に変更しました。

PostgreSQL では Laravel の enum が CHECK 制約として扱われるため、将来の値追加・変更時に migration が重くなりやすい問題を避ける目的です。

---

### `database/migrations/2026_05_29_000001_drop_postgres_enum_check_constraints.php`

既存 DB に残っている enum 相当の CHECK 制約を削除するための migration です。

非負数チェックなど、enum とは関係ない制約は対象外にしています。

---

### `app/Http/Requests/*`

Request validation の固定配列を Enum 参照へ変更しました。

例：

```php
Rule::in(LeaveKind::values())
Rule::in(EventStatus::values())
```

入力値の制御は基本的に Request 側で担保します。

---

### `app/Http/Controllers/*`

画面選択肢、初期値、検索条件など、Controller 内で enum 値を直接使う箇所のみ Enum を import しました。

Request validation だけで完結している箇所では、Controller 側に import は追加していません。

---

### `app/Models/Event.php`, `app/Models/Leave.php`, `app/Models/User.php`

Model にあったラベル変換や固定値判定を Enum 側へ移行しました。

Model は状態や属性の扱いに集中し、表示名の定義は Enum に寄せています。

---

### `app/Services/*`, `app/Services/Calendar/Providers/*`

サービス層・Provider 層の固定文字列条件を Enum 参照に変更しました。

特にカレンダー系 Provider の検索条件を Enum 化したことで、値変更時の修正漏れリスクを下げています。

---

## 確認内容

* `enum()` 定義が残っていないことを確認
* PostgreSQL の対象 CHECK 制約が残っていないことを確認
* 新規 migration が実行済みであることを確認
* `php artisan test` 実行済み

```bash
194 passed (511 assertions)
```

---
