### PR TITLE
交通費のパターン機能とそれをベースにした表の自動生成コマンドを追加

### DIFF
--- a/app/Console/Commands/GenerateMonthlyExpensesByPattern.php
+++ b/app/Console/Commands/GenerateMonthlyExpensesByPattern.php
@@ -5,9 +5,12 @@ namespace App\Console\Commands;
 use App\Enums\ExpenseCategory;
 use App\Enums\ExpenseReportStatus;
 use App\Enums\ExpenseTripType;
+use App\Models\CommuterPass;
 use App\Models\EmploymentTerm;
 use App\Models\Expense;
 use App\Models\ExpenseReport;
+use App\Models\User;
+use App\Services\Calendar\CalendarResolver;
 use App\Services\CommutingExpenses\CommutePatternService;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
@@ -19,7 +22,7 @@ class GenerateMonthlyExpensesByPattern extends Command
 
     protected $description = 'Generate monthly expense_reports and expenses using valid commute patterns when available';
 
-    public function handle(CommutePatternService $patterns): int
+    public function handle(CommutePatternService $patterns, CalendarResolver $calendarResolver): int
     {
         $now = now();
         $year = (int) ($this->argument('year') ?? $now->year);
@@ -50,7 +53,7 @@ class GenerateMonthlyExpensesByPattern extends Command
 
         $this->info("Target users: {$users->count()}");
 
-        DB::transaction(function () use ($users, $year, $month, $startOfMonth, $endOfMonth, $daysInMonth, $patterns) {
+        DB::transaction(function () use ($users, $year, $month, $startOfMonth, $endOfMonth, $daysInMonth, $patterns, $calendarResolver) {
             foreach ($users as $user) {
                 $report = ExpenseReport::query()
                     ->where('user_id', $user->id)
@@ -82,12 +85,20 @@ class GenerateMonthlyExpensesByPattern extends Command
                     ->all();
 
                 $activePatterns = $patterns->forPeriod($user, $startOfMonth, $endOfMonth);
+                $workOnMap = $this->buildWorkOnMap($calendarResolver, $user, $startOfMonth, $endOfMonth);
+                $passActiveMap = $this->buildPassActiveMap($user, $startOfMonth, $endOfMonth);
 
                 for ($day = 1; $day <= $daysInMonth; $day++) {
                     $date = (clone $startOfMonth)->day($day);
                     $dateString = $date->toDateString();
 
                     if (in_array($dateString, $existingDates, true)) {
+                        continue;
+                    }
+
+                    if (! ($workOnMap[$dateString] ?? false) || ($passActiveMap[$dateString] ?? false)) {
+                        $this->createBlankExpense($report, $dateString);
+
                         continue;
                     }
 
@@ -123,18 +134,7 @@ class GenerateMonthlyExpensesByPattern extends Command
                         continue;
                     }
 
-                    Expense::create([
-                        'expense_report_id' => $report->id,
-                        'expense_date' => $dateString,
-                        'seq' => 100,
-                        'station_from' => null,
-                        'station_to' => null,
-                        'note' => null,
-                        'cost' => 0,
-                        'trip_type' => ExpenseTripType::ROUND_TRIP->value,
-                        'category' => ExpenseCategory::REGULAR->value,
-                        'commuter_pass_id' => null,
-                    ]);
+                    $this->createBlankExpense($report, $dateString);
                 }
             }
         });
@@ -142,5 +142,72 @@ class GenerateMonthlyExpensesByPattern extends Command
         $this->info('Done.');
 
         return Command::SUCCESS;
+    }
+
+    private function buildWorkOnMap(CalendarResolver $calendarResolver, User $user, Carbon $start, Carbon $end): array
+    {
+        $events = $calendarResolver->build($user, $start, $end);
+        $daily = [];
+
+        foreach ($events as $event) {
+            $dateKey = $event['dateKey'] ?? (isset($event['start'])
+                ? (is_string($event['start']) ? substr($event['start'], 0, 10) : Carbon::parse($event['start'])->toDateString())
+                : null);
+
+            if (! $dateKey) {
+                continue;
+            }
+
+            $daily[$dateKey] ??= ['has_on' => false];
+
+            if (strtolower((string) ($event['display'] ?? '')) === 'on') {
+                $daily[$dateKey]['has_on'] = true;
+            }
+        }
+
+        $workOnMap = [];
+        foreach ($daily as $date => $flags) {
+            $workOnMap[$date] = $flags['has_on'];
+        }
+
+        return $workOnMap;
+    }
+
+    private function buildPassActiveMap(User $user, Carbon $start, Carbon $end): array
+    {
+        $passes = CommuterPass::query()
+            ->where('user_id', $user->id)
+            ->whereDate('date_from', '<=', $end->toDateString())
+            ->whereDate('date_to', '>=', $start->toDateString())
+            ->get(['date_from', 'date_to']);
+
+        $passActiveMap = [];
+
+        foreach ($passes as $pass) {
+            $from = Carbon::parse($pass->date_from)->max($start);
+            $to = Carbon::parse($pass->date_to)->min($end);
+
+            for ($date = $from->copy(); $date->lte($to); $date->addDay()) {
+                $passActiveMap[$date->toDateString()] = true;
+            }
+        }
+
+        return $passActiveMap;
+    }
+
+    private function createBlankExpense(ExpenseReport $report, string $date): void
+    {
+        Expense::create([
+            'expense_report_id' => $report->id,
+            'expense_date' => $date,
+            'seq' => 100,
+            'station_from' => null,
+            'station_to' => null,
+            'note' => null,
+            'cost' => 0,
+            'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+            'category' => ExpenseCategory::REGULAR->value,
+            'commuter_pass_id' => null,
+        ]);
     }
 }

--- a/app/Console/Commands/GenerateMonthlyExpensesByPattern.php
+++ b/app/Console/Commands/GenerateMonthlyExpensesByPattern.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\ExpenseCategory;
+use App\Enums\ExpenseReportStatus;
+use App\Enums\ExpenseTripType;
+use App\Models\EmploymentTerm;
+use App\Models\Expense;
+use App\Models\ExpenseReport;
+use App\Services\CommutingExpenses\CommutePatternService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class GenerateMonthlyExpensesByPattern extends Command
+{
+    protected $signature = 'expenses:generate-monthly-by-pattern {year?} {month?}';
+
+    protected $description = 'Generate monthly expense_reports and expenses using valid commute patterns when available';
+
+    public function handle(CommutePatternService $patterns): int
+    {
+        $now = now();
+        $year = (int) ($this->argument('year') ?? $now->year);
+        $month = (int) ($this->argument('month') ?? $now->month);
+
+        $startOfMonth = Carbon::create($year, $month, 1)->startOfDay();
+        $endOfMonth = (clone $startOfMonth)->endOfMonth();
+
+        $this->info("Generating expense reports by pattern for {$year}-{$month} ...");
+
+        $terms = EmploymentTerm::query()
+            ->where('start_date', '<=', $endOfMonth->toDateString())
+            ->where(function ($q) use ($startOfMonth) {
+                $q->whereNull('end_date')
+                    ->orWhere('end_date', '>=', $startOfMonth->toDateString());
+            })
+            ->with('user')
+            ->get();
+
+        if ($terms->isEmpty()) {
+            $this->info('No active employment terms found for target month.');
+
+            return Command::SUCCESS;
+        }
+
+        $users = $terms->pluck('user')->filter()->unique('id');
+        $daysInMonth = (int) $startOfMonth->daysInMonth;
+
+        $this->info("Target users: {$users->count()}");
+
+        DB::transaction(function () use ($users, $year, $month, $startOfMonth, $endOfMonth, $daysInMonth, $patterns) {
+            foreach ($users as $user) {
+                $report = ExpenseReport::query()
+                    ->where('user_id', $user->id)
+                    ->where('year', $year)
+                    ->where('month', $month)
+                    ->first();
+
+                if (! $report) {
+                    $report = ExpenseReport::create([
+                        'user_id' => $user->id,
+                        'employee_code' => $user->employee_code ?? null,
+                        'employee_family_name' => $user->family_name,
+                        'employee_first_name' => $user->first_name,
+                        'employee_middle_name' => $user->middle_name ?? null,
+                        'year' => $year,
+                        'month' => $month,
+                        'status' => ExpenseReportStatus::DRAFT,
+                        'submitted_at' => null,
+                        'approved_at' => null,
+                        'paid_at' => null,
+                        'total_amount' => 0,
+                    ]);
+                }
+
+                $existingDates = Expense::query()
+                    ->where('expense_report_id', $report->id)
+                    ->pluck('expense_date')
+                    ->map(fn ($d) => Carbon::parse($d)->toDateString())
+                    ->all();
+
+                $activePatterns = $patterns->forPeriod($user, $startOfMonth, $endOfMonth);
+
+                for ($day = 1; $day <= $daysInMonth; $day++) {
+                    $date = (clone $startOfMonth)->day($day);
+                    $dateString = $date->toDateString();
+
+                    if (in_array($dateString, $existingDates, true)) {
+                        continue;
+                    }
+
+                    $pattern = $activePatterns->first(function ($pattern) use ($dateString) {
+                        return $pattern->valid_from->toDateString() <= $dateString
+                            && $pattern->valid_to->toDateString() >= $dateString;
+                    });
+
+                    $dow = $date->format('D');
+                    $legs = $pattern
+                        ? $pattern->legs
+                            ->filter(fn ($leg) => (is_object($leg->dow) ? $leg->dow->value : $leg->dow) === $dow)
+                            ->sortBy([['seq', 'asc'], ['id', 'asc']])
+                            ->values()
+                        : collect();
+
+                    if ($legs->isNotEmpty()) {
+                        foreach ($legs as $index => $leg) {
+                            Expense::create([
+                                'expense_report_id' => $report->id,
+                                'expense_date' => $dateString,
+                                'seq' => $leg->seq ?: (($index + 1) * 100),
+                                'station_from' => $leg->station_from,
+                                'station_to' => $leg->station_to,
+                                'note' => $leg->note,
+                                'cost' => (int) $leg->cost,
+                                'trip_type' => is_object($leg->trip_type) ? $leg->trip_type->value : $leg->trip_type,
+                                'category' => ExpenseCategory::REGULAR->value,
+                                'commuter_pass_id' => null,
+                            ]);
+                        }
+
+                        continue;
+                    }
+
+                    Expense::create([
+                        'expense_report_id' => $report->id,
+                        'expense_date' => $dateString,
+                        'seq' => 100,
+                        'station_from' => null,
+                        'station_to' => null,
+                        'note' => null,
+                        'cost' => 0,
+                        'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+                        'category' => ExpenseCategory::REGULAR->value,
+                        'commuter_pass_id' => null,
+                    ]);
+                }
+            }
+        });
+
+        $this->info('Done.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends ConsoleKernel
         // $schedule->command('inspire')->hourly();
 
         // 毎月 2 日の 0:00 に当月分を自動生成
-        $schedule->command('expenses:generate-monthly')
+        $schedule->command('expenses:generate-monthly-by-pattern')
             ->monthlyOn(2, '0:00')
             ->withoutOverlapping();
 

--- a/app/Http/Controllers/CommutePatternController.php
+++ b/app/Http/Controllers/CommutePatternController.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\DayOfWeek;
+use App\Enums\ExpenseTripType;
+use App\Models\CommutePattern;
+use App\Models\User;
+use App\Services\CommutingExpenses\CommutePatternService;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+
+class CommutePatternController extends Controller
+{
+    public function selfEdit(Request $request, CommutePatternService $patterns)
+    {
+        return $this->renderFor($request->user(), $request, false, $patterns);
+    }
+
+    public function adminEdit(User $user, Request $request, CommutePatternService $patterns)
+    {
+        $viewer = $request->user();
+        if ($viewer->can('viewAny', User::class) && ! $viewer->can('view', $user)) {
+            return redirect()->route('expenses.admin.report', $request->only(['year', 'month']));
+        }
+
+        $this->authorize('view', $user);
+
+        return $this->renderFor($user, $request, true, $patterns);
+    }
+
+    public function save(Request $request): JsonResponse
+    {
+        $data = $this->validatePayload($request);
+        $target = $this->resolveTargetUser($request, $data['user_id'] ?? null);
+
+        $this->authorize('update', $target);
+
+        $pattern = null;
+        if (! empty($data['pattern_id'])) {
+            $pattern = CommutePattern::query()
+                ->where('user_id', $target->id)
+                ->findOrFail($data['pattern_id']);
+        }
+
+        $pattern = DB::transaction(function () use ($data, $target, $pattern) {
+            $pattern ??= new CommutePattern;
+            $pattern->user_id = $target->id;
+            $pattern->fill([
+                'submitted_at' => $pattern->submitted_at ?: now('Asia/Tokyo'),
+                'closest_station' => $data['closest_station'],
+                'train_line' => $data['train_line'] ?? null,
+                'valid_from' => $data['valid_from'],
+                'valid_to' => $data['valid_to'],
+                'reason' => $data['reason'] ?? null,
+            ]);
+            $pattern->save();
+
+            $rows = collect($data['rows'])->values();
+            $incomingIds = $rows
+                ->pluck('id')
+                ->filter()
+                ->map(fn ($id) => (int) $id)
+                ->unique()
+                ->values();
+
+            if ($incomingIds->isNotEmpty()) {
+                $ownedCount = $pattern->legs()
+                    ->whereIn('id', $incomingIds)
+                    ->count();
+
+                abort_if($ownedCount !== $incomingIds->count(), 403, 'Some commute pattern leg IDs do not belong to this pattern.');
+            }
+
+            $deleteQuery = $pattern->legs();
+            if ($incomingIds->isNotEmpty()) {
+                $deleteQuery->whereNotIn('id', $incomingIds);
+            }
+            $deleteQuery->delete();
+
+            foreach ($rows as $index => $row) {
+                $payload = [
+                    'dow' => $row['dow'],
+                    'seq' => (int) ($row['seq'] ?? (($index + 1) * 100)),
+                    'station_from' => $row['station_from'] ?? null,
+                    'station_to' => $row['station_to'] ?? null,
+                    'note' => $row['note'] ?? null,
+                    'cost' => (int) ($row['cost'] ?? 0),
+                    'trip_type' => $row['trip_type'] ?? ExpenseTripType::ROUND_TRIP->value,
+                ];
+
+                if (! empty($row['id'])) {
+                    $pattern->legs()->whereKey($row['id'])->firstOrFail()->update($payload);
+                } else {
+                    $pattern->legs()->create($payload);
+                }
+            }
+
+            return $pattern->fresh(['legs']);
+        });
+
+        return response()->json([
+            'ok' => true,
+            'pattern_id' => $pattern->id,
+            'redirect_url' => $this->routeFor($request, $target, $pattern),
+        ]);
+    }
+
+    public function destroy(Request $request, CommutePattern $pattern): JsonResponse
+    {
+        $target = $pattern->user()->firstOrFail();
+        $this->authorize('update', $target);
+
+        $pattern->delete();
+
+        return response()->json([
+            'ok' => true,
+            'redirect_url' => $this->routeFor($request, $target, null, true),
+        ]);
+    }
+
+    private function renderFor(User $user, Request $request, bool $isAdminMode, CommutePatternService $patterns)
+    {
+        $allPatterns = $patterns->allForUser($user);
+        $selected = null;
+
+        if (! $request->boolean('new')) {
+            if ($request->filled('pattern')) {
+                $selected = CommutePattern::query()
+                    ->where('user_id', $user->id)
+                    ->with(['legs' => fn ($q) => $q->orderByRaw(CommutePatternService::DOW_ORDER)->orderBy('seq')->orderBy('id')])
+                    ->findOrFail($request->integer('pattern'));
+            } else {
+                $selected = $patterns->activeOrLatest($user);
+            }
+        }
+
+        $validFrom = old('valid_from', optional($selected?->valid_from)->toDateString() ?: now('Asia/Tokyo')->toDateString());
+
+        return view('expenses.pattern', [
+            'user' => $user,
+            'isAdminMode' => $isAdminMode,
+            'patterns' => $allPatterns,
+            'pattern' => $selected,
+            'rows' => $this->rowsFor($selected),
+            'dowValues' => CommutePatternService::DOW_VALUES,
+            'defaultValidFrom' => $validFrom,
+            'defaultValidTo' => old('valid_to', optional($selected?->valid_to)->toDateString() ?: $this->defaultValidTo(Carbon::parse($validFrom))),
+        ]);
+    }
+
+    private function validatePayload(Request $request): array
+    {
+        return $request->validate([
+            'pattern_id' => ['nullable', 'integer', 'exists:commute_patterns,id'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'closest_station' => ['required', 'string', 'max:255'],
+            'train_line' => ['nullable', 'string', 'max:255'],
+            'valid_from' => ['required', 'date'],
+            'valid_to' => ['required', 'date', 'after_or_equal:valid_from'],
+            'reason' => ['nullable', 'string'],
+
+            'rows' => ['required', 'array', 'min:1'],
+            'rows.*.id' => ['nullable', 'integer'],
+            'rows.*.dow' => ['required', Rule::in(DayOfWeek::values())],
+            'rows.*.seq' => ['nullable', 'integer', 'min:0'],
+            'rows.*.station_from' => ['nullable', 'string', 'max:255'],
+            'rows.*.station_to' => ['nullable', 'string', 'max:255'],
+            'rows.*.note' => ['nullable', 'string'],
+            'rows.*.cost' => ['required', 'integer', 'min:0'],
+            'rows.*.trip_type' => ['required', Rule::in(ExpenseTripType::values())],
+        ]);
+    }
+
+    private function resolveTargetUser(Request $request, ?int $userId): User
+    {
+        if (! $userId || (int) $request->user()->id === (int) $userId) {
+            return $request->user();
+        }
+
+        return User::findOrFail($userId);
+    }
+
+    private function rowsFor(?CommutePattern $pattern): array
+    {
+        if (! $pattern) {
+            return collect(CommutePatternService::DOW_VALUES)
+                ->map(fn (string $dow) => [
+                    'id' => null,
+                    'dow' => $dow,
+                    'seq' => 100,
+                    'station_from' => null,
+                    'station_to' => null,
+                    'note' => null,
+                    'cost' => 0,
+                    'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+                ])
+                ->all();
+        }
+
+        return $pattern->legs
+            ->map(fn ($leg) => [
+                'id' => $leg->id,
+                'dow' => is_object($leg->dow) ? $leg->dow->value : $leg->dow,
+                'seq' => (int) $leg->seq,
+                'station_from' => $leg->station_from,
+                'station_to' => $leg->station_to,
+                'note' => $leg->note,
+                'cost' => (int) $leg->cost,
+                'trip_type' => is_object($leg->trip_type) ? $leg->trip_type->value : $leg->trip_type,
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function defaultValidTo(Carbon $validFrom): string
+    {
+        $year = $validFrom->month <= 3 ? $validFrom->year : $validFrom->year + 1;
+
+        return Carbon::create($year, 3, 31, 0, 0, 0, 'Asia/Tokyo')->toDateString();
+    }
+
+    private function routeFor(Request $request, User $target, ?CommutePattern $pattern, bool $new = false): string
+    {
+        $query = $new ? ['new' => 1] : [];
+        if ($pattern) {
+            $query['pattern'] = $pattern->id;
+        }
+
+        if ($request->user()->is($target)) {
+            return route('expenses.pattern', $query);
+        }
+
+        return route('expenses.admin.pattern', array_merge(['user' => $target], $query));
+    }
+}

--- a/app/Http/Controllers/ExpenseEditController.php
+++ b/app/Http/Controllers/ExpenseEditController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Expense;
 use App\Models\User;
 use App\Models\ExpenseReport;
+use App\Services\Calendar\CalendarResolver;
 use App\Services\CommutingExpenses\RouteDeclarationService;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
@@ -184,6 +186,10 @@ class ExpenseEditController extends Controller
         $this->authorize('submit', $report);
         $user = $request->user();
 
+        if ($message = $this->offDayExpenseValidationMessage($report)) {
+            return back()->with('toast_errors', [$message]);
+        }
+
         // 既に提出済みなら何もしない（冪等）
         if ($report->status !== ExpenseReportStatus::SUBMITTED->value) {
             $report->status = ExpenseReportStatus::SUBMITTED->value;
@@ -223,6 +229,64 @@ class ExpenseEditController extends Controller
         ]);
 
         return back()->with('toast', 'Expense report has been returned to draft.');
+    }
+
+    private function offDayExpenseValidationMessage(ExpenseReport $report): ?string
+    {
+        $expenses = $report->expenses()
+            ->where('cost', '>', 0)
+            ->where(function ($query) {
+                $query->whereNull('note')
+                    ->orWhere('note', '');
+            })
+            ->orderBy('expense_date')
+            ->orderBy('seq')
+            ->get(['expense_date', 'seq']);
+
+        if ($expenses->isEmpty()) {
+            return null;
+        }
+
+        $workOnMap = $this->workOnMapForReport($report);
+
+        $invalid = $expenses->first(function (Expense $expense) use ($workOnMap) {
+            $date = $expense->expense_date->toDateString();
+
+            return ! ($workOnMap[$date] ?? false);
+        });
+
+        if (! $invalid) {
+            return null;
+        }
+
+        return sprintf(
+            'Please write a reason in Note for travel expenses on non-working days. First invalid row: %s.',
+            $invalid->expense_date->toDateString()
+        );
+    }
+
+    private function workOnMapForReport(ExpenseReport $report): array
+    {
+        $start = Carbon::create($report->year, $report->month, 1, 0, 0, 0, 'Asia/Tokyo')->startOfDay();
+        $end = (clone $start)->endOfMonth();
+        $events = app(CalendarResolver::class)->build($report->user()->firstOrFail(), $start, $end);
+
+        $workOnMap = [];
+        foreach ($events as $event) {
+            $dateKey = $event['dateKey'] ?? (isset($event['start'])
+                ? (is_string($event['start']) ? substr($event['start'], 0, 10) : Carbon::parse($event['start'])->toDateString())
+                : null);
+
+            if (! $dateKey) {
+                continue;
+            }
+
+            if (strtolower((string) ($event['display'] ?? '')) === 'on') {
+                $workOnMap[$dateKey] = true;
+            }
+        }
+
+        return $workOnMap;
     }
 
     /**

--- a/app/Http/Controllers/ExpenseEditController.php
+++ b/app/Http/Controllers/ExpenseEditController.php
@@ -237,8 +237,8 @@ class ExpenseEditController extends Controller
         $year  = (int) $request->input('year', now()->year);
         $month = (int) $request->input('month', now()->month);
 
-        // 既存の Artisan コマンドをそのまま利用
-        Artisan::call('expenses:generate-monthly', [
+        // パターンが有効な日はパターン、未登録日は従来通り空行で生成する
+        Artisan::call('expenses:generate-monthly-by-pattern', [
             'year'  => $year,
             'month' => $month,
         ]);

--- a/app/Http/Controllers/ExpenseEditController.php
+++ b/app/Http/Controllers/ExpenseEditController.php
@@ -231,6 +231,10 @@ class ExpenseEditController extends Controller
         return back()->with('toast', 'Expense report has been returned to draft.');
     }
 
+    /**
+     * 経費レポートの提出前バリデーション：オフ日の経費に理由が書いてあるか
+     * ルール：費用 > 0 かつ（理由が null または空文字）な行があって、その日がカレンダー上の「ON」じゃない場合はエラー
+     */
     private function offDayExpenseValidationMessage(ExpenseReport $report): ?string
     {
         $expenses = $report->expenses()
@@ -265,6 +269,10 @@ class ExpenseEditController extends Controller
         );
     }
 
+    /**
+     * 経費レポートの対象月のカレンダーイベントを取得し、「ON」日のマップを作る
+     * 例: [ '2024-06-03' => true, '2024-06-04' => false, ... ]
+     */
     private function workOnMapForReport(ExpenseReport $report): array
     {
         $start = Carbon::create($report->year, $report->month, 1, 0, 0, 0, 'Asia/Tokyo')->startOfDay();

--- a/app/Models/CommutePattern.php
+++ b/app/Models/CommutePattern.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class CommutePattern extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'submitted_at',
+        'closest_station',
+        'train_line',
+        'valid_from',
+        'valid_to',
+        'reason',
+    ];
+
+    protected $casts = [
+        'submitted_at' => 'datetime',
+        'valid_from' => 'date',
+        'valid_to' => 'date',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function legs(): HasMany
+    {
+        return $this->hasMany(CommutePatternLeg::class);
+    }
+}

--- a/app/Models/CommutePatternLeg.php
+++ b/app/Models/CommutePatternLeg.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DayOfWeek;
+use App\Enums\ExpenseTripType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CommutePatternLeg extends Model
+{
+    protected $fillable = [
+        'commute_pattern_id',
+        'dow',
+        'seq',
+        'station_from',
+        'station_to',
+        'note',
+        'cost',
+        'trip_type',
+    ];
+
+    protected $casts = [
+        'dow' => DayOfWeek::class,
+        'trip_type' => ExpenseTripType::class,
+        'cost' => 'integer',
+        'seq' => 'integer',
+    ];
+
+    public function pattern(): BelongsTo
+    {
+        return $this->belongsTo(CommutePattern::class, 'commute_pattern_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -320,6 +320,11 @@ class User extends Authenticatable
         return $this->hasMany(RouteDeclaration::class);
     }
 
+    public function commutePatterns()
+    {
+        return $this->hasMany(CommutePattern::class);
+    }
+
     public function district()
     {
         return $this->belongsTo(District::class);

--- a/app/Services/CommutingExpenses/CommutePatternService.php
+++ b/app/Services/CommutingExpenses/CommutePatternService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services\CommutingExpenses;
+
+use App\Models\CommutePattern;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class CommutePatternService
+{
+    public const DOW_VALUES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+    public const DOW_ORDER = "CASE dow WHEN 'Sun' THEN 0 WHEN 'Mon' THEN 1 WHEN 'Tue' THEN 2 WHEN 'Wed' THEN 3 WHEN 'Thu' THEN 4 WHEN 'Fri' THEN 5 WHEN 'Sat' THEN 6 ELSE 99 END";
+
+    public function allForUser(User $user): Collection
+    {
+        return CommutePattern::query()
+            ->where('user_id', $user->id)
+            ->with([
+                'legs' => fn ($q) => $q->orderByRaw(self::DOW_ORDER)->orderBy('seq')->orderBy('id'),
+            ])
+            ->orderByDesc('valid_from')
+            ->orderByDesc('submitted_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    public function activeOn(User $user, Carbon $date): ?CommutePattern
+    {
+        return CommutePattern::query()
+            ->where('user_id', $user->id)
+            ->whereDate('valid_from', '<=', $date->toDateString())
+            ->whereDate('valid_to', '>=', $date->toDateString())
+            ->with([
+                'legs' => fn ($q) => $q->orderByRaw(self::DOW_ORDER)->orderBy('seq')->orderBy('id'),
+            ])
+            ->orderByDesc('valid_from')
+            ->orderByDesc('submitted_at')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    public function activeOrLatest(User $user, ?Carbon $date = null): ?CommutePattern
+    {
+        $date ??= now('Asia/Tokyo');
+
+        return $this->activeOn($user, $date)
+            ?: CommutePattern::query()
+                ->where('user_id', $user->id)
+                ->with([
+                    'legs' => fn ($q) => $q->orderByRaw(self::DOW_ORDER)->orderBy('seq')->orderBy('id'),
+                ])
+                ->orderByDesc('valid_from')
+                ->orderByDesc('submitted_at')
+                ->orderByDesc('id')
+                ->first();
+    }
+
+    public function forPeriod(User $user, Carbon $start, Carbon $end): Collection
+    {
+        return CommutePattern::query()
+            ->where('user_id', $user->id)
+            ->whereDate('valid_from', '<=', $end->toDateString())
+            ->whereDate('valid_to', '>=', $start->toDateString())
+            ->with([
+                'legs' => fn ($q) => $q->orderByRaw(self::DOW_ORDER)->orderBy('seq')->orderBy('id'),
+            ])
+            ->orderByDesc('valid_from')
+            ->orderByDesc('submitted_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+}

--- a/database/migrations/2026_05_29_000002_create_commute_patterns_table.php
+++ b/database/migrations/2026_05_29_000002_create_commute_patterns_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Enums\ExpenseTripType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('commute_patterns', function (Blueprint $t) {
+            $t->id();
+
+            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+            $t->timestamp('submitted_at')->nullable()->index();
+
+            $t->string('closest_station');
+            $t->string('train_line')->nullable();
+            $t->date('valid_from')->index();
+            $t->date('valid_to')->index();
+            $t->text('reason')->nullable();
+
+            $t->timestamps();
+
+            $t->index(['user_id', 'valid_from', 'valid_to']);
+        });
+
+        Schema::create('commute_pattern_legs', function (Blueprint $t) {
+            $t->id();
+
+            $t->foreignId('commute_pattern_id')
+                ->constrained('commute_patterns')
+                ->cascadeOnDelete();
+
+            $t->string('dow', 3)->index();
+            $t->unsignedInteger('seq')->default(100);
+
+            $t->string('station_from')->nullable();
+            $t->string('station_to')->nullable();
+            $t->text('note')->nullable();
+            $t->unsignedInteger('cost')->default(0);
+            $t->string('trip_type', 32)->default(ExpenseTripType::ROUND_TRIP->value);
+
+            $t->timestamps();
+
+            $t->index(['commute_pattern_id', 'dow', 'seq']);
+        });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('alter table "commute_pattern_legs" add constraint "commute_pattern_legs_seq_non_negative" check ("seq" >= 0)');
+            DB::statement('alter table "commute_pattern_legs" add constraint "commute_pattern_legs_cost_non_negative" check ("cost" >= 0)');
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('commute_pattern_legs');
+        Schema::dropIfExists('commute_patterns');
+    }
+};

--- a/public/js/commute-patterns.js
+++ b/public/js/commute-patterns.js
@@ -1,0 +1,436 @@
+(function () {
+  'use strict';
+
+  function notify(message, variant = 'success') {
+    if (typeof window.showToast === 'function') {
+      window.showToast(message, { variant, delay: 9000 });
+      return;
+    }
+    window.alert(message);
+  }
+
+  function blockSave(e) {
+    const isSaveKey =
+      (e.key && (e.key === 's' || e.key === 'S')) ||
+      (e.code && e.code === 'KeyS');
+
+    if ((e.ctrlKey || e.metaKey) && isSaveKey) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return false;
+    }
+  }
+
+  window.addEventListener('keydown', blockSave, { capture: true });
+  window.addEventListener('keypress', blockSave, { capture: true });
+  document.addEventListener('keydown', blockSave, { capture: true });
+  document.addEventListener('keypress', blockSave, { capture: true });
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const boot = window.COMMUTE_PATTERN_BOOTSTRAP || {};
+    const sheetEl = document.getElementById('patternSheet');
+    const scrollWrapper = document.getElementById('patternSheetScroll');
+
+    if (!sheetEl || !scrollWrapper) return;
+
+    const csrfToken = boot.csrfToken;
+    const patternId = boot.patternId || null;
+    const targetUserId = boot.targetUserId;
+    const initialRows = boot.initialRows || [];
+    const dowValues = boot.dowValues || ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const dowOrder = new Map(dowValues.map((dow, index) => [dow, index]));
+
+    const ACTION_BTN_HTML = '<button type="button" class="btn btn-outline-danger btn-sm js-row-del" title="この行を削除">Del</button>';
+    const ADD_BTN_HTML = '<button type="button" class="btn btn-outline-primary btn-sm js-row-add" title="この曜日の行を下に追加">Add</button>';
+
+    const COL = Object.freeze({
+      ACTIONS: 0,
+      ADD: 1,
+      DAY: 2,
+      FROM: 3,
+      TO: 4,
+      AMOUNT: 5,
+      TRIP: 6,
+      NOTE: 7,
+      ID: 8,
+      SEQ: 9,
+    });
+
+    const dayOptions = dowValues.map(dow => ({ id: dow, name: dow }));
+    const tripTypeOptions = [
+      { id: 'round_trip', name: 'Round Trip' },
+      { id: 'one_way', name: 'One Way' },
+    ];
+
+    function buildMatrix(rows) {
+      return rows.map(r => [
+        ACTION_BTN_HTML,
+        ADD_BTN_HTML,
+        r.dow || 'Sun',
+        r.station_from || '',
+        r.station_to || '',
+        Number.isFinite(Number(r.cost)) ? Number(r.cost) : 0,
+        r.trip_type || 'round_trip',
+        r.note || '',
+        r.id ?? '',
+        r.seq ?? 100,
+      ]);
+    }
+
+    const heightSelect = document.getElementById('commutePatternHeight');
+    const savedHeight = localStorage.getItem('commutePatternHeight') || '560';
+
+    if (heightSelect) {
+      heightSelect.value = savedHeight;
+    }
+
+    function applyTableHeight(value) {
+      if (value === 'full') {
+        scrollWrapper.style.maxHeight = '';
+      } else {
+        scrollWrapper.style.maxHeight = `${Number(value) || 560}px`;
+      }
+    }
+
+    applyTableHeight(savedHeight);
+    heightSelect?.addEventListener('change', () => {
+      localStorage.setItem('commutePatternHeight', heightSelect.value);
+      applyTableHeight(heightSelect.value);
+    });
+
+    const sheet = jspreadsheet(sheetEl, {
+      worksheets: [{
+        data: buildMatrix(initialRows),
+        columns: [
+          { title: '-', type: 'html', width: 60, readOnly: true },
+          { title: '+', type: 'html', width: 60, readOnly: true },
+          { title: 'Day', type: 'dropdown', width: 90, source: dayOptions },
+          { title: 'From', type: 'text', width: 220 },
+          { title: 'To', type: 'text', width: 220 },
+          { title: 'Amount', type: 'numeric', width: 110, mask: '#,##0' },
+          { title: 'Trip Type', type: 'dropdown', width: 120, source: tripTypeOptions },
+          { title: 'Note', type: 'text', width: 260 },
+          { title: '_id', type: 'text', width: 0, readOnly: true },
+          { title: '_seq', type: 'numeric', width: 0, readOnly: true },
+        ],
+        minDimensions: [10, Math.max(initialRows.length, 1)],
+        allowInsertRow: false,
+        allowManualInsertRow: false,
+        allowDeleteRow: false,
+        allowInsertColumn: false,
+        allowDeleteColumn: false,
+        allowRenameColumn: false,
+        allowComments: false,
+        allowSaving: false,
+        tableOverflow: false,
+        tableHeight: '470px',
+      }],
+    });
+
+    function hideInternalCols() {
+      sheet[0].hideColumn(COL.ID);
+      sheet[0].hideColumn(COL.SEQ);
+    }
+    hideInternalCols();
+
+    function readCurrentRows() {
+      const data = sheet[0].getData(false);
+      return data.map(arr => ({
+        dow: arr[COL.DAY] || '',
+        station_from: arr[COL.FROM] || '',
+        station_to: arr[COL.TO] || '',
+        cost: (arr[COL.AMOUNT] === '' || arr[COL.AMOUNT] == null)
+          ? 0
+          : Number(String(arr[COL.AMOUNT]).replace(/,/g, '')),
+        trip_type: arr[COL.TRIP] || '',
+        note: arr[COL.NOTE] || '',
+        id: arr[COL.ID] || '',
+        seq: (arr[COL.SEQ] === '' || arr[COL.SEQ] == null) ? 100 : Number(arr[COL.SEQ]),
+      })).filter(r => r.dow);
+    }
+
+    function sortRows(rows) {
+      return rows.slice().sort((a, b) => {
+        const aDow = dowOrder.has(a.dow) ? dowOrder.get(a.dow) : 99;
+        const bDow = dowOrder.has(b.dow) ? dowOrder.get(b.dow) : 99;
+        if (aDow !== bDow) return aDow - bDow;
+        return (Number(a.seq) || 0) - (Number(b.seq) || 0);
+      });
+    }
+
+    function renderRows(rows) {
+      sheet[0].setData(buildMatrix(sortRows(rows)));
+      hideInternalCols();
+    }
+
+    function decideSeqForDay(targetDow, rows, hintAfterSeq = null) {
+      const same = rows.filter(r => r.dow === targetDow).sort((a, b) => a.seq - b.seq);
+      if (same.length === 0) return 100;
+      const maxSeq = same[same.length - 1].seq ?? 100;
+      if (hintAfterSeq == null) return maxSeq + 100;
+
+      const next = same.find(r => r.seq > hintAfterSeq);
+      if (next && (next.seq - hintAfterSeq) > 1) return Math.floor((hintAfterSeq + next.seq) / 2);
+      return maxSeq + 100;
+    }
+
+    const pickDowEl = document.getElementById('pickDow');
+    const addDowBtn = document.getElementById('addDowBtn');
+
+    addDowBtn?.addEventListener('click', () => {
+      const dow = pickDowEl?.value || 'Sun';
+      const rows = readCurrentRows();
+      const seq = decideSeqForDay(dow, rows);
+      rows.push({
+        dow,
+        station_from: '',
+        station_to: '',
+        cost: 0,
+        trip_type: 'round_trip',
+        note: '',
+        id: '',
+        seq,
+      });
+      const updated = sortRows(rows);
+      renderRows(updated);
+      const newIndex = updated.findIndex(r => r.dow === dow && r.seq === seq);
+      if (newIndex >= 0) sheet[0].selectCell(COL.FROM, newIndex);
+      notify(`Row added for ${dow}.`, 'success');
+    });
+
+    sheetEl.addEventListener('click', (e) => {
+      const delBtn = e.target.closest('.js-row-del');
+      const addBtn = e.target.closest('.js-row-add');
+      const td = e.target.closest('td');
+      if (!td) return;
+
+      const rowIndex = Number(td.getAttribute('data-y'));
+      if (Number.isNaN(rowIndex) || rowIndex < 0) return;
+
+      if (delBtn) {
+        const rows = readCurrentRows();
+        if (rows.length <= 1) {
+          const only = rows[0] || { dow: 'Sun', seq: 100 };
+          renderRows([{
+            ...only,
+            station_from: '',
+            station_to: '',
+            cost: 0,
+            trip_type: 'round_trip',
+            note: '',
+            id: only.id || '',
+          }]);
+          notify('The last row has been cleared.', 'warning');
+          return;
+        }
+
+        const deleted = rows[rowIndex];
+        rows.splice(rowIndex, 1);
+        renderRows(rows);
+        notify(`Row for ${deleted?.dow || 'selected day'} will be deleted on save.`, 'success');
+        return;
+      }
+
+      if (addBtn) {
+        const rows = readCurrentRows();
+        const row = rows[rowIndex];
+        if (!row) return;
+
+        const seq = decideSeqForDay(row.dow, rows, row.seq);
+        rows.splice(rowIndex + 1, 0, {
+          dow: row.dow,
+          station_from: '',
+          station_to: '',
+          cost: 0,
+          trip_type: 'round_trip',
+          note: '',
+          id: '',
+          seq,
+        });
+
+        const updated = sortRows(rows);
+        renderRows(updated);
+        const newIndex = updated.findIndex(r => r.dow === row.dow && r.seq === seq);
+        if (newIndex >= 0) sheet[0].selectCell(COL.FROM, newIndex);
+        notify(`Row added for ${row.dow}.`, 'success');
+      }
+    });
+
+    const validFromEl = document.getElementById('validFrom');
+    const validToEl = document.getElementById('validTo');
+    let validToTouched = false;
+
+    function defaultValidTo(validFrom) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(validFrom || '')) return '';
+      const [year, month] = validFrom.split('-').map(Number);
+      const endYear = month <= 3 ? year : year + 1;
+      return `${String(endYear).padStart(4, '0')}-03-31`;
+    }
+
+    validToEl?.addEventListener('input', () => {
+      validToTouched = true;
+    });
+
+    validFromEl?.addEventListener('change', () => {
+      if (!validToEl || validToTouched) return;
+      validToEl.value = defaultValidTo(validFromEl.value);
+    });
+
+    function metaPayload() {
+      return {
+        pattern_id: patternId,
+        user_id: targetUserId,
+        closest_station: document.getElementById('closestStation')?.value?.trim() || '',
+        train_line: document.getElementById('trainLine')?.value?.trim() || null,
+        valid_from: validFromEl?.value || '',
+        valid_to: validToEl?.value || '',
+        reason: document.getElementById('patternReason')?.value?.trim() || null,
+      };
+    }
+
+    function validateBeforeSave(meta, rows) {
+      if (!meta.closest_station) return 'Closest Station is required.';
+      if (!meta.valid_from || !meta.valid_to) return 'Valid From and Valid To are required.';
+      if (meta.valid_to < meta.valid_from) return 'Valid To must be after or equal to Valid From.';
+      if (!rows.length) return 'At least one pattern row is required.';
+
+      for (const row of rows) {
+        if (!dowOrder.has(row.dow)) return `Invalid day: ${row.dow}`;
+        if (!Number.isFinite(row.cost) || row.cost < 0) return `Invalid amount: ${row.cost}`;
+        if (!row.trip_type) return `Please select Trip Type for ${row.dow}.`;
+      }
+
+      return null;
+    }
+
+    const saveBtn = document.getElementById('savePatternBtn');
+    saveBtn?.addEventListener('click', async () => {
+      const meta = metaPayload();
+      const rows = sortRows(readCurrentRows());
+      const validationError = validateBeforeSave(meta, rows);
+      if (validationError) {
+        notify(validationError, 'warning');
+        return;
+      }
+
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving...';
+
+      try {
+        const resp = await fetch(boot.saveUrl, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': csrfToken,
+            'Accept': 'application/json',
+          },
+          body: JSON.stringify({ ...meta, rows }),
+        });
+
+        if (!resp.ok) {
+          let msg = '';
+          try { msg = (await resp.json())?.message || ''; } catch (_) { msg = await resp.text(); }
+          throw new Error(`Save failed: ${resp.status} ${msg}`);
+        }
+
+        const data = await resp.json();
+        notify('Saved successfully.', 'success');
+        setTimeout(() => {
+          window.location.href = data.redirect_url || window.location.href;
+        }, 900);
+      } catch (err) {
+        console.error(err);
+        notify('An error occurred while saving. ' + (err?.message || err), 'danger');
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+      }
+    });
+
+    const deletePatternBtn = document.getElementById('deletePatternBtn');
+    deletePatternBtn?.addEventListener('click', () => {
+      if (!boot.deleteUrl) return;
+
+      const modalEl = document.getElementById('confirmPatternDeleteModal');
+      const modal = new bootstrap.Modal(modalEl);
+      modal.show();
+
+      const yesBtn = document.getElementById('confirmPatternDeleteYes');
+      yesBtn.replaceWith(yesBtn.cloneNode(true));
+      const newYesBtn = document.getElementById('confirmPatternDeleteYes');
+
+      newYesBtn.addEventListener('click', async () => {
+        modal.hide();
+        deletePatternBtn.disabled = true;
+
+        try {
+          const resp = await fetch(boot.deleteUrl, {
+            method: 'DELETE',
+            headers: {
+              'X-CSRF-TOKEN': csrfToken,
+              'Accept': 'application/json',
+            },
+          });
+
+          if (!resp.ok) {
+            let msg = '';
+            try { msg = (await resp.json())?.message || ''; } catch (_) { msg = await resp.text(); }
+            throw new Error(`Delete failed: ${resp.status} ${msg}`);
+          }
+
+          const data = await resp.json();
+          notify('Deleted successfully.', 'success');
+          setTimeout(() => {
+            window.location.href = data.redirect_url || window.location.href;
+          }, 900);
+        } catch (err) {
+          console.error(err);
+          notify('Deletion error: ' + (err?.message || err), 'danger');
+          deletePatternBtn.disabled = false;
+        }
+      });
+    });
+
+    (function setupFloatingSave() {
+      if (!saveBtn) return;
+
+      const bgBar = document.createElement('div');
+      bgBar.id = 'patternSaveBtnBackground';
+      bgBar.style.position = 'fixed';
+      bgBar.style.left = '0';
+      bgBar.style.right = '0';
+      bgBar.style.bottom = '0';
+      bgBar.style.height = '60px';
+      bgBar.style.background = 'rgba(136, 174, 255, 0.18)';
+      bgBar.style.backdropFilter = 'blur(1px)';
+      bgBar.style.zIndex = '998';
+      bgBar.style.display = 'none';
+      document.body.appendChild(bgBar);
+
+      const floatingBtn = saveBtn.cloneNode(true);
+      floatingBtn.id = 'savePatternBtnFloating';
+      floatingBtn.style.position = 'fixed';
+      floatingBtn.style.bottom = '14px';
+      floatingBtn.style.right = '20px';
+      floatingBtn.style.zIndex = '999';
+      floatingBtn.style.display = 'none';
+      floatingBtn.style.boxShadow = '0 2px 8px rgba(0,0,0,0.25)';
+      floatingBtn.style.opacity = '0.95';
+      floatingBtn.style.borderRadius = '6px';
+      document.body.appendChild(floatingBtn);
+
+      floatingBtn.addEventListener('click', () => saveBtn.click());
+
+      function checkSaveBtnVisibility() {
+        const rect = saveBtn.getBoundingClientRect();
+        const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+        floatingBtn.style.display = inView ? 'none' : 'block';
+        bgBar.style.display = inView ? 'none' : 'block';
+      }
+
+      window.addEventListener('scroll', checkSaveBtnVisibility);
+      window.addEventListener('resize', checkSaveBtnVisibility);
+      checkSaveBtnVisibility();
+    })();
+  });
+})();

--- a/public/js/expenses.js
+++ b/public/js/expenses.js
@@ -386,6 +386,63 @@
       return maxSeq + 1024;
     }
 
+    function validateRowsForSave(rows) {
+      for (const r of rows) {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(r.date)) return `Invalid date format ${r.date}`;
+        const [yy, mm] = r.date.split('-').map(Number);
+        //if (yy !== Number(year) || mm !== Number(month)) return `Dates outside of this month are included: ${r.date}`;
+        if (r.cost < 0 || !Number.isFinite(r.cost)) return `Invalid amount: ${r.cost}`;
+        if (!r.trip) return `Please select "Trip Type" ${r.date}`;
+      }
+
+      return null;
+    }
+
+    function buildBatchPayload(rows) {
+      const updates = rows
+        .filter(r => r.id && initialIdSet.has(String(r.id)))
+        .map(u => ({
+          id:           u.id,
+          station_from: u.from || null,
+          station_to:   u.to   || null,
+          note:         u.note || null,
+          cost:         u.cost,
+          trip_type:    u.trip,
+          seq:          u.seq,
+        }));
+
+      const creates = rows
+        .filter(r => !r.id)
+        .map(c => ({
+          expense_date: c.date,
+          seq:          Number.isFinite(c.seq) ? c.seq : 100,
+          station_from: c.from || null,
+          station_to:   c.to   || null,
+          note:         c.note || null,
+          cost:         c.cost,
+          trip_type:    c.trip,
+          category:     'regular',
+        }));
+
+      return { updates, creates };
+    }
+
+    async function saveRows(rows) {
+      const { updates, creates } = buildBatchPayload(rows);
+
+      const resp = await fetch('/api/expenses/batch', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
+        body: JSON.stringify({ report_id: reportId, updates, creates }),
+      });
+
+      if (!resp.ok) {
+        let msg = '';
+        try { msg = (await resp.json())?.message || ''; } catch (_) { msg = await resp.text(); }
+        throw new Error(`Save failed: ${resp.status} ${msg}`);
+      }
+    }
+
     addByDateBtn?.addEventListener('click', () => {
       if (isLocked) return; // ★ ロック中は何もしない
       const dateStr = pickDateEl?.value || '';
@@ -416,53 +473,15 @@
         if (isLocked) return; // ★ ロックなら何もしない
 
         const rows = readCurrentRows();
-
-        for (const r of rows) {
-          if (!/^\d{4}-\d{2}-\d{2}$/.test(r.date)) { showToast(`Invalid date format ${r.date}`, 'warning'); return; }
-          const [yy, mm] = r.date.split('-').map(Number);
-          //if (yy !== Number(year) || mm !== Number(month)) { showToast(`Dates outside of this month are included: ${r.date}`, 'warning'); return; }
-          if (r.cost < 0 || !Number.isFinite(r.cost)) { showToast(`Invalid amount: ${r.cost}`, 'warning'); return; }
-          if (!r.trip) { showToast(`Please select "Trip Type" ${r.date}`, 'warning'); return; }
+        const validationError = validateRowsForSave(rows);
+        if (validationError) {
+          showToast(validationError, 'warning');
+          return;
         }
 
         saveBtn.disabled = true; saveBtn.textContent = 'Saving…';
         try {
-          const updates = rows
-            .filter(r => r.id && initialIdSet.has(String(r.id)))
-            .map(u => ({
-              id:           u.id,
-              station_from: u.from || null,
-              station_to:   u.to   || null,
-              note:         u.note || null,
-              cost:         u.cost,
-              trip_type:    u.trip,
-              seq:          u.seq,
-            }));
-
-          const creates = rows
-            .filter(r => !r.id)
-            .map(c => ({
-              expense_date: c.date,
-              seq:          Number.isFinite(c.seq) ? c.seq : 100,
-              station_from: c.from || null,
-              station_to:   c.to   || null,
-              note:         c.note || null,
-              cost:         c.cost,
-              trip_type:    c.trip,
-              category:     'regular',
-            }));
-
-          const resp = await fetch('/api/expenses/batch', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' },
-            body: JSON.stringify({ report_id: reportId, updates, creates }),
-          });
-          if (!resp.ok) {
-            let msg = '';
-            try { msg = (await resp.json())?.message || ''; } catch (_) { msg = await resp.text(); }
-            throw new Error(`Save failed: ${resp.status} ${msg}`);
-          }
-
+          await saveRows(rows);
           showToast('Saved successfully.', 'success');
 
           // ★ トーストを少し見せてからリロード
@@ -676,27 +695,86 @@
       const submitFormEl = document.getElementById('submitForm');
       if (!submitFormEl) return;
 
-      submitFormEl.addEventListener('submit', () => {
-        // ★ hidden の _token / _method は無効化しない
-        document.querySelectorAll('button, input, select, textarea').forEach(el => {
-          // hidden（type=hidden）は送信に必要な場合があるのでスキップ
-          if (el.tagName === 'INPUT' && el.type === 'hidden') return;
-          // 念のため _token / _method 名もスキップ
-          if (el.name === '_token' || el.name === '_method') return;
-          el.disabled = true;
-        });
+      let submitInProgress = false;
+      let submitOverlay = null;
+      let submitBtnText = '';
+      const disabledBeforeSubmit = new Map();
 
-        // 送信用ボタン表示切替
+      function setSubmitUiLocked(locked) {
         const btn = submitFormEl.querySelector('button[type="submit"]');
-        if (btn) { btn.innerText = 'Submitting...'; btn.disabled = true; }
 
-        // 薄いオーバーレイ
-        const overlay = document.createElement('div');
-        overlay.style.cssText = `
-      position:fixed; inset:0; background:rgba(255,255,255,.4);
-      backdrop-filter:saturate(120%) blur(1px); z-index:1060;
-    `;
-        document.body.appendChild(overlay);
+        if (locked) {
+          disabledBeforeSubmit.clear();
+
+          // ★ hidden の _token / _method は無効化しない
+          document.querySelectorAll('button, input, select, textarea').forEach(el => {
+            // hidden（type=hidden）は送信に必要な場合があるのでスキップ
+            if (el.tagName === 'INPUT' && el.type === 'hidden') return;
+            // 念のため _token / _method 名もスキップ
+            if (el.name === '_token' || el.name === '_method') return;
+
+            disabledBeforeSubmit.set(el, el.disabled);
+            el.disabled = true;
+          });
+
+          if (btn) {
+            submitBtnText = btn.innerText;
+            btn.innerText = 'Saving...';
+            btn.disabled = true;
+          }
+
+          // 薄いオーバーレイ
+          submitOverlay = document.createElement('div');
+          submitOverlay.style.cssText = `
+        position:fixed; inset:0; background:rgba(255,255,255,.4);
+        backdrop-filter:saturate(120%) blur(1px); z-index:1060;
+      `;
+          document.body.appendChild(submitOverlay);
+
+          return;
+        }
+
+        disabledBeforeSubmit.forEach((wasDisabled, el) => {
+          el.disabled = wasDisabled;
+        });
+        disabledBeforeSubmit.clear();
+
+        if (btn) {
+          btn.innerText = submitBtnText || 'Submit';
+        }
+
+        submitOverlay?.remove();
+        submitOverlay = null;
+      }
+
+      submitFormEl.addEventListener('submit', async (e) => {
+        if (submitInProgress) return;
+
+        e.preventDefault();
+        if (isLocked) return;
+
+        const rows = readCurrentRows();
+        const validationError = validateRowsForSave(rows);
+        if (validationError) {
+          showToast(validationError, 'warning');
+          return;
+        }
+
+        setSubmitUiLocked(true);
+
+        try {
+          await saveRows(rows);
+
+          const btn = submitFormEl.querySelector('button[type="submit"]');
+          if (btn) btn.innerText = 'Submitting...';
+
+          submitInProgress = true;
+          submitFormEl.submit();
+        } catch (err) {
+          console.error(err);
+          showToast('An error occurred while saving before submit.\n' + (err?.message || err), 'danger');
+          setSubmitUiLocked(false);
+        }
       });
     })();
 

--- a/resources/views/expenses/edit.blade.php
+++ b/resources/views/expenses/edit.blade.php
@@ -22,7 +22,7 @@
       @php $me = auth()->user(); @endphp
       <div class="d-flex flex-wrap gap-2">
           @if($me->hasAnyRole(['admin','super_admin']))
-              <a href="{{ route('routes.admin.create', $report->employee_code) }}"
+              <a href="{{ route('routes.admin.create', $user) }}"
                 class="btn btn-outline-primary btn-sm btn-route-fixed">
                   ＋ Route Declaration
               </a>
@@ -34,7 +34,7 @@
           @endif
 
           @if($me->hasAnyRole(['admin','super_admin']))
-              <a href="{{ route('commuter_passes.admin.create', $report->employee_code) }}"
+              <a href="{{ route('commuter_passes.admin.create', $user) }}"
                 class="btn btn-outline-primary btn-sm btn-route-fixed">
                   ＋ Commuter Pass
               </a>
@@ -42,6 +42,18 @@
               <a href="{{ route('commuter_passes.create') }}"
                 class="btn btn-outline-primary btn-sm btn-route-fixed">
                   ＋ Commuter Pass
+              </a>
+          @endif
+
+          @if($me->hasAnyRole(['admin','super_admin']))
+              <a href="{{ route('expenses.admin.pattern', $user) }}"
+                class="btn btn-outline-primary btn-sm btn-route-fixed">
+                  ＋ Pattern
+              </a>
+          @else
+              <a href="{{ route('expenses.pattern') }}"
+                class="btn btn-outline-primary btn-sm btn-route-fixed">
+                  ＋ Pattern
               </a>
           @endif
       </div>

--- a/resources/views/expenses/pattern.blade.php
+++ b/resources/views/expenses/pattern.blade.php
@@ -1,0 +1,192 @@
+{{-- resources/views/expenses/pattern.blade.php --}}
+@extends('layouts.app')
+
+@section('title', 'Commuting Expense Pattern')
+
+@push('styles')
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsuites/dist/jsuites.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5/dist/jspreadsheet.min.css">
+<link rel="stylesheet" href="{{ asset('css/expenses.css') }}?v={{ filemtime(public_path('css/expenses.css')) }}">
+@endpush
+
+@section('content')
+@php
+    $newUrl = $isAdminMode
+        ? route('expenses.admin.pattern', ['user' => $user, 'new' => 1])
+        : route('expenses.pattern', ['new' => 1]);
+    $loadUrl = $isAdminMode
+        ? route('expenses.admin.pattern', ['user' => $user])
+        : route('expenses.pattern');
+    $backUrl = $isAdminMode
+        ? route('expenses.admin.edit', ['user' => $user])
+        : route('expenses.edit');
+@endphp
+
+<div class="page-wrap">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">
+      Commuting Pattern
+      <small class="text-muted fs-6">
+        for {{ $user->first_name }} {{ $user->family_name }} ({{ $user->employee_code }})
+      </small>
+    </h1>
+
+    <div class="d-flex flex-wrap gap-2">
+      <a href="{{ $backUrl }}" class="btn btn-outline-secondary btn-sm btn-route-fixed">Back</a>
+      <a href="{{ $newUrl }}" class="btn btn-outline-primary btn-sm btn-route-fixed">＋ New Pattern</a>
+    </div>
+  </div>
+
+  @if($patterns->isNotEmpty())
+    <form method="GET" action="{{ $loadUrl }}" class="mb-3 d-flex align-items-center gap-2">
+      <label for="patternPick" class="form-label m-0">Pattern</label>
+      <select id="patternPick" name="pattern" class="form-select form-select-sm" style="max-width:420px">
+        @foreach($patterns as $p)
+          <option value="{{ $p->id }}" @selected($pattern?->id === $p->id)>
+            {{ $p->valid_from?->format('Y-m-d') }} - {{ $p->valid_to?->format('Y-m-d') }}
+            / {{ $p->closest_station }}
+          </option>
+        @endforeach
+      </select>
+      <button type="submit" class="btn btn-sm btn-outline-primary">Load</button>
+    </form>
+  @endif
+
+  <div class="header-box mb-2">
+    <div class="row g-2 align-items-end">
+      <div class="col-md-3">
+        <label for="closestStation" class="form-label small mb-0">Closest Station <span class="text-danger">*</span></label>
+        <input type="text" id="closestStation" class="form-control form-control-sm"
+          value="{{ old('closest_station', $pattern?->closest_station) }}" required>
+      </div>
+
+      <div class="col-md-3">
+        <label for="trainLine" class="form-label small mb-0">Train Line</label>
+        <input type="text" id="trainLine" class="form-control form-control-sm"
+          value="{{ old('train_line', $pattern?->train_line) }}">
+      </div>
+
+      <div class="col-md-2">
+        <label for="validFrom" class="form-label small mb-0">Valid From <span class="text-danger">*</span></label>
+        <input type="date" id="validFrom" class="form-control form-control-sm"
+          value="{{ $defaultValidFrom }}" required>
+      </div>
+
+      <div class="col-md-2">
+        <label for="validTo" class="form-label small mb-0">Valid To <span class="text-danger">*</span></label>
+        <input type="date" id="validTo" class="form-control form-control-sm"
+          value="{{ $defaultValidTo }}" required>
+      </div>
+
+      <div class="col-md-2 d-flex gap-2 justify-content-md-end">
+        <button id="savePatternBtn" class="btn btn-primary btn-sm" type="button">Save</button>
+        @if($pattern)
+          <button id="deletePatternBtn" class="btn btn-outline-danger btn-sm" type="button">Delete</button>
+        @endif
+      </div>
+
+      <div class="col-12">
+        <label for="patternReason" class="form-label small mb-0">Reason for Submitting Expenses</label>
+        <textarea id="patternReason" rows="2" class="form-control form-control-sm">{{ old('reason', $pattern?->reason) }}</textarea>
+      </div>
+    </div>
+  </div>
+
+  <div class="header-box mb-2">
+    <div class="d-flex flex-wrap align-items-center gap-2">
+      <label for="pickDow" class="form-label m-0">Day</label>
+      <select id="pickDow" class="form-select form-select-sm" style="width:110px">
+        @foreach($dowValues as $dow)
+          <option value="{{ $dow }}">{{ $dow }}</option>
+        @endforeach
+      </select>
+      <button id="addDowBtn" class="btn btn-success btn-sm" type="button">＋ Add Day</button>
+
+      <div class="ms-auto expense-edit-table-toolbar">
+        <label for="commutePatternHeight" class="form-label m-0 small text-muted">Table Height</label>
+        <select id="commutePatternHeight" class="form-select form-select-sm expense-edit-height-select">
+          <option value="420">Compact</option>
+          <option value="560">Standard</option>
+          <option value="720">Tall</option>
+          <option value="full">Full</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <div id="patternSheetScroll">
+    <div id="patternSheet"></div>
+  </div>
+
+  <div class="mt-2 d-flex gap-2">
+    <a href="https://world.jorudan.co.jp/mln/en/?sub_lang=nosub"
+      class="btn btn-outline-secondary btn-sm"
+      target="_blank" rel="noopener noreferrer">
+      Open Jorudan (Japanese Transit Planner)
+    </a>
+    <a href="https://www.google.com/maps/"
+      class="btn btn-outline-secondary btn-sm"
+      target="_blank" rel="noopener noreferrer">
+      Open Google Maps
+    </a>
+  </div>
+
+  <div class="modal fade" id="confirmPatternDeleteModal" tabindex="-1" aria-labelledby="confirmPatternDeleteLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header bg-warning text-dark py-2 custom-orange-header">
+          <h6 class="modal-title" id="confirmPatternDeleteLabel">Delete Confirmation</h6>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+        </div>
+        <div class="modal-body small">
+          Are you sure you want to delete this commute pattern?
+        </div>
+        <div class="modal-footer py-2">
+          <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" id="confirmPatternDeleteYes" class="btn btn-danger btn-sm">Delete</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('styles')
+<style>
+  .btn-route-fixed {
+    width: 150px;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  #patternSheetScroll {
+    width: 100%;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  #patternSheet {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin: 0 auto;
+  }
+</style>
+@endpush
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jsuites/dist/jsuites.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspreadsheet-ce@5/dist/index.min.js"></script>
+<script>
+  window.COMMUTE_PATTERN_BOOTSTRAP = {
+    csrfToken: @json(csrf_token()),
+    targetUserId: @json($user->id),
+    patternId: @json($pattern?->id),
+    initialRows: @json($rows),
+    dowValues: @json($dowValues),
+    saveUrl: @json(route('api.commute_patterns.batch')),
+    deleteUrl: @json($pattern ? route('api.commute_patterns.destroy', $pattern) : null),
+  };
+</script>
+<script src="{{ asset('js/commute-patterns.js') }}?v={{ filemtime(public_path('js/commute-patterns.js')) }}" defer></script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -171,15 +171,23 @@ Route::middleware(['auth', 'role:super_admin'])->group(function () {
 });
 
 use App\Http\Controllers\ExpenseEditController;
+use App\Http\Controllers\CommutePatternController;
 
 Route::middleware(['auth'])->group(function () {
     // ユーザー本人: /expenses/edit?year=YYYY&month=M
     Route::get('/expenses/edit', [ExpenseEditController::class, 'selfEdit'])
         ->name('expenses.edit');
 
+    Route::get('/expenses/pattern', [CommutePatternController::class, 'selfEdit'])
+        ->name('expenses.pattern');
+
     // 管理者: /expenses/{user}/edit?year=YYYY&month=M
     Route::get('/expenses/{user}/edit', [ExpenseEditController::class, 'adminEdit'])
         ->name('expenses.admin.edit');
+
+    Route::get('/expenses/{user}/pattern', [CommutePatternController::class, 'adminEdit'])
+        ->name('expenses.admin.pattern');
+
     // ★ 提出（report単位）
     Route::put('/expenses/reports/{report}/submit', [ExpenseEditController::class, 'submit'])
         ->name('expenses.submit');
@@ -201,6 +209,9 @@ Route::middleware(['auth'])->group(function () {
     Route::put('/api/expenses/batch',         [ExpenseApiController::class, 'batchSave'])->name('api.expenses.batch');
     Route::put('/api/expenses/{expense}',     [ExpenseApiController::class, 'update'])->name('api.expenses.update');
     Route::delete('/api/expenses/{expense}',  [ExpenseApiController::class, 'destroy'])->name('api.expenses.destroy');
+
+    Route::put('/api/commute-patterns/batch', [CommutePatternController::class, 'save'])->name('api.commute_patterns.batch');
+    Route::delete('/api/commute-patterns/{pattern}', [CommutePatternController::class, 'destroy'])->name('api.commute_patterns.destroy');
 });
 
 use App\Http\Controllers\ExpenseReportController;

--- a/tests/Feature/ExpenseEditControllerTest.php
+++ b/tests/Feature/ExpenseEditControllerTest.php
@@ -2,9 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Enums\ExpenseCategory;
 use App\Enums\ExpenseReportStatus;
+use App\Enums\ExpenseTripType;
 use App\Models\Department;
 use App\Models\District;
+use App\Models\Expense;
 use App\Models\ExpenseReport;
 use App\Models\User;
 use App\Models\UserManagementScope;
@@ -308,6 +311,38 @@ class ExpenseEditControllerTest extends TestCase
              ->assertRedirect(
                  route('expenses.edit', ['year' => $report->year, 'month' => $report->month])
              );
+    }
+
+    public function test_submit_requires_note_for_positive_cost_on_non_working_day(): void
+    {
+        [$user, $report] = $this->makeUserWithReport(2026, 5);
+
+        Expense::create([
+            'expense_report_id' => $report->id,
+            'expense_date' => '2026-05-01',
+            'seq' => 100,
+            'station_from' => 'Home',
+            'station_to' => 'School',
+            'note' => null,
+            'cost' => 240,
+            'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+            'category' => ExpenseCategory::REGULAR->value,
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('expenses.submit', $report))
+            ->assertRedirect()
+            ->assertSessionHas('toast_errors', function ($errors) {
+                return in_array(
+                    'Please write a reason in Note for travel expenses on non-working days. First invalid row: 2026-05-01.',
+                    $errors,
+                    true
+                );
+            });
+
+        $report->refresh();
+        $this->assertSame(ExpenseReportStatus::DRAFT, $report->status);
+        $this->assertNull($report->submitted_at);
     }
 
     // =========================================================================

--- a/tests/Feature/GenerateMonthlyExpensesByPatternTest.php
+++ b/tests/Feature/GenerateMonthlyExpensesByPatternTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ExpenseCategory;
+use App\Enums\ExpenseReportStatus;
+use App\Enums\ExpenseTripType;
+use App\Models\CommutePattern;
+use App\Models\EmploymentTerm;
+use App\Models\Expense;
+use App\Models\ExpenseReport;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GenerateMonthlyExpensesByPatternTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_self_pattern_page_renders(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->get(route('expenses.pattern', ['new' => 1]))
+            ->assertOk()
+            ->assertViewIs('expenses.pattern')
+            ->assertSee('Commuting Pattern')
+            ->assertSee('window.COMMUTE_PATTERN_BOOTSTRAP', false);
+    }
+
+    public function test_it_generates_pattern_rows_for_valid_weekdays_and_blank_rows_otherwise(): void
+    {
+        $user = User::factory()->general()->create([
+            'family_name' => 'Pattern',
+            'first_name' => 'Teacher',
+        ]);
+
+        EmploymentTerm::create([
+            'user_id' => $user->id,
+            'start_date' => '2026-05-01',
+            'end_date' => null,
+            'type_name' => 'Employee',
+            'type_code' => 'employee',
+        ]);
+
+        $pattern = CommutePattern::create([
+            'user_id' => $user->id,
+            'submitted_at' => now('Asia/Tokyo'),
+            'closest_station' => 'Home',
+            'train_line' => 'Local',
+            'valid_from' => '2026-05-01',
+            'valid_to' => '2026-05-31',
+            'reason' => null,
+        ]);
+
+        $pattern->legs()->create([
+            'dow' => 'Mon',
+            'seq' => 100,
+            'station_from' => 'Home',
+            'station_to' => 'School',
+            'cost' => 500,
+            'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+            'note' => 'main',
+        ]);
+
+        $pattern->legs()->create([
+            'dow' => 'Mon',
+            'seq' => 200,
+            'station_from' => 'School',
+            'station_to' => 'Office',
+            'cost' => 300,
+            'trip_type' => ExpenseTripType::ONE_WAY->value,
+            'note' => 'extra',
+        ]);
+
+        $this->artisan('expenses:generate-monthly-by-pattern', [
+            'year' => 2026,
+            'month' => 5,
+        ])->assertSuccessful();
+
+        $report = ExpenseReport::query()
+            ->where('user_id', $user->id)
+            ->where('year', 2026)
+            ->where('month', 5)
+            ->firstOrFail();
+
+        $this->assertSame(ExpenseReportStatus::DRAFT, $report->status);
+
+        $mondayRows = Expense::query()
+            ->where('expense_report_id', $report->id)
+            ->whereDate('expense_date', '2026-05-04')
+            ->orderBy('seq')
+            ->get();
+
+        $this->assertCount(2, $mondayRows);
+        $this->assertSame(['Home', 'School', 500, ExpenseTripType::ROUND_TRIP->value], [
+            $mondayRows[0]->station_from,
+            $mondayRows[0]->station_to,
+            $mondayRows[0]->cost,
+            $mondayRows[0]->trip_type->value,
+        ]);
+        $this->assertSame(['School', 'Office', 300, ExpenseTripType::ONE_WAY->value], [
+            $mondayRows[1]->station_from,
+            $mondayRows[1]->station_to,
+            $mondayRows[1]->cost,
+            $mondayRows[1]->trip_type->value,
+        ]);
+
+        $blankTuesday = Expense::query()
+            ->where('expense_report_id', $report->id)
+            ->whereDate('expense_date', '2026-05-05')
+            ->firstOrFail();
+
+        $this->assertNull($blankTuesday->station_from);
+        $this->assertNull($blankTuesday->station_to);
+        $this->assertSame(0, $blankTuesday->cost);
+        $this->assertSame(ExpenseTripType::ROUND_TRIP, $blankTuesday->trip_type);
+        $this->assertSame(ExpenseCategory::REGULAR, $blankTuesday->category);
+    }
+
+    public function test_pattern_api_creates_updates_syncs_and_deletes_pattern(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $createResponse = $this->actingAs($user)->putJson(route('api.commute_patterns.batch'), [
+            'user_id' => $user->id,
+            'closest_station' => 'Home',
+            'train_line' => 'Local',
+            'valid_from' => '2026-04-01',
+            'valid_to' => '2027-03-31',
+            'reason' => 'initial',
+            'rows' => [
+                [
+                    'dow' => 'Sun',
+                    'seq' => 100,
+                    'station_from' => 'Home',
+                    'station_to' => 'School',
+                    'cost' => 400,
+                    'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+                    'note' => null,
+                ],
+                [
+                    'dow' => 'Mon',
+                    'seq' => 100,
+                    'station_from' => 'Home',
+                    'station_to' => 'Office',
+                    'cost' => 500,
+                    'trip_type' => ExpenseTripType::ONE_WAY->value,
+                    'note' => 'temporary',
+                ],
+            ],
+        ]);
+
+        $createResponse->assertOk()->assertJson(['ok' => true]);
+
+        $pattern = CommutePattern::query()->where('user_id', $user->id)->firstOrFail();
+        $this->assertCount(2, $pattern->legs);
+
+        $sunLeg = $pattern->legs()->where('dow', 'Sun')->firstOrFail();
+
+        $this->actingAs($user)->putJson(route('api.commute_patterns.batch'), [
+            'pattern_id' => $pattern->id,
+            'user_id' => $user->id,
+            'closest_station' => 'Updated Home',
+            'train_line' => null,
+            'valid_from' => '2026-04-01',
+            'valid_to' => '2027-03-31',
+            'reason' => 'updated',
+            'rows' => [
+                [
+                    'id' => $sunLeg->id,
+                    'dow' => 'Sun',
+                    'seq' => 100,
+                    'station_from' => 'Updated Home',
+                    'station_to' => 'School',
+                    'cost' => 450,
+                    'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+                    'note' => 'kept',
+                ],
+            ],
+        ])->assertOk()->assertJson(['ok' => true]);
+
+        $pattern->refresh();
+        $this->assertSame('Updated Home', $pattern->closest_station);
+        $this->assertCount(1, $pattern->legs);
+        $this->assertSame(450, $pattern->legs()->firstOrFail()->cost);
+
+        $this->actingAs($user)
+            ->deleteJson(route('api.commute_patterns.destroy', $pattern))
+            ->assertOk()
+            ->assertJson(['ok' => true]);
+
+        $this->assertDatabaseMissing('commute_patterns', ['id' => $pattern->id]);
+        $this->assertDatabaseMissing('commute_pattern_legs', ['commute_pattern_id' => $pattern->id]);
+    }
+}

--- a/tests/Feature/GenerateMonthlyExpensesByPatternTest.php
+++ b/tests/Feature/GenerateMonthlyExpensesByPatternTest.php
@@ -6,9 +6,11 @@ use App\Enums\ExpenseCategory;
 use App\Enums\ExpenseReportStatus;
 use App\Enums\ExpenseTripType;
 use App\Models\CommutePattern;
+use App\Models\CommuterPass;
 use App\Models\EmploymentTerm;
 use App\Models\Expense;
 use App\Models\ExpenseReport;
+use App\Models\ScheduleLine;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -44,6 +46,37 @@ class GenerateMonthlyExpensesByPatternTest extends TestCase
             'type_code' => 'employee',
         ]);
 
+        ScheduleLine::create([
+            'user_id' => $user->id,
+            'dow' => 1,
+            'school_name' => 'School',
+            'start_time' => '09:00:00',
+            'end_time' => '17:00:00',
+            'effective_start' => '2026-05-01',
+            'effective_end' => '2026-05-31',
+            'total_minutes' => 480,
+        ]);
+
+        ScheduleLine::create([
+            'user_id' => $user->id,
+            'dow' => 3,
+            'school_name' => 'School',
+            'start_time' => '09:00:00',
+            'end_time' => '17:00:00',
+            'effective_start' => '2026-05-01',
+            'effective_end' => '2026-05-31',
+            'total_minutes' => 480,
+        ]);
+
+        CommuterPass::create([
+            'user_id' => $user->id,
+            'date_from' => '2026-05-06',
+            'date_to' => '2026-05-06',
+            'station_from' => 'Home',
+            'station_to' => 'School',
+            'cost' => 12000,
+        ]);
+
         $pattern = CommutePattern::create([
             'user_id' => $user->id,
             'submitted_at' => now('Asia/Tokyo'),
@@ -72,6 +105,16 @@ class GenerateMonthlyExpensesByPatternTest extends TestCase
             'cost' => 300,
             'trip_type' => ExpenseTripType::ONE_WAY->value,
             'note' => 'extra',
+        ]);
+
+        $pattern->legs()->create([
+            'dow' => 'Wed',
+            'seq' => 100,
+            'station_from' => 'Home',
+            'station_to' => 'School',
+            'cost' => 700,
+            'trip_type' => ExpenseTripType::ROUND_TRIP->value,
+            'note' => 'pass-covered',
         ]);
 
         $this->artisan('expenses:generate-monthly-by-pattern', [
@@ -117,6 +160,15 @@ class GenerateMonthlyExpensesByPatternTest extends TestCase
         $this->assertSame(0, $blankTuesday->cost);
         $this->assertSame(ExpenseTripType::ROUND_TRIP, $blankTuesday->trip_type);
         $this->assertSame(ExpenseCategory::REGULAR, $blankTuesday->category);
+
+        $blankPassDay = Expense::query()
+            ->where('expense_report_id', $report->id)
+            ->whereDate('expense_date', '2026-05-06')
+            ->firstOrFail();
+
+        $this->assertNull($blankPassDay->station_from);
+        $this->assertNull($blankPassDay->station_to);
+        $this->assertSame(0, $blankPassDay->cost);
     }
 
     public function test_pattern_api_creates_updates_syncs_and_deletes_pattern(): void


### PR DESCRIPTION
[交通費のパターン機能とそれをベースにした表の自動生成コマンドを追加](https://github.com/Jin6hara/LaravelSprout/pull/126/commits/c75b42d207ae4e03949586cc319ec1faff1bc64c)
## PR Summary

今回の実装では、月次交通費の自動生成に **通勤パターン** を利用できる仕組みを追加しました。

新たに `GenerateMonthlyExpensesByPattern` を追加し、対象日に有効な `commute_patterns` がある場合は、曜日別の `commute_pattern_legs` から交通費明細を作成します。
該当する通勤パターンがない日は、従来通り空の1行を作成します。

これにより、固定的な通勤ルートを持つユーザーについては、月次交通費明細をより自動的に生成できるようになりました。

---

## 技術概要

* `commute_patterns` を親テーブル、`commute_pattern_legs` を曜日別詳細テーブルとして追加
* `expenses/pattern.blade.php` に週単位の Pattern 編集画面を追加
* JSpreadsheet で Edit 画面に近い操作感の週次テーブルを実装
* Pattern の作成、更新、行同期、削除を API 経由で処理
* 月次生成の手動実行とスケジューラーを新コマンドへ切り替え
* Feature test で画面描画、Pattern CRUD、月次生成ロジックを検証

---

## 追加ファイル

### `app/Console/Commands/GenerateMonthlyExpensesByPattern.php`

有効な通勤パターンを参照して、月次交通費明細を生成する新 Artisan コマンドです。

対象日に有効な Pattern がある場合は、曜日に対応する `commute_pattern_legs` から明細を作成します。
Pattern が存在しない日については、従来通り空の交通費行を作成します。

---

### `app/Http/Controllers/CommutePatternController.php`

Pattern 編集画面の表示、保存 API、削除 API を担当します。

主な処理：

* Pattern 編集画面の表示
* Pattern の作成・更新
* 曜日別 leg 行の同期
* Pattern の削除

---

### `app/Models/CommutePattern.php`

`commute_patterns` 用モデルです。

ユーザーとの関連、曜日別明細行との関連を持ちます。

---

### `app/Models/CommutePatternLeg.php`

`commute_pattern_legs` 用モデルです。

曜日、出発地、到着地、金額、往復区分など、Pattern の曜日別明細を保持します。

---

### `app/Services/CommutingExpenses/CommutePatternService.php`

通勤 Pattern に関する共通処理を切り出しました。

主な役割：

* 有効期間内 Pattern の取得
* 曜日順ソート
* ユーザー別 Pattern 取得
* 月次生成処理からの Pattern 参照

---

### `database/migrations/2026_05_29_000002_create_commute_patterns_table.php`

通勤 Pattern 用の親子テーブルを追加しました。

追加内容：

* `commute_patterns`
* `commute_pattern_legs`
* 必要な index
* PostgreSQL 向け check 制約

---

### `resources/views/expenses/pattern.blade.php`

週単位の通勤 Pattern 編集画面です。

既存の交通費 Edit 画面のスタイル・操作感を踏襲し、JSpreadsheet による編集 UI を表示します。

---

### `public/js/commute-patterns.js`

Pattern 画面の JSpreadsheet 制御を担当します。

主な処理：

* 曜日行の表示
* 行追加
* 行削除
* 保存処理
* Pattern 削除処理
* API 通信

---

### `tests/Feature/GenerateMonthlyExpensesByPatternTest.php`

通勤 Pattern 対応の Feature test を追加しました。

主な検証内容：

* Pattern 画面描画
* Pattern API CRUD
* Pattern を使った月次交通費生成
* Pattern がない日の空行生成

---

## 修正ファイル

### `app/Console/Kernel.php`

毎月2日の自動生成コマンドを、新しい Pattern 対応コマンドへ切り替えました。

```php
expenses:generate-monthly-by-pattern
```

---

### `app/Http/Controllers/ExpenseEditController.php`

管理者の手動生成でも、Pattern 対応コマンドを呼ぶように変更しました。

---

### `app/Models/User.php`

ユーザーから通勤 Pattern を取得できるように、`commutePatterns()` リレーションを追加しました。

---

### `resources/views/expenses/edit.blade.php`

Pattern 画面への導線を追加しました。

また、管理者用の Route Declaration / Commuter Pass リンクについて、`$report` ではなく `$user` を渡す形に修正しました。
これにより、レポート未作成月でも安全にリンクを表示できます。

---

### `routes/web.php`

Pattern 画面ルートと、Pattern 保存・削除 API ルートを追加しました。

---

## 検証

以下のコマンドで Feature test を実行済みです。

```bash
docker exec -w /var/www/html/Jin_10 jin_app php artisan test
```

結果：

```text
197 passed (537 assertions)
```

---

## コミットメッセージ候補

```text
Add commute pattern based monthly expense generation
```

日本語：

```text
通勤パターンによる月次交通費自動生成を追加
```

---

## PRタイトル候補

```text
通勤パターンを利用した月次交通費自動生成を追加
```
