### PR TITLE
⭐️Daily Board (Shift Assigner Plus）

### DIFF
--- a/app/Http/Controllers/ApprovalController.php
+++ b/app/Http/Controllers/ApprovalController.php
@@ -6,12 +6,16 @@ use App\Enums\LeaveKind;
 use App\Models\ApprovalRequest;
 use App\Models\Leave;
 use App\Services\Approval\ApprovalService;
+use App\Services\Leave\GeneratedShiftDecisionService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class ApprovalController extends Controller
 {
-    public function __construct(private ApprovalService $approvalService) {}
+    public function __construct(
+        private ApprovalService $approvalService,
+        private GeneratedShiftDecisionService $generatedShiftDecision
+    ) {}
 
     /**
      * 承認リクエスト詳細表示
@@ -66,7 +70,7 @@ class ApprovalController extends Controller
                 }
             }
 
-            $generatedShiftDetails = $this->generatedShiftDetailsForApproval($approvalRequest);
+            $generatedShiftDetails = $this->generatedShiftDecision->detailsForApprovalRequest($approvalRequest);
         }
 
         return view('approvals.show', [
@@ -97,10 +101,10 @@ class ApprovalController extends Controller
     {
         $this->authorize('act', $approvalRequest);
 
-        $generatedShiftAction = $request->input('inactive_generated_shift_action');
-        $generatedShiftCount = $this->generatedShiftDetailsForApproval($approvalRequest)->count();
+        $generatedShiftAction = $this->generatedShiftActionFromRequest($request);
+        $generatedShiftCount = $this->generatedShiftDecision->detailsForApprovalRequest($approvalRequest)->count();
 
-        if ($generatedShiftCount > 0 && !in_array($generatedShiftAction, ['detach', 'delete'], true)) {
+        if ($generatedShiftCount > 0 && $this->generatedShiftDecision->normalizeAction($generatedShiftAction) === null) {
             return back()->with('toast_errors', [
                 'Please confirm what to do with generated shift(s) before denying this leave request.',
             ]);
@@ -116,55 +120,9 @@ class ApprovalController extends Controller
         return back()->with('toast', '却下しました。');
     }
 
-    private function generatedShiftDetailsForApproval(ApprovalRequest $approvalRequest)
+    private function generatedShiftActionFromRequest(Request $request): ?string
     {
-        $approvalRequest->loadMissing('approvable');
-        $approvable = $approvalRequest->approvable;
-
-        if (!$approvable instanceof Leave) {
-            return collect();
-        }
-
-        $meta = $approvalRequest->metadata ?? [];
-        $batchId = $meta['batch_id'] ?? null;
-
-        $leaves = collect([$approvable]);
-
-        if ($batchId) {
-            $leaves = ApprovalRequest::query()
-                ->where('approvable_type', Leave::class)
-                ->where('metadata->batch_id', $batchId)
-                ->with('approvable')
-                ->get()
-                ->pluck('approvable')
-                ->filter(fn($leave) => $leave instanceof Leave)
-                ->unique('id')
-                ->values();
-        }
-
-        $leaves->each->load([
-            'generatedEvents.originalUser:id,first_name,family_name,employee_code',
-            'generatedEvents.assignedUser:id,first_name,family_name,employee_code',
-        ]);
-
-        return $leaves
-            ->flatMap(fn(Leave $leave) => $leave->generatedEvents->map(function ($event) use ($leave) {
-                $original = trim(($event->originalUser?->first_name ?? '') . ' ' . ($event->originalUser?->family_name ?? ''));
-                $assigned = trim(($event->assignedUser?->first_name ?? '') . ' ' . ($event->assignedUser?->family_name ?? ''));
-
-                return [
-                    'leave_id' => $leave->id,
-                    'id' => $event->id,
-                    'date' => optional($event->event_date)->format('Y-m-d') ?: '-',
-                    'original' => $original !== '' ? $original : '-',
-                    'assigned' => $assigned !== '' ? $assigned : '-',
-                    'school' => $event->school_name ?: '-',
-                    'time' => trim(optional($event->start_time)->format('H:i') . ' - ' . optional($event->end_time)->format('H:i'), ' -') ?: '-',
-                    'lesson' => $event->Lesson ?: '-',
-                    'status' => $event->status ?: '-',
-                    'notes' => $event->notes ?: '-',
-                ];
-            }))
-            ->values();
+        return $request->input('generated_shift_action')
+            ?? $request->input('inactive_generated_shift_action');
     }
 }

--- a/app/Http/Controllers/ApprovalController.php
+++ b/app/Http/Controllers/ApprovalController.php
@@ -24,6 +24,7 @@ class ApprovalController extends Controller
         $meta       = $approvalRequest->metadata ?? [];
         $approvable = $approvalRequest->approvable;
         $dateSummary = null;
+        $generatedShiftDetails = collect();
 
         if ($approvable instanceof Leave) {
             $kind = $meta['kind'] ?? $approvable->kind ?? null;
@@ -64,11 +65,14 @@ class ApprovalController extends Controller
                     $dateSummary = $meta['date'] ?? optional($approvable->start_date)->format('Y-m-d') ?? '-';
                 }
             }
+
+            $generatedShiftDetails = $this->generatedShiftDetailsForApproval($approvalRequest);
         }
 
         return view('approvals.show', [
-            'approvalRequest' => $approvalRequest,
-            'dateSummary'     => $dateSummary,
+            'approvalRequest'       => $approvalRequest,
+            'dateSummary'           => $dateSummary,
+            'generatedShiftDetails' => $generatedShiftDetails,
         ]);
     }
 
@@ -93,8 +97,74 @@ class ApprovalController extends Controller
     {
         $this->authorize('act', $approvalRequest);
 
-        $this->approvalService->deny($approvalRequest, Auth::id(), $request->input('comment'));
+        $generatedShiftAction = $request->input('inactive_generated_shift_action');
+        $generatedShiftCount = $this->generatedShiftDetailsForApproval($approvalRequest)->count();
+
+        if ($generatedShiftCount > 0 && !in_array($generatedShiftAction, ['detach', 'delete'], true)) {
+            return back()->with('toast_errors', [
+                'Please confirm what to do with generated shift(s) before denying this leave request.',
+            ]);
+        }
+
+        $this->approvalService->deny(
+            $approvalRequest,
+            Auth::id(),
+            $request->input('comment'),
+            $generatedShiftAction
+        );
 
         return back()->with('toast', '却下しました。');
+    }
+
+    private function generatedShiftDetailsForApproval(ApprovalRequest $approvalRequest)
+    {
+        $approvalRequest->loadMissing('approvable');
+        $approvable = $approvalRequest->approvable;
+
+        if (!$approvable instanceof Leave) {
+            return collect();
+        }
+
+        $meta = $approvalRequest->metadata ?? [];
+        $batchId = $meta['batch_id'] ?? null;
+
+        $leaves = collect([$approvable]);
+
+        if ($batchId) {
+            $leaves = ApprovalRequest::query()
+                ->where('approvable_type', Leave::class)
+                ->where('metadata->batch_id', $batchId)
+                ->with('approvable')
+                ->get()
+                ->pluck('approvable')
+                ->filter(fn($leave) => $leave instanceof Leave)
+                ->unique('id')
+                ->values();
+        }
+
+        $leaves->each->load([
+            'generatedEvents.originalUser:id,first_name,family_name,employee_code',
+            'generatedEvents.assignedUser:id,first_name,family_name,employee_code',
+        ]);
+
+        return $leaves
+            ->flatMap(fn(Leave $leave) => $leave->generatedEvents->map(function ($event) use ($leave) {
+                $original = trim(($event->originalUser?->first_name ?? '') . ' ' . ($event->originalUser?->family_name ?? ''));
+                $assigned = trim(($event->assignedUser?->first_name ?? '') . ' ' . ($event->assignedUser?->family_name ?? ''));
+
+                return [
+                    'leave_id' => $leave->id,
+                    'id' => $event->id,
+                    'date' => optional($event->event_date)->format('Y-m-d') ?: '-',
+                    'original' => $original !== '' ? $original : '-',
+                    'assigned' => $assigned !== '' ? $assigned : '-',
+                    'school' => $event->school_name ?: '-',
+                    'time' => trim(optional($event->start_time)->format('H:i') . ' - ' . optional($event->end_time)->format('H:i'), ' -') ?: '-',
+                    'lesson' => $event->Lesson ?: '-',
+                    'status' => $event->status ?: '-',
+                    'notes' => $event->notes ?: '-',
+                ];
+            }))
+            ->values();
     }
 }

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -444,6 +444,13 @@ class EventAssignController extends Controller
     public function destroy(Request $request, Event $event)
     {
         $this->authorize('delete', $event);
+
+        if ($event->source_leave_id) {
+            return back()->with('toast_errors', [
+                'This shift is managed by an absence. Please edit the absence instead.',
+            ]);
+        }
+
         $event->delete();
         return back()->with('toast', 'Deleted');
     }

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -357,15 +357,19 @@ class EventAssignController extends Controller
         $ngCount = count($results) - $okCount;
 
         // ✅ JSON返却でもフラッシュを仕込む
-        $flash = $ngCount ? "一部保存に失敗しました（保存: {$okCount} / 失敗: {$ngCount}）" : "Updated {$okCount} shift(s).";
-        session()->flash('toast', $flash);
+        $flash = $ngCount
+            ? "Some shifts failed to save (saved: {$okCount} / failed: {$ngCount})."
+            : "Updated {$okCount} shift(s).";
+        if (! $request->headers->has('X-Daily-Board')) {
+            session()->flash('toast', $flash);
+        }
 
         return response()->json([
             'ok'      => $ngCount === 0,
             'updated' => $okCount,
             'failed'  => $ngCount,
             'results' => $results,
-            'message' => $ngCount ? '一部保存に失敗しました' : 'すべて保存しました',
+            'message' => $ngCount ? 'Some shifts failed to save.' : "Updated {$okCount} shift(s).",
         ]);
     }
 

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -138,6 +138,67 @@ class EventAssignController extends Controller
     }
 
     /**
+     * 単日カレンダーとイベント編集テーブルを同一画面で表示する
+     * GET /forecast/day-assigner — 指定日の Forecast List と Shift 編集行を同期して扱う
+     */
+    public function dailyBoard(Request $request)
+    {
+        $this->authorize('viewAny', Event::class);
+
+        try {
+            $selectedDate = Carbon::parse($request->input('date', now()->toDateString()))->toDateString();
+        } catch (\Throwable $e) {
+            $selectedDate = now()->toDateString();
+        }
+
+        $userOptions = $this->scopeService->targetUserQuery()
+            ->select('id', 'first_name', 'family_name', 'employee_code')
+            ->orderBy('employee_code')
+            ->limit(500)
+            ->get();
+
+        $schoolNames = $this->scopeService->schoolQuery()
+            ->where('is_active', true)
+            ->orderBy('school_name')
+            ->distinct()
+            ->pluck('school_name');
+
+        $events = Event::query()
+            ->where('district_id', $this->scopeService->currentDistrictId())
+            ->where('department_id', $this->scopeService->currentDepartmentId())
+            ->whereDate('event_date', $selectedDate)
+            ->with(['assignedUser:id,name,employee_code', 'originalUser:id,name,employee_code'])
+            ->orderBy('school_name')
+            ->orderBy('start_time')
+            ->orderBy('assigned_user_id')
+            ->get();
+
+        $statusOptions = [
+            EventStatus::Filled->value => EventStatus::Filled->label(),
+            EventStatus::Fixed->value => EventStatus::Fixed->label(),
+            EventStatus::Pending->value => EventStatus::Pending->label(),
+            EventStatus::InProcess->value => EventStatus::InProcess->label(),
+        ];
+        $typeOptions = [
+            ShiftType::RegularTime->value => ShiftType::RegularTime->short(),
+            ShiftType::Overtime->value => ShiftType::Overtime->short(),
+            ShiftType::ScheduleChange->value => ShiftType::ScheduleChange->short(),
+            ShiftType::Special->value => ShiftType::Special->short(),
+            ShiftType::RosteredWorkingDay->value => ShiftType::RosteredWorkingDay->short(),
+            ShiftType::NoneRequired->value => ShiftType::NoneRequired->short(),
+        ];
+
+        return view('calendar.dailyBoard', compact(
+            'events',
+            'userOptions',
+            'statusOptions',
+            'typeOptions',
+            'schoolNames',
+            'selectedDate'
+        ));
+    }
+
+    /**
      * イベントを複製して新規作成
      * POST /calendar/events/copy — バリデーション済みデータを元に時刻を正規化し、同スコープで新規 Event を作成
      */

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -6,6 +6,7 @@ use App\Enums\EventStatus;
 use App\Enums\ShiftType;
 use App\Http\Requests\EventAssign\BulkUpdateEventRequest;
 use App\Http\Requests\EventAssign\CopyEventRequest;
+use App\Http\Requests\EventAssign\StoreEventRequest;
 use App\Http\Requests\EventAssign\UpdateEventRequest;
 use App\Models\Event;
 use App\Models\User;
@@ -239,23 +240,61 @@ class EventAssignController extends Controller
      * 空の新規イベントを作成
      * POST /calendar/events — 指定日に pending・regular_time の空白イベントを生成して管理画面へ戻す
      */
-    public function store(Request $request)
+    public function store(StoreEventRequest $request)
     {
         $this->authorize('create', Event::class);
 
-        // リクエストやURLクエリから event_date を取得（POSTでもGETでも対応）
-        $date = $request->input('event_date', now()->toDateString());
+        $validated = $request->validated();
+        $date = $validated['event_date'];
+        $redirectUrl = $this->eventStoreRedirectUrl($request, $date);
 
-        // 空白イベントを作成
-        $event = Event::create([
-            'event_date'    => $date,
-            'status'        => EventStatus::Pending->value,
-            'type'          => ShiftType::RegularTime->value,
-            'district_id'   => $this->scopeService->currentDistrictId(),
-            'department_id' => $this->scopeService->currentDepartmentId(),
-        ]);
+        $originalUser = $this->resolveEventUser($request, 'original');
+        if (($request->filled('original_user_id') || $request->filled('original_user_lookup')) && ! $originalUser) {
+            return redirect()->to($redirectUrl)
+                ->withInput()
+                ->with('toast_errors', ['Original user not found. Please select a user from the suggestions.']);
+        }
 
-        return back()->with('toast', "Created shift at {$date}.");
+        $assignedUser = $this->resolveEventUser($request, 'assigned');
+        if (($request->filled('assigned_user_id') || $request->filled('assigned_user_lookup')) && ! $assignedUser) {
+            return redirect()->to($redirectUrl)
+                ->withInput()
+                ->with('toast_errors', ['Assigned user not found. Please select a user from the suggestions.']);
+        }
+
+        unset(
+            $validated['original_user_lookup'],
+            $validated['assigned_user_lookup'],
+            $validated['redirect_to']
+        );
+
+        $validated['original_user_id'] = $originalUser?->id;
+        $validated['assigned_user_id'] = $assignedUser?->id;
+        $validated['status'] = $validated['status'] ?? EventStatus::Pending->value;
+        $validated['type'] = $validated['type'] ?? ShiftType::RegularTime->value;
+
+        foreach (['start_time', 'end_time'] as $k) {
+            if (!empty($validated[$k])) {
+                $validated[$k] = Carbon::createFromFormat('H:i', $validated[$k])->format('H:i:s');
+            } else {
+                $validated[$k] = null;
+            }
+        }
+
+        if (empty($validated['total_duration']) && $validated['start_time'] && $validated['end_time']) {
+            $start = Carbon::createFromFormat('H:i:s', $validated['start_time']);
+            $end   = Carbon::createFromFormat('H:i:s', $validated['end_time']);
+            if ($end->lt($start)) $end->addDay();
+            $mins = $start->diffInMinutes($end);
+            $validated['total_duration'] = sprintf('%d:%02d', intdiv($mins, 60), $mins % 60);
+        }
+
+        $this->authorizeReferencedUsers($validated);
+        $validated['district_id']   = $this->scopeService->currentDistrictId();
+        $validated['department_id'] = $this->scopeService->currentDepartmentId();
+        Event::create($validated);
+
+        return redirect()->to($redirectUrl)->with('toast', "Created shift at {$date}.");
     }
 
     /**
@@ -691,6 +730,48 @@ class EventAssignController extends Controller
             $targetUser = User::findOrFail((int) $userId);
             $this->authorize('view', $targetUser);
         }
+    }
+
+    private function eventStoreRedirectUrl(StoreEventRequest $request, string $date): string
+    {
+        $redirectTo = (string) $request->input('redirect_to', '');
+        if ($redirectTo !== '' && str_starts_with($redirectTo, url('/'))) {
+            return $redirectTo;
+        }
+
+        return route('calendar.edit', ['event_date' => $date]);
+    }
+
+    private function resolveEventUser(StoreEventRequest $request, string $prefix): ?User
+    {
+        $userId = (int) $request->input("{$prefix}_user_id");
+        if ($userId > 0) {
+            return $this->scopeService->targetUserQuery()->whereKey($userId)->first();
+        }
+
+        $lookup = trim((string) $request->input("{$prefix}_user_lookup", ''));
+        if ($lookup === '') {
+            return null;
+        }
+
+        if (preg_match('/\[([^\]]+)\]\s*$/', $lookup, $m)) {
+            return $this->scopeService->targetUserQuery()
+                ->where('employee_code', trim($m[1]))
+                ->first();
+        }
+
+        $matches = $this->scopeService->targetUserQuery()
+            ->where(function ($q) use ($lookup) {
+                $q->whereLikeInsensitive('first_name', $lookup)
+                    ->orWhereLikeInsensitive('family_name', $lookup)
+                    ->orWhereLikeInsensitive('name', $lookup)
+                    ->orWhereLikeInsensitive('employee_code', $lookup)
+                    ->orWhereLikeInsensitive('email', $lookup);
+            })
+            ->limit(2)
+            ->get();
+
+        return $matches->count() === 1 ? $matches->first() : null;
     }
 
     /**

--- a/app/Http/Controllers/EventAssignController.php
+++ b/app/Http/Controllers/EventAssignController.php
@@ -267,6 +267,12 @@ class EventAssignController extends Controller
         $this->authorize('update', $event);
 
         $validated = $request->validated();
+        if ($this->hasUpdateConflict($event, $validated['updated_at'] ?? null)) {
+            return back()
+                ->withInput()
+                ->with('toast', 'Already updated by others. Please reload before saving.');
+        }
+        unset($validated['updated_at']);
 
         // ⬇︎ H:i または H:i:s を安全に H:i:s へ正規化（例外を出さない）
         $normalizeTime = function ($val) {
@@ -329,6 +335,17 @@ class EventAssignController extends Controller
             }
             $this->authorize('update', $event);
             $this->authorizeReferencedUsers($data);
+            if ($this->hasUpdateConflict($event, $data['updated_at'] ?? null)) {
+                $results[] = [
+                    'id' => $event->id,
+                    'ok' => false,
+                    'conflict' => true,
+                    'message' => 'Already updated by others. Please reload before saving.',
+                    'current_updated_at' => $this->eventUpdateToken($event),
+                ];
+                continue;
+            }
+            unset($data['updated_at']);
 
             // H:i → H:i:s に正規化
             foreach (['start_time', 'end_time'] as $k) {
@@ -350,15 +367,23 @@ class EventAssignController extends Controller
 
             $event->fill($data)->save(); // Observerがあれば最終整合を取ってくれます
 
-            $results[] = ['id' => $event->id, 'ok' => true];
+            $results[] = [
+                'id' => $event->id,
+                'ok' => true,
+                'updated_at' => $this->eventUpdateToken($event),
+            ];
         }
 
         $okCount = collect($results)->where('ok', true)->count();
         $ngCount = count($results) - $okCount;
+        $conflictCount = collect($results)->where('conflict', true)->count();
 
         // ✅ JSON返却でもフラッシュを仕込む
+        $failureMessage = $conflictCount
+            ? 'Some shifts were already updated by others. Please reload before saving.'
+            : 'Some shifts failed to save.';
         $flash = $ngCount
-            ? "Some shifts failed to save (saved: {$okCount} / failed: {$ngCount})."
+            ? "{$failureMessage} (saved: {$okCount} / failed: {$ngCount})."
             : "Updated {$okCount} shift(s).";
         if (! $request->headers->has('X-Daily-Board')) {
             session()->flash('toast', $flash);
@@ -369,7 +394,7 @@ class EventAssignController extends Controller
             'updated' => $okCount,
             'failed'  => $ngCount,
             'results' => $results,
-            'message' => $ngCount ? 'Some shifts failed to save.' : "Updated {$okCount} shift(s).",
+            'message' => $ngCount ? $failureMessage : "Updated {$okCount} shift(s).",
         ]);
     }
 
@@ -666,5 +691,22 @@ class EventAssignController extends Controller
             $targetUser = User::findOrFail((int) $userId);
             $this->authorize('view', $targetUser);
         }
+    }
+
+    /**
+     * 画面表示時の更新時刻と現在の更新時刻が違う場合は、古い画面からの保存として扱う
+     */
+    private function hasUpdateConflict(Event $event, ?string $submittedUpdatedAt): bool
+    {
+        if ($submittedUpdatedAt === null || $submittedUpdatedAt === '' || $event->updated_at === null) {
+            return false;
+        }
+
+        return $this->eventUpdateToken($event) !== Carbon::parse($submittedUpdatedAt)->format('Y-m-d H:i:s');
+    }
+
+    private function eventUpdateToken(Event $event): ?string
+    {
+        return $event->updated_at?->format('Y-m-d H:i:s');
     }
 }

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -43,12 +43,17 @@ class LeaveController extends Controller
     public function store(StoreLeaveRequest $request)
     {
         // 承認フローがある場合は pending から始めるなど調整してください
-        $targetUser = \App\Models\User::find((int) $request->input('user_id'));
-        abort_if(! $targetUser, 404);
+        $redirectUrl = $this->leaveStoreRedirectUrl($request, $request->input('start_date'));
+        $targetUser = $this->resolveLeaveTargetUser($request);
+        if (! $targetUser) {
+            return redirect()->to($redirectUrl)
+                ->withInput()
+                ->with('toast_errors', ['Target not found. Please select a user from the suggestions.']);
+        }
         $this->authorize('manage', $targetUser);
 
         $leave = Leave::create([
-            'user_id'       => (int)$request->input('user_id'),
+            'user_id'       => $targetUser->id,
             'start_date'    => $request->date('start_date'),
             'end_date'      => $request->input('end_date') ? $request->date('end_date') : null,
             'kind'          => $request->input('kind'),
@@ -67,8 +72,50 @@ class LeaveController extends Controller
         $date = optional($leave->start_date)->format('Y-m-d');
 
         // Observer が自動でスナップショット生成
-        return redirect()->to(route('calendar.edit') . '?event_date=' . urlencode($date))
+        return redirect()->to($this->leaveStoreRedirectUrl($request, $date))
             ->with('toast', 'Absence successfully registered. If a regular shift exists for that day, an Event will be created automatically.');
+    }
+
+    private function leaveStoreRedirectUrl(StoreLeaveRequest $request, ?string $date): string
+    {
+        $redirectTo = (string) $request->input('redirect_to', '');
+        if ($redirectTo !== '' && str_starts_with($redirectTo, url('/'))) {
+            return $redirectTo;
+        }
+
+        return route('calendar.edit') . '?event_date=' . urlencode((string) $date);
+    }
+
+    private function resolveLeaveTargetUser(StoreLeaveRequest $request): ?User
+    {
+        $userId = (int) $request->input('user_id');
+        if ($userId > 0) {
+            return $this->scopeService->targetUserQuery()->whereKey($userId)->first();
+        }
+
+        $lookup = trim((string) $request->input('user_lookup', ''));
+        if ($lookup === '') {
+            return null;
+        }
+
+        if (preg_match('/\[([^\]]+)\]\s*$/', $lookup, $m)) {
+            return $this->scopeService->targetUserQuery()
+                ->where('employee_code', trim($m[1]))
+                ->first();
+        }
+
+        $matches = $this->scopeService->targetUserQuery()
+            ->where(function ($q) use ($lookup) {
+                $q->whereLikeInsensitive('first_name', $lookup)
+                    ->orWhereLikeInsensitive('family_name', $lookup)
+                    ->orWhereLikeInsensitive('name', $lookup)
+                    ->orWhereLikeInsensitive('employee_code', $lookup)
+                    ->orWhereLikeInsensitive('email', $lookup);
+            })
+            ->limit(2)
+            ->get();
+
+        return $matches->count() === 1 ? $matches->first() : null;
     }
 
 

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -13,8 +13,10 @@ use App\Services\Leave\CancelLeaveService;
 use App\Services\Leave\ReportLeaveService;
 use App\Enums\LeaveExcused;
 use App\Enums\LeaveStatus;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 
 class LeaveController extends Controller
 {
@@ -123,11 +125,15 @@ class LeaveController extends Controller
      * 休暇申請の取消
      * 承認済みの場合は LeaveBalanceService で有給残を返戻する
      */
-    public function cancel(Leave $leave)
+    public function cancel(Request $request, Leave $leave)
     {
         $this->authorize('cancel', $leave);
 
-        $this->cancelService->handle($leave);
+        try {
+            $this->cancelService->handle($leave, $request->input('generated_shift_action'));
+        } catch (InvalidArgumentException $e) {
+            return back()->with('toast_errors', [$e->getMessage()]);
+        }
 
         return back()->with('toast', '申請を取り消しました。');
     }

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\LeaveManage\UpdateLeaveManageRequest;
 use App\Models\Leave;
 use App\Services\CurrentScopeService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 
 
@@ -68,7 +69,16 @@ class LeaveManageController extends Controller
 
         // 4) クエリ（Event版と同順序・構成）
         $leaves = Leave::query()
-            ->with(['user:id,first_name,family_name,employee_code'])
+            ->with([
+                'user:id,first_name,family_name,employee_code',
+                'generatedEvents' => fn($q) => $q
+                    ->with([
+                        'originalUser:id,first_name,family_name,employee_code',
+                        'assignedUser:id,first_name,family_name,employee_code',
+                    ])
+                    ->orderBy('event_date')
+                    ->orderBy('start_time'),
+            ])
             ->where('district_id', $this->scopeService->currentDistrictId())
             ->where('department_id', $this->scopeService->currentDepartmentId())
             ->when($leaveId,     fn($q) => $q->where('id', $leaveId)) // ★個別編集用パラメータ: leave_id があれば最優先で一意絞り込み
@@ -213,7 +223,20 @@ class LeaveManageController extends Controller
     {
         $this->authorize('delete', $leave);
 
-        $leave->delete();
+        $keepGeneratedShifts = $request->boolean('keep_generated_shifts');
+        $generatedShiftCount = $leave->generatedEvents()->count();
+
+        DB::transaction(function () use ($leave, $keepGeneratedShifts) {
+            if ($keepGeneratedShifts) {
+                $leave->generatedEvents()->update(['source_leave_id' => null]);
+            }
+
+            $leave->delete();
+        });
+
+        if ($keepGeneratedShifts && $generatedShiftCount > 0) {
+            return back()->with('toast', "Leave deleted. Kept {$generatedShiftCount} generated shift(s).");
+        }
 
         return back()->with('toast', 'Leave deleted.');
     }

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\LeaveManage\StoreLeaveManageRequest;
 use App\Http\Requests\LeaveManage\UpdateLeaveManageRequest;
 use App\Models\Leave;
 use App\Services\CurrentScopeService;
+use App\Services\Leave\GeneratedShiftDecisionService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
@@ -17,7 +18,10 @@ use Carbon\Carbon;
 
 class LeaveManageController extends Controller
 {
-    public function __construct(private CurrentScopeService $scopeService) {}
+    public function __construct(
+        private CurrentScopeService $scopeService,
+        private GeneratedShiftDecisionService $generatedShiftDecision
+    ) {}
 
     /**
      * Leaveの月次一覧（管理者用）
@@ -105,6 +109,11 @@ class LeaveManageController extends Controller
             ->paginate(24)
             ->withQueryString();
 
+        $generatedShiftDetailsByLeaveId = $leaves->getCollection()
+            ->mapWithKeys(fn(Leave $leave) => [
+                $leave->id => $this->generatedShiftDecision->detailsForLeave($leave),
+            ]);
+
         // 5) オプション
         $statusOptions = LeaveStatus::manageLabels();
         $kindOptions = LeaveKind::labels();
@@ -118,7 +127,8 @@ class LeaveManageController extends Controller
             'kindOptions',
             'excusedOptions',
             'fmtDate',
-            'fmtTime'
+            'fmtTime',
+            'generatedShiftDetailsByLeaveId'
         ));
     }
 
@@ -159,23 +169,22 @@ class LeaveManageController extends Controller
         $this->authorize('update', $leave);
 
         $data = $request->validated();
-        $inactiveGeneratedShiftAction = $data['inactive_generated_shift_action'] ?? null;
+        $generatedShiftAction = $data['generated_shift_action']
+            ?? $data['inactive_generated_shift_action']
+            ?? null;
+        unset($data['generated_shift_action']);
         unset($data['inactive_generated_shift_action']);
 
         $targetUser = \App\Models\User::findOrFail((int) $data['user_id']);
         $this->authorize('manage', $targetUser);
 
-        if (
-            !in_array($data['status'], LeaveStatus::snapshotValues(), true)
-            && $leave->generatedEvents()->exists()
-            && !in_array($inactiveGeneratedShiftAction, ['detach', 'delete'], true)
-        ) {
+        if ($this->generatedShiftDecision->requiresActionForStatus($leave, $data['status'], $generatedShiftAction)) {
             return back()->with('toast_errors', [
                 'Please confirm what to do with the generated shift(s) before changing this absence status.',
             ]);
         }
 
-        $leave->generatedShiftInactiveAction = $inactiveGeneratedShiftAction;
+        $leave->generatedShiftAction = $this->generatedShiftDecision->normalizeAction($generatedShiftAction);
         $leave->fill($data);
         $leave->save();
 
@@ -193,15 +202,12 @@ class LeaveManageController extends Controller
         $validated = $request->validated();
 
         foreach ($validated['items'] as $it) {
-            if (in_array($it['status'], LeaveStatus::snapshotValues(), true)) {
-                continue;
-            }
-
             $leave = Leave::findOrFail($it['id']);
-            if (
-                $leave->generatedEvents()->exists()
-                && !in_array($it['inactive_generated_shift_action'] ?? null, ['detach', 'delete'], true)
-            ) {
+            $generatedShiftAction = $it['generated_shift_action']
+                ?? $it['inactive_generated_shift_action']
+                ?? null;
+
+            if ($this->generatedShiftDecision->requiresActionForStatus($leave, $it['status'], $generatedShiftAction)) {
                 return response()->json([
                     'ok'      => false,
                     'updated' => 0,
@@ -219,7 +225,10 @@ class LeaveManageController extends Controller
             $targetUser = \App\Models\User::findOrFail((int) $it['user_id']);
             $this->authorize('manage', $targetUser);
 
-            $leave->generatedShiftInactiveAction = $it['inactive_generated_shift_action'] ?? null;
+            $generatedShiftAction = $it['generated_shift_action']
+                ?? $it['inactive_generated_shift_action']
+                ?? null;
+            $leave->generatedShiftAction = $this->generatedShiftDecision->normalizeAction($generatedShiftAction);
             $leave->fill([
                 'user_id'     => $it['user_id'],
                 'start_date'  => $it['start_date'],
@@ -257,18 +266,20 @@ class LeaveManageController extends Controller
     {
         $this->authorize('delete', $leave);
 
-        $keepGeneratedShifts = $request->boolean('keep_generated_shifts');
+        $generatedShiftAction = $request->input('generated_shift_action');
+        if (!$generatedShiftAction && $request->boolean('keep_generated_shifts')) {
+            $generatedShiftAction = GeneratedShiftDecisionService::ACTION_DETACH;
+        }
+        $generatedShiftAction = $this->generatedShiftDecision->normalizeAction($generatedShiftAction)
+            ?? GeneratedShiftDecisionService::ACTION_DELETE;
         $generatedShiftCount = $leave->generatedEvents()->count();
 
-        DB::transaction(function () use ($leave, $keepGeneratedShifts) {
-            if ($keepGeneratedShifts) {
-                $leave->generatedEvents()->update(['source_leave_id' => null]);
-            }
-
+        DB::transaction(function () use ($leave, $generatedShiftAction) {
+            $this->generatedShiftDecision->applyAction($leave, $generatedShiftAction);
             $leave->delete();
         });
 
-        if ($keepGeneratedShifts && $generatedShiftCount > 0) {
+        if ($generatedShiftAction === GeneratedShiftDecisionService::ACTION_DETACH && $generatedShiftCount > 0) {
             return back()->with('toast', "Leave deleted. Kept {$generatedShiftCount} generated shift(s).");
         }
 

--- a/app/Http/Controllers/LeaveManageController.php
+++ b/app/Http/Controllers/LeaveManageController.php
@@ -159,9 +159,23 @@ class LeaveManageController extends Controller
         $this->authorize('update', $leave);
 
         $data = $request->validated();
+        $inactiveGeneratedShiftAction = $data['inactive_generated_shift_action'] ?? null;
+        unset($data['inactive_generated_shift_action']);
+
         $targetUser = \App\Models\User::findOrFail((int) $data['user_id']);
         $this->authorize('manage', $targetUser);
 
+        if (
+            !in_array($data['status'], LeaveStatus::snapshotValues(), true)
+            && $leave->generatedEvents()->exists()
+            && !in_array($inactiveGeneratedShiftAction, ['detach', 'delete'], true)
+        ) {
+            return back()->with('toast_errors', [
+                'Please confirm what to do with the generated shift(s) before changing this absence status.',
+            ]);
+        }
+
+        $leave->generatedShiftInactiveAction = $inactiveGeneratedShiftAction;
         $leave->fill($data);
         $leave->save();
 
@@ -178,6 +192,25 @@ class LeaveManageController extends Controller
 
         $validated = $request->validated();
 
+        foreach ($validated['items'] as $it) {
+            if (in_array($it['status'], LeaveStatus::snapshotValues(), true)) {
+                continue;
+            }
+
+            $leave = Leave::findOrFail($it['id']);
+            if (
+                $leave->generatedEvents()->exists()
+                && !in_array($it['inactive_generated_shift_action'] ?? null, ['detach', 'delete'], true)
+            ) {
+                return response()->json([
+                    'ok'      => false,
+                    'updated' => 0,
+                    'failed'  => 1,
+                    'message' => 'Please use individual Save and confirm what to do with generated shift(s) before changing an absence to Rejected or Cancelled.',
+                ], 422);
+            }
+        }
+
         // 一括反映
         foreach ($validated['items'] as $it) {
             $leave = Leave::findOrFail($it['id']);
@@ -186,6 +219,7 @@ class LeaveManageController extends Controller
             $targetUser = \App\Models\User::findOrFail((int) $it['user_id']);
             $this->authorize('manage', $targetUser);
 
+            $leave->generatedShiftInactiveAction = $it['inactive_generated_shift_action'] ?? null;
             $leave->fill([
                 'user_id'     => $it['user_id'],
                 'start_date'  => $it['start_date'],

--- a/app/Http/Requests/EventAssign/BulkUpdateEventRequest.php
+++ b/app/Http/Requests/EventAssign/BulkUpdateEventRequest.php
@@ -25,6 +25,7 @@ class BulkUpdateEventRequest extends FormRequest
     {
         return [
             'id'               => ['required', 'integer', 'exists:events,id'],
+            'updated_at'       => ['required', 'date_format:Y-m-d H:i:s'],
             'event_date'       => ['required', 'date'],
             'original_user_id' => ['nullable', 'exists:users,id'],
             'Leave_type'       => ['nullable', 'string'],

--- a/app/Http/Requests/EventAssign/StoreEventRequest.php
+++ b/app/Http/Requests/EventAssign/StoreEventRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\EventAssign;
+
+use App\Enums\EventStatus;
+use App\Enums\ShiftType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreEventRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'event_date'            => ['required', 'date'],
+            'original_user_id'      => ['nullable', 'integer'],
+            'original_user_lookup'  => ['nullable', 'string', 'max:255'],
+            'Leave_type'            => ['nullable', 'string'],
+            'title'                 => ['nullable', 'string', 'max:255'],
+            'school_name'           => ['nullable', 'string', 'max:255'],
+            'start_time'            => ['nullable', 'date_format:H:i'],
+            'end_time'              => ['nullable', 'date_format:H:i'],
+            'total_duration'        => ['nullable', 'regex:/^\d{1,2}:\d{2}$/'],
+            'Lesson'                => ['nullable', 'string'],
+            'assigned_user_id'      => ['nullable', 'integer'],
+            'assigned_user_lookup'  => ['nullable', 'string', 'max:255'],
+            'status'                => ['nullable', Rule::in(EventStatus::values())],
+            'type'                  => ['nullable', Rule::in(ShiftType::values())],
+            'notes'                 => ['nullable', 'string'],
+            'redirect_to'           => ['nullable', 'string', 'max:2048'],
+        ];
+    }
+}

--- a/app/Http/Requests/EventAssign/UpdateEventRequest.php
+++ b/app/Http/Requests/EventAssign/UpdateEventRequest.php
@@ -18,6 +18,7 @@ class UpdateEventRequest extends FormRequest
     {
         return [
             'event_date'       => ['required', 'date'],
+            'updated_at'       => ['nullable', 'date_format:Y-m-d H:i:s'],
             'original_user_id' => ['nullable', 'exists:users,id'],
             'Leave_type'       => ['nullable', 'string'],
             'title'            => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/Leave/StoreLeaveRequest.php
+++ b/app/Http/Requests/Leave/StoreLeaveRequest.php
@@ -18,7 +18,8 @@ class StoreLeaveRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id'      => ['required', 'exists:users,id'],
+            'user_id'      => ['nullable', 'integer'],
+            'user_lookup'  => ['nullable', 'string', 'max:255'],
             'start_date'   => ['required', 'date'],
             'end_date'     => ['nullable', 'date', 'after_or_equal:start_date'],
             'kind'         => ['required', Rule::in(LeaveKind::storeValues())],
@@ -28,6 +29,7 @@ class StoreLeaveRequest extends FormRequest
             'time_start'   => ['nullable', 'date_format:H:i'],
             'time_end'     => ['nullable', 'date_format:H:i', 'after:time_start'],
             'status'       => ['nullable', Rule::in(LeaveStatus::storeValues())],
+            'redirect_to'  => ['nullable', 'string', 'max:2048'],
         ];
     }
 }

--- a/app/Http/Requests/LeaveManage/BulkUpdateLeaveManageRequest.php
+++ b/app/Http/Requests/LeaveManage/BulkUpdateLeaveManageRequest.php
@@ -32,6 +32,7 @@ class BulkUpdateLeaveManageRequest extends FormRequest
             'items.*.time_end'     => ['nullable', 'date_format:H:i', 'required_with:items.*.time_start'],
             'items.*.handle_type'  => ['nullable', 'string'],
             'items.*.status'       => ['required', Rule::in(LeaveStatus::values())],
+            'items.*.generated_shift_action' => ['nullable', Rule::in(['detach', 'delete'])],
             'items.*.inactive_generated_shift_action' => ['nullable', Rule::in(['detach', 'delete'])],
         ];
     }

--- a/app/Http/Requests/LeaveManage/BulkUpdateLeaveManageRequest.php
+++ b/app/Http/Requests/LeaveManage/BulkUpdateLeaveManageRequest.php
@@ -32,6 +32,7 @@ class BulkUpdateLeaveManageRequest extends FormRequest
             'items.*.time_end'     => ['nullable', 'date_format:H:i', 'required_with:items.*.time_start'],
             'items.*.handle_type'  => ['nullable', 'string'],
             'items.*.status'       => ['required', Rule::in(LeaveStatus::values())],
+            'items.*.inactive_generated_shift_action' => ['nullable', Rule::in(['detach', 'delete'])],
         ];
     }
 

--- a/app/Http/Requests/LeaveManage/UpdateLeaveManageRequest.php
+++ b/app/Http/Requests/LeaveManage/UpdateLeaveManageRequest.php
@@ -30,6 +30,7 @@ class UpdateLeaveManageRequest extends FormRequest
             'time_end'     => ['nullable', 'date_format:H:i', 'required_with:time_start'],
             'handle_type'  => ['nullable', 'string'],
             'status'       => ['required', Rule::in(LeaveStatus::values())],
+            'generated_shift_action' => ['nullable', Rule::in(['detach', 'delete'])],
             'inactive_generated_shift_action' => ['nullable', Rule::in(['detach', 'delete'])],
         ];
     }

--- a/app/Http/Requests/LeaveManage/UpdateLeaveManageRequest.php
+++ b/app/Http/Requests/LeaveManage/UpdateLeaveManageRequest.php
@@ -30,6 +30,7 @@ class UpdateLeaveManageRequest extends FormRequest
             'time_end'     => ['nullable', 'date_format:H:i', 'required_with:time_start'],
             'handle_type'  => ['nullable', 'string'],
             'status'       => ['required', Rule::in(LeaveStatus::values())],
+            'inactive_generated_shift_action' => ['nullable', Rule::in(['detach', 'delete'])],
         ];
     }
 

--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -10,6 +10,7 @@ use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 class Leave extends Model
@@ -43,6 +44,11 @@ class Leave extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function generatedEvents(): HasMany
+    {
+        return $this->hasMany(Event::class, 'source_leave_id');
     }
 
     public function scopeApproved(Builder $q): Builder

--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -17,7 +17,7 @@ class Leave extends Model
 {
     use HasFactory;
 
-    public ?string $generatedShiftInactiveAction = null;
+    public ?string $generatedShiftAction = null;
 
     protected $fillable = [
         'user_id',

--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -17,6 +17,8 @@ class Leave extends Model
 {
     use HasFactory;
 
+    public ?string $generatedShiftInactiveAction = null;
+
     protected $fillable = [
         'user_id',
         'start_date',

--- a/app/Services/Approval/ApprovalService.php
+++ b/app/Services/Approval/ApprovalService.php
@@ -67,7 +67,7 @@ class ApprovalService
             ]);
             $approvalRequest->update(['current_state' => 'rejected']);
             if ($approvable instanceof Leave) {
-                $approvable->generatedShiftInactiveAction = $generatedShiftAction;
+                $approvable->generatedShiftAction = $generatedShiftAction;
             }
             $approvable->update([
                 'status' => $approvable instanceof Leave ? LeaveStatus::Rejected->value : 'rejected',
@@ -112,7 +112,7 @@ class ApprovalService
 
             $req->actions()->create(['actor_id' => $actorId, 'action' => 'rejected', 'comment' => $comment]);
             $req->update(['current_state' => 'rejected']);
-            $leave->generatedShiftInactiveAction = $generatedShiftAction;
+            $leave->generatedShiftAction = $generatedShiftAction;
             $leave->update(['status' => LeaveStatus::Rejected->value]);
         }
     }

--- a/app/Services/Approval/ApprovalService.php
+++ b/app/Services/Approval/ApprovalService.php
@@ -44,14 +44,19 @@ class ApprovalService
         });
     }
 
-    public function deny(ApprovalRequest $approvalRequest, int $actorId, ?string $comment): void
+    public function deny(
+        ApprovalRequest $approvalRequest,
+        int $actorId,
+        ?string $comment,
+        ?string $generatedShiftAction = null
+    ): void
     {
-        DB::transaction(function () use ($approvalRequest, $actorId, $comment) {
+        DB::transaction(function () use ($approvalRequest, $actorId, $comment, $generatedShiftAction) {
             $meta       = $approvalRequest->metadata ?? [];
             $approvable = $approvalRequest->approvable;
 
             if ($approvable instanceof Leave && !empty($meta['batch_id'])) {
-                $this->denyBatch($meta['batch_id'], $actorId, $comment);
+                $this->denyBatch($meta['batch_id'], $actorId, $comment, $generatedShiftAction);
                 return;
             }
 
@@ -61,7 +66,10 @@ class ApprovalService
                 'comment'  => $comment,
             ]);
             $approvalRequest->update(['current_state' => 'rejected']);
-            $approvalRequest->approvable->update([
+            if ($approvable instanceof Leave) {
+                $approvable->generatedShiftInactiveAction = $generatedShiftAction;
+            }
+            $approvable->update([
                 'status' => $approvable instanceof Leave ? LeaveStatus::Rejected->value : 'rejected',
             ]);
         });
@@ -88,7 +96,7 @@ class ApprovalService
         }
     }
 
-    private function denyBatch(string $batchId, int $actorId, ?string $comment): void
+    private function denyBatch(string $batchId, int $actorId, ?string $comment, ?string $generatedShiftAction = null): void
     {
         $allRequests = ApprovalRequest::query()
             ->where('approvable_type', Leave::class)
@@ -104,6 +112,7 @@ class ApprovalService
 
             $req->actions()->create(['actor_id' => $actorId, 'action' => 'rejected', 'comment' => $comment]);
             $req->update(['current_state' => 'rejected']);
+            $leave->generatedShiftInactiveAction = $generatedShiftAction;
             $leave->update(['status' => LeaveStatus::Rejected->value]);
         }
     }

--- a/app/Services/Calendar/LeaveSnapshotService.php
+++ b/app/Services/Calendar/LeaveSnapshotService.php
@@ -9,12 +9,15 @@ use App\Models\Event;
 use App\Models\EventDetail;
 use App\Models\Leave;
 use App\Models\ScheduleLine;
+use App\Services\Leave\GeneratedShiftDecisionService;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 
 class LeaveSnapshotService
 {
+    public function __construct(private GeneratedShiftDecisionService $generatedShiftDecision) {}
+
     /**
      * Leaveに紐づくスナップショットを再生成
      */
@@ -22,12 +25,10 @@ class LeaveSnapshotService
     {
         DB::transaction(function () use ($leave) {
             if (!in_array($leave->status, LeaveStatus::snapshotValues(), true)) {
-                if ($leave->generatedShiftInactiveAction === 'delete') {
-                    $this->deleteSnapshotsForLeave($leave);
-                    return;
-                }
-
-                $this->detachSnapshotsForLeave($leave);
+                $this->generatedShiftDecision->applyAction(
+                    $leave,
+                    $leave->generatedShiftAction ?: GeneratedShiftDecisionService::ACTION_DETACH
+                );
                 return;
             }
 
@@ -50,10 +51,7 @@ class LeaveSnapshotService
      */
     public function deleteSnapshotsForLeave(Leave $leave): void
     {
-        // source_leave_id 紐付きイベントを物理削除（SoftDeletesなら ->forceDelete() でも可）
-        Event::query()
-            ->where('source_leave_id', $leave->id)
-            ->delete(); // EventDetail は FK cascade で自動削除
+        $this->generatedShiftDecision->applyAction($leave, GeneratedShiftDecisionService::ACTION_DELETE);
     }
 
     /**
@@ -61,9 +59,7 @@ class LeaveSnapshotService
      */
     public function detachSnapshotsForLeave(Leave $leave): void
     {
-        Event::query()
-            ->where('source_leave_id', $leave->id)
-            ->update(['source_leave_id' => null]);
+        $this->generatedShiftDecision->applyAction($leave, GeneratedShiftDecisionService::ACTION_DETACH);
     }
 
     /**

--- a/app/Services/Calendar/LeaveSnapshotService.php
+++ b/app/Services/Calendar/LeaveSnapshotService.php
@@ -21,11 +21,18 @@ class LeaveSnapshotService
     public function rebuildSnapshotsForLeave(Leave $leave): void
     {
         DB::transaction(function () use ($leave) {
+            if (!in_array($leave->status, LeaveStatus::snapshotValues(), true)) {
+                if ($leave->generatedShiftInactiveAction === 'delete') {
+                    $this->deleteSnapshotsForLeave($leave);
+                    return;
+                }
+
+                $this->detachSnapshotsForLeave($leave);
+                return;
+            }
+
             // まず既存のスナップショットを消す（冪等性）
             $this->deleteSnapshotsForLeave($leave);
-
-            // Approved, Pendingの場合生成（ポリシーは要件に合わせて）
-            if (!in_array($leave->status, LeaveStatus::snapshotValues(), true)) return;
 
             // 期間生成（end_date が null の場合は単日）
             $start = Carbon::parse($leave->start_date);
@@ -47,6 +54,16 @@ class LeaveSnapshotService
         Event::query()
             ->where('source_leave_id', $leave->id)
             ->delete(); // EventDetail は FK cascade で自動削除
+    }
+
+    /**
+     * Leave が Rejected / Cancelled などになった場合、紐づく Event は削除せず手動シフトとして残す
+     */
+    public function detachSnapshotsForLeave(Leave $leave): void
+    {
+        Event::query()
+            ->where('source_leave_id', $leave->id)
+            ->update(['source_leave_id' => null]);
     }
 
     /**

--- a/app/Services/Leave/CancelLeaveService.php
+++ b/app/Services/Leave/CancelLeaveService.php
@@ -5,19 +5,35 @@ namespace App\Services\Leave;
 use App\Enums\LeaveStatus;
 use App\Models\Leave;
 use App\Services\LeaveBalanceService;
+use InvalidArgumentException;
 use Illuminate\Support\Facades\DB;
 
 class CancelLeaveService
 {
-    public function handle(Leave $leave): void
-    {
-        DB::transaction(function () use ($leave) {
-            $wasApproved = $leave->status === LeaveStatus::Approved->value;
+    public function __construct(
+        private GeneratedShiftDecisionService $generatedShiftDecision,
+        private LeaveBalanceService $leaveBalanceService
+    ) {}
 
+    public function handle(Leave $leave, ?string $generatedShiftAction = null): void
+    {
+        DB::transaction(function () use ($leave, $generatedShiftAction) {
+            $wasApproved = $leave->status === LeaveStatus::Approved->value;
+            $normalizedAction = $this->generatedShiftDecision->normalizeAction($generatedShiftAction);
+
+            if ($this->generatedShiftDecision->hasGeneratedShifts($leave)) {
+                if (!$normalizedAction) {
+                    throw new InvalidArgumentException('Generated shift action is required before cancelling this leave.');
+                }
+
+                $this->generatedShiftDecision->applyAction($leave, $normalizedAction);
+            }
+
+            $leave->generatedShiftAction = $normalizedAction;
             $leave->update(['status' => LeaveStatus::Cancelled->value]);
 
             if ($wasApproved) {
-                app(LeaveBalanceService::class)->revert($leave);
+                $this->leaveBalanceService->revert($leave);
             }
         });
     }

--- a/app/Services/Leave/GeneratedShiftDecisionService.php
+++ b/app/Services/Leave/GeneratedShiftDecisionService.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Services\Leave;
+
+use App\Enums\LeaveStatus;
+use App\Models\ApprovalRequest;
+use App\Models\Leave;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+class GeneratedShiftDecisionService
+{
+    public const ACTION_DETACH = 'detach';
+    public const ACTION_DELETE = 'delete';
+
+    public function normalizeAction(?string $action): ?string
+    {
+        return in_array($action, [self::ACTION_DETACH, self::ACTION_DELETE], true)
+            ? $action
+            : null;
+    }
+
+    public function hasGeneratedShifts(Leave $leave): bool
+    {
+        return $leave->generatedEvents()->exists();
+    }
+
+    public function requiresActionForStatus(Leave $leave, string $status, ?string $action): bool
+    {
+        return !in_array($status, LeaveStatus::snapshotValues(), true)
+            && $this->hasGeneratedShifts($leave)
+            && $this->normalizeAction($action) === null;
+    }
+
+    public function applyAction(Leave $leave, string $action): int
+    {
+        $action = $this->normalizeAction($action);
+
+        if ($action === self::ACTION_DELETE) {
+            return $leave->generatedEvents()->delete();
+        }
+
+        if ($action === self::ACTION_DETACH) {
+            return $leave->generatedEvents()->update(['source_leave_id' => null]);
+        }
+
+        throw new InvalidArgumentException('Invalid generated shift action.');
+    }
+
+    public function detailsForLeave(Leave $leave): Collection
+    {
+        $leave->loadMissing([
+            'generatedEvents.originalUser:id,first_name,family_name,employee_code',
+            'generatedEvents.assignedUser:id,first_name,family_name,employee_code',
+        ]);
+
+        return $leave->generatedEvents
+            ->sortBy([
+                ['event_date', 'asc'],
+                ['start_time', 'asc'],
+            ])
+            ->map(fn($event) => $this->eventDetails($leave, $event))
+            ->values();
+    }
+
+    public function detailsForApprovalRequest(ApprovalRequest $approvalRequest): Collection
+    {
+        return $this->leavesForApprovalRequest($approvalRequest)
+            ->flatMap(fn(Leave $leave) => $this->detailsForLeave($leave))
+            ->values();
+    }
+
+    public function leavesForApprovalRequest(ApprovalRequest $approvalRequest): Collection
+    {
+        $approvalRequest->loadMissing('approvable');
+        $approvable = $approvalRequest->approvable;
+
+        if (!$approvable instanceof Leave) {
+            return collect();
+        }
+
+        $batchId = $approvalRequest->metadata['batch_id'] ?? null;
+
+        if (!$batchId) {
+            return collect([$approvable]);
+        }
+
+        return ApprovalRequest::query()
+            ->where('approvable_type', Leave::class)
+            ->where('metadata->batch_id', $batchId)
+            ->with('approvable')
+            ->get()
+            ->pluck('approvable')
+            ->filter(fn($leave) => $leave instanceof Leave)
+            ->unique('id')
+            ->values();
+    }
+
+    private function eventDetails(Leave $leave, $event): array
+    {
+        $original = trim(($event->originalUser?->first_name ?? '') . ' ' . ($event->originalUser?->family_name ?? ''));
+        $assigned = trim(($event->assignedUser?->first_name ?? '') . ' ' . ($event->assignedUser?->family_name ?? ''));
+
+        return [
+            'leave_id' => $leave->id,
+            'id' => $event->id,
+            'date' => optional($event->event_date)->format('Y-m-d') ?: '-',
+            'original' => $original !== '' ? $original : '-',
+            'assigned' => $assigned !== '' ? $assigned : '-',
+            'school' => $event->school_name ?: '-',
+            'time' => trim(optional($event->start_time)->format('H:i') . ' - ' . optional($event->end_time)->format('H:i'), ' -') ?: '-',
+            'lesson' => $event->Lesson ?: '-',
+            'status' => $event->status ?: '-',
+            'notes' => $event->notes ?: '-',
+        ];
+    }
+}

--- a/public/css/daily-shift-board.css
+++ b/public/css/daily-shift-board.css
@@ -222,6 +222,24 @@
   border-color: #9eeaf9;
 }
 
+.dsb-sub-pill--assigned-once {
+  background: #d1e7dd;
+  border-color: #75b798;
+}
+
+.dsb-sub-pill--assigned-multiple {
+  background: #a7f3d0;
+  border-color: #10b981;
+}
+
+.dsb-sub-assigned-count {
+  margin-top: 2px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: #14532d;
+  line-height: 1;
+}
+
 .dsb-sub-time {
   font-size: 0.68rem;
   color: #6c757d;

--- a/public/css/daily-shift-board.css
+++ b/public/css/daily-shift-board.css
@@ -9,14 +9,34 @@
 
 .dsb-top-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 280px;
-  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) 10px var(--dsb-sub-width, 420px);
+  gap: 0.35rem;
   align-items: stretch;
 }
 
 .dsb-calendar-section,
 .dsb-sub-section {
   min-width: 0;
+}
+
+.dsb-width-handle {
+  align-self: stretch;
+  margin-top: 28px;
+  min-height: 180px;
+  background: #dee2e6;
+  border-left: 1px solid #adb5bd;
+  border-right: 1px solid #adb5bd;
+  cursor: ew-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.dsb-width-grip {
+  color: #6c757d;
+  font-size: 0.75rem;
+  line-height: 1;
 }
 
 .dsb-section-head {
@@ -328,6 +348,10 @@
 @media (max-width: 992px) {
   .dsb-top-grid {
     grid-template-columns: 1fr;
+  }
+
+  .dsb-width-handle {
+    display: none;
   }
 
   .dsb-sub-summary {

--- a/public/css/daily-shift-board.css
+++ b/public/css/daily-shift-board.css
@@ -1,0 +1,182 @@
+.daily-shift-board {
+  font-size: 0.86rem;
+}
+
+.dsb-date-form {
+  border-bottom: 1px solid #dee2e6;
+  padding-bottom: 0.5rem;
+}
+
+.dsb-top-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.dsb-calendar-section,
+.dsb-sub-section {
+  min-width: 0;
+}
+
+.dsb-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 28px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #333;
+  border-bottom: 1px solid #adb5bd;
+  margin-bottom: 0.3rem;
+}
+
+.dsb-calendar-pane {
+  height: 320px;
+  min-height: 180px;
+  max-height: 78vh;
+  overflow: auto;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  padding: 0.35rem;
+  background: #fff;
+}
+
+#dailyCalendar {
+  min-width: 680px;
+}
+
+.dsb-sub-summary {
+  height: 320px;
+  min-height: 180px;
+  max-height: 78vh;
+  overflow: auto;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  padding: 0.5rem;
+  background: #f8f9fa;
+}
+
+.dsb-sub-group {
+  margin-bottom: 0.75rem;
+}
+
+.dsb-sub-group-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #6c757d;
+  text-transform: uppercase;
+  margin-bottom: 0.2rem;
+}
+
+.dsb-sub-pill {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin: 0 0.2rem 0.25rem 0;
+  padding: 0.14rem 0.38rem;
+  border-radius: 4px;
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  line-height: 1.15;
+}
+
+.dsb-sub-pill--absent {
+  background: #cff4fc;
+  border-color: #9eeaf9;
+}
+
+.dsb-sub-time {
+  font-size: 0.68rem;
+  color: #6c757d;
+}
+
+.dsb-resize-handle {
+  height: 10px;
+  margin: 0.35rem 0;
+  background: #dee2e6;
+  border-top: 1px solid #adb5bd;
+  border-bottom: 1px solid #adb5bd;
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.dsb-resize-grip {
+  font-size: 0.6rem;
+  color: #6c757d;
+  letter-spacing: 1px;
+  line-height: 1;
+}
+
+.dsb-editor-pane {
+  height: 430px;
+  min-height: 180px;
+  max-height: 78vh;
+  overflow: auto;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.daily-shift-table {
+  font-size: 0.8125rem;
+  margin-bottom: 0;
+}
+
+.daily-shift-table th,
+.daily-shift-table td {
+  padding: 0.25rem 0.35rem;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.daily-shift-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.daily-shift-table .form-control-sm,
+.daily-shift-table .form-select-sm {
+  min-height: 28px;
+  padding-top: 0.15rem;
+  padding-bottom: 0.15rem;
+  font-size: 0.8125rem;
+}
+
+.daily-shift-table textarea.form-control-sm {
+  resize: vertical;
+  min-height: 28px;
+}
+
+.daily-shift-table .btn-sm {
+  padding: 0.15rem 0.35rem;
+  font-size: 0.75rem;
+}
+
+.js-daily-event-row.is-saving {
+  opacity: 0.72;
+}
+
+.js-daily-event-row.is-saved {
+  outline: 2px solid rgba(25, 135, 84, 0.35);
+  outline-offset: -2px;
+}
+
+.js-daily-event-row.is-error {
+  outline: 2px solid rgba(220, 53, 69, 0.45);
+  outline-offset: -2px;
+}
+
+@media (max-width: 992px) {
+  .dsb-top-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dsb-sub-summary {
+    height: 180px;
+  }
+}

--- a/public/css/daily-shift-board.css
+++ b/public/css/daily-shift-board.css
@@ -46,6 +46,142 @@
   min-width: 680px;
 }
 
+.dsb-fc-event {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.18rem 0.45rem;
+  min-width: 0;
+}
+
+.dsb-fc-event-title {
+  font-weight: 700;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.dsb-fc-event-meta {
+  font-size: 0.76rem;
+  line-height: 1.25;
+  opacity: 0.95;
+  white-space: normal;
+}
+
+.dsb-fc-event-codes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.18rem;
+}
+
+.dsb-fc-code {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 0.03rem 0.3rem;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.88);
+  color: #212529;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.dsb-modal-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.35rem 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.dsb-modal-meta-item {
+  display: flex;
+  gap: 0.35rem;
+  min-width: 0;
+  font-size: 0.86rem;
+}
+
+.dsb-modal-meta-label {
+  flex: 0 0 auto;
+  color: #6c757d;
+  font-weight: 600;
+}
+
+.dsb-modal-meta-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.dsb-modal-section-title {
+  margin: 0.75rem 0 0.35rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #343a40;
+  border-bottom: 1px solid #dee2e6;
+  padding-bottom: 0.18rem;
+}
+
+.dsb-class-detail-list {
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dsb-class-detail-row {
+  display: grid;
+  grid-template-columns: 90px 90px minmax(0, 1fr) 80px;
+  gap: 0.45rem;
+  align-items: center;
+  padding: 0.32rem 0.5rem;
+  border-bottom: 1px solid #edf0f2;
+  font-size: 0.84rem;
+}
+
+.dsb-class-detail-row:last-child {
+  border-bottom: none;
+}
+
+.dsb-class-detail-time {
+  color: #495057;
+  font-variant-numeric: tabular-nums;
+}
+
+.dsb-class-detail-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 22px;
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  background: #e9ecef;
+  font-weight: 700;
+}
+
+.dsb-class-detail-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dsb-class-detail-min {
+  color: #6c757d;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.dsb-modal-notes {
+  white-space: pre-wrap;
+  font-size: 0.86rem;
+  color: #495057;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  padding: 0.5rem;
+}
+
 .dsb-sub-summary {
   height: 320px;
   min-height: 180px;

--- a/public/css/daily-shift-board.css
+++ b/public/css/daily-shift-board.css
@@ -300,6 +300,21 @@
   margin-bottom: 0;
 }
 
+.dsb-editor-scroll {
+  min-height: 100%;
+}
+
+.daily-shift-table thead {
+  cursor: grab;
+  user-select: none;
+}
+
+.dsb-editor-scroll.is-dragging,
+.dsb-editor-scroll.is-dragging * {
+  cursor: grabbing !important;
+  user-select: none !important;
+}
+
 .daily-shift-table th,
 .daily-shift-table td {
   padding: 0.25rem 0.35rem;

--- a/public/css/generated-shift-confirmation.css
+++ b/public/css/generated-shift-confirmation.css
@@ -1,0 +1,52 @@
+.generated-shift-list {
+  max-height: min(52vh, 31rem);
+  overflow-y: auto;
+  padding-right: .25rem;
+}
+
+.generated-shift-card {
+  background: #f8fbff;
+  border: 1px solid #c8d8ec;
+  border-radius: 6px;
+  padding: .75rem;
+}
+
+.generated-shift-card + .generated-shift-card {
+  margin-top: .5rem;
+}
+
+.generated-shift-meta {
+  display: grid;
+  gap: .5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.generated-shift-field {
+  min-width: 0;
+}
+
+.generated-shift-label {
+  color: #6c757d;
+  display: block;
+  font-size: .75rem;
+  line-height: 1.1;
+}
+
+.generated-shift-value {
+  overflow-wrap: anywhere;
+}
+
+.generated-shift-wide {
+  background: #fff;
+  border: 1px solid #dce6f2;
+  border-radius: 4px;
+  margin-top: .5rem;
+  padding: .5rem;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 576px) {
+  .generated-shift-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/public/css/shift-copy-modal.css
+++ b/public/css/shift-copy-modal.css
@@ -1,0 +1,18 @@
+.shift-copy-form .modal-header,
+.shift-copy-modal-body,
+.shift-copy-form .modal-footer {
+  background-color: #eef6ff;
+}
+
+.shift-copy-form .form-control,
+.shift-copy-form .form-select {
+  background-color: #fff;
+  border-color: #b6c7d8;
+}
+
+.shift-copy-form .form-control:focus,
+.shift-copy-form .form-select:focus {
+  background-color: #fff;
+  border-color: #86b7fe;
+  box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.18);
+}

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -168,6 +168,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const summaryEl = document.getElementById('dailySubSummary');
     if (!summaryEl) return;
 
+    const assignmentCounts = new Map();
+    (events || []).forEach((event) => {
+      const props = event.extendedProps || {};
+      if (props.category !== 'event') return;
+
+      const assignedUserId = props.assigned_user_id;
+      if (assignedUserId == null || assignedUserId === '') return;
+
+      const key = String(assignedUserId);
+      assignmentCounts.set(key, (assignmentCounts.get(key) || 0) + 1);
+    });
+
     const subEvent = (events || []).find((event) => {
       const props = event.extendedProps || {};
       const classes = event.classNames || [];
@@ -214,12 +226,32 @@ document.addEventListener('DOMContentLoaded', function () {
         group.appendChild(none);
       } else {
         list.forEach((item) => {
+          const userId = item && typeof item === 'object' ? item.id : null;
+          const assignedCount = !absent && userId != null
+            ? Number(assignmentCounts.get(String(userId)) || 0)
+            : 0;
+          const pillClasses = ['dsb-sub-pill'];
+          if (absent) {
+            pillClasses.push('dsb-sub-pill--absent');
+          } else if (assignedCount >= 2) {
+            pillClasses.push('dsb-sub-pill--assigned-multiple');
+          } else if (assignedCount === 1) {
+            pillClasses.push('dsb-sub-pill--assigned-once');
+          }
+
           const pill = document.createElement('span');
-          pill.className = absent ? 'dsb-sub-pill dsb-sub-pill--absent' : 'dsb-sub-pill';
+          pill.className = pillClasses.join(' ');
 
           const name = document.createElement('span');
           name.textContent = item?.name || String(item || '');
           pill.appendChild(name);
+
+          if (assignedCount > 0) {
+            const badge = document.createElement('span');
+            badge.className = 'dsb-sub-assigned-count';
+            badge.textContent = `Assigned x${assignedCount}`;
+            pill.appendChild(badge);
+          }
 
           if (item?.start_hm || item?.end_hm) {
             const time = document.createElement('span');

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -1,0 +1,293 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const config = window.dailyShiftBoard || {};
+  const selectedDate = config.selectedDate;
+  const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
+    || document.querySelector('input[name="_token"]')?.value;
+  const statusEl = document.getElementById('dailyBoardSaveStatus');
+
+  function setStatus(message, kind = 'muted') {
+    if (!statusEl) return;
+    statusEl.textContent = message || '';
+    statusEl.className = `small text-${kind}`;
+  }
+
+  function hhmmToMin(t) {
+    if (!t) return null;
+    const parts = String(t).trim().replace('：', ':').split(':');
+    if (parts.length < 2) return null;
+    const h = Number(parts[0]);
+    const m = Number(parts[1]);
+    if (Number.isNaN(h) || Number.isNaN(m)) return null;
+    return h * 60 + m;
+  }
+
+  function pad2(n) {
+    return String(n).padStart(2, '0');
+  }
+
+  function recalcTotal(row, force = false) {
+    const start = row.querySelector('[name="start_time"]')?.value || '';
+    const end = row.querySelector('[name="end_time"]')?.value || '';
+    const out = row.querySelector('[name="total_duration"]');
+    if (!out) return;
+    if (!force && out.value) return;
+
+    const s = hhmmToMin(start);
+    const e = hhmmToMin(end);
+    if (s == null || e == null) return;
+
+    let diff = e - s;
+    if (diff < 0) diff += 1440;
+    out.value = Math.floor(diff / 60) + ':' + pad2(diff % 60);
+  }
+
+  function collectRow(row) {
+    const data = { id: Number(row.dataset.eventId) };
+    row.querySelectorAll('input[name], select[name], textarea[name]').forEach((field) => {
+      data[field.name] = field.value;
+    });
+    return data;
+  }
+
+  async function saveRows(rows) {
+    const targetRows = Array.from(rows).filter(Boolean);
+    if (!targetRows.length) {
+      setStatus('No rows to save.', 'warning');
+      return false;
+    }
+
+    targetRows.forEach((row) => {
+      row.classList.remove('is-saved', 'is-error');
+      row.classList.add('is-saving');
+      recalcTotal(row, true);
+    });
+
+    setStatus('Saving...', 'muted');
+
+    try {
+      const res = await fetch(config.bulkUpdateUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify({ items: targetRows.map(collectRow) }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      const ok = res.ok && data.ok !== false;
+
+      targetRows.forEach((row) => {
+        row.classList.remove('is-saving');
+        row.classList.add(ok ? 'is-saved' : 'is-error');
+      });
+
+      if (!ok) {
+        setStatus(data.message || 'Save failed.', 'danger');
+        return false;
+      }
+
+      setStatus(data.message || 'Saved.', 'success');
+      if (window.dailyShiftBoardCalendar) {
+        window.dailyShiftBoardCalendar.refetchEvents();
+      }
+      setTimeout(() => {
+        targetRows.forEach((row) => row.classList.remove('is-saved'));
+      }, 1800);
+      return true;
+    } catch (err) {
+      console.error(err);
+      targetRows.forEach((row) => {
+        row.classList.remove('is-saving');
+        row.classList.add('is-error');
+      });
+      setStatus('Network error.', 'danger');
+      return false;
+    }
+  }
+
+  document.querySelectorAll('.js-daily-event-row').forEach((row) => recalcTotal(row));
+
+  document.addEventListener('input', (e) => {
+    if (!e.target.classList.contains('js-dsb-time')) return;
+    const row = e.target.closest('.js-daily-event-row');
+    if (row) recalcTotal(row, true);
+  });
+
+  document.addEventListener('click', (e) => {
+    const rowSave = e.target.closest('.js-dsb-row-save');
+    if (rowSave) {
+      const row = rowSave.closest('.js-daily-event-row');
+      saveRows([row]);
+      return;
+    }
+
+    if (e.target.id === 'dailyBoardBulkSave') {
+      saveRows(document.querySelectorAll('.js-daily-event-row'));
+    }
+  });
+
+  document.addEventListener('change', (e) => {
+    if (!e.target.classList.contains('js-dsb-status')) return;
+    const row = e.target.closest('.js-daily-event-row');
+    if (row) saveRows([row]);
+  });
+
+  function renderSubSummary(events) {
+    const countEl = document.getElementById('dailySubCount');
+    const summaryEl = document.getElementById('dailySubSummary');
+    if (!summaryEl) return;
+
+    const subEvent = (events || []).find((event) => {
+      const props = event.extendedProps || {};
+      const classes = event.classNames || [];
+      return props.category === 'subcount' || classes.includes('ev-subcount');
+    });
+
+    summaryEl.innerHTML = '';
+
+    if (!subEvent) {
+      if (countEl) countEl.textContent = '0';
+      const empty = document.createElement('div');
+      empty.className = 'text-muted small';
+      empty.textContent = 'No SUB candidate data for this date.';
+      summaryEl.appendChild(empty);
+      return;
+    }
+
+    const props = subEvent.extendedProps || {};
+    const breakdown = props.count_breakdown || {};
+    const count = Number.isFinite(props.count)
+      ? props.count
+      : (Number(breakdown.line || 0) + Number(breakdown.work_instead || 0) + Number(breakdown.subs || 0));
+
+    if (countEl) countEl.textContent = String(count);
+
+    const meta = document.createElement('div');
+    meta.className = 'small text-muted mb-2';
+    meta.textContent = `Regular: ${breakdown.line || 0} / RWD: ${breakdown.work_instead || 0} / Extra: ${breakdown.subs || 0}`;
+    summaryEl.appendChild(meta);
+
+    const addGroup = (title, list, absent = false) => {
+      const group = document.createElement('div');
+      group.className = 'dsb-sub-group';
+
+      const heading = document.createElement('div');
+      heading.className = 'dsb-sub-group-title';
+      heading.textContent = title;
+      group.appendChild(heading);
+
+      if (!list || !list.length) {
+        const none = document.createElement('span');
+        none.className = 'text-muted small';
+        none.textContent = '-';
+        group.appendChild(none);
+      } else {
+        list.forEach((item) => {
+          const pill = document.createElement('span');
+          pill.className = absent ? 'dsb-sub-pill dsb-sub-pill--absent' : 'dsb-sub-pill';
+
+          const name = document.createElement('span');
+          name.textContent = item?.name || String(item || '');
+          pill.appendChild(name);
+
+          if (item?.start_hm || item?.end_hm) {
+            const time = document.createElement('span');
+            time.className = 'dsb-sub-time';
+            time.textContent = `${item.start_hm || ''}${item.start_hm && item.end_hm ? '-' : ''}${item.end_hm || ''}`;
+            pill.appendChild(time);
+          }
+
+          group.appendChild(pill);
+        });
+      }
+
+      summaryEl.appendChild(group);
+    };
+
+    const users = props.users || {};
+    const absentUsers = props.absent_users || {};
+    addGroup('Available Regular Subs', users.line || []);
+    addGroup('Available Rostered Working Day', users.work_instead || []);
+    addGroup('Available Extra Subs', users.subs || []);
+    addGroup('Absence Regular Subs', absentUsers.line || [], true);
+    addGroup('Absence Rostered Working Day', absentUsers.work_instead || [], true);
+    addGroup('Absence Extra Subs', absentUsers.subs || [], true);
+  }
+
+  const calendarEl = document.getElementById('dailyCalendar');
+  if (calendarEl && window.FullCalendar) {
+    const calendar = new FullCalendar.Calendar(calendarEl, {
+      locale: 'en',
+      initialView: 'listDay',
+      initialDate: selectedDate,
+      height: '100%',
+      displayEventTime: false,
+      headerToolbar: { left: '', center: 'title', right: '' },
+      noEventsContent: 'No forecast events.',
+      events(fetchInfo, successCallback, failureCallback) {
+        const url = new URL(config.eventsUrl, window.location.origin);
+        url.searchParams.set('start', fetchInfo.startStr);
+        url.searchParams.set('end', fetchInfo.endStr);
+
+        fetch(url.toString(), { headers: { 'Accept': 'application/json' } })
+          .then((res) => {
+            if (!res.ok) throw new Error('Failed to load events.');
+            return res.json();
+          })
+          .then((events) => {
+            renderSubSummary(events);
+            successCallback(events);
+          })
+          .catch((err) => {
+            console.error(err);
+            renderSubSummary([]);
+            failureCallback(err);
+          });
+      },
+      eventClick(info) {
+        info.jsEvent?.preventDefault();
+      },
+    });
+    calendar.render();
+    window.dailyShiftBoardCalendar = calendar;
+  }
+
+  function setupResizeHandle(handle) {
+    const targetId = handle.dataset.target;
+    const storageKey = handle.dataset.storageKey;
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    const saved = Number(localStorage.getItem(storageKey));
+    if (saved) {
+      target.style.height = `${Math.max(180, Math.min(saved, window.innerHeight * 0.78))}px`;
+    }
+
+    handle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      const startY = e.clientY;
+      const startHeight = target.getBoundingClientRect().height;
+
+      const onMove = (ev) => {
+        const next = Math.max(180, Math.min(startHeight + ev.clientY - startY, window.innerHeight * 0.78));
+        target.style.height = `${Math.round(next)}px`;
+        if (targetId === 'dailyCalendarPane' && window.dailyShiftBoardCalendar) {
+          window.dailyShiftBoardCalendar.updateSize();
+        }
+      };
+
+      const onUp = () => {
+        localStorage.setItem(storageKey, String(Math.round(target.getBoundingClientRect().height)));
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+
+  document.querySelectorAll('.dsb-resize-handle').forEach(setupResizeHandle);
+});

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -490,5 +490,48 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  function setupSubWidthHandle() {
+    const grid = document.querySelector('.dsb-top-grid');
+    const handle = document.querySelector('.dsb-width-handle');
+    if (!grid || !handle) return;
+
+    const storageKey = 'dailyShiftBoardSubWidth';
+    const saved = Number(localStorage.getItem(storageKey));
+    if (saved) {
+      grid.style.setProperty('--dsb-sub-width', `${Math.round(saved)}px`);
+    }
+
+    handle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = Number(
+        getComputedStyle(grid).getPropertyValue('--dsb-sub-width').replace('px', '').trim()
+      ) || 420;
+
+      const onMove = (ev) => {
+        const gridWidth = grid.getBoundingClientRect().width;
+        const maxWidth = Math.max(320, Math.min(720, gridWidth * 0.62));
+        const next = Math.max(320, Math.min(startWidth - (ev.clientX - startX), maxWidth));
+        grid.style.setProperty('--dsb-sub-width', `${Math.round(next)}px`);
+        if (window.dailyShiftBoardCalendar) {
+          window.dailyShiftBoardCalendar.updateSize();
+        }
+      };
+
+      const onUp = () => {
+        const current = Number(
+          getComputedStyle(grid).getPropertyValue('--dsb-sub-width').replace('px', '').trim()
+        ) || 420;
+        localStorage.setItem(storageKey, String(Math.round(current)));
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+
   document.querySelectorAll('.dsb-resize-handle').forEach(setupResizeHandle);
+  setupSubWidthHandle();
 });

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -259,10 +259,24 @@ document.addEventListener('DOMContentLoaded', function () {
     const storageKey = handle.dataset.storageKey;
     const target = document.getElementById(targetId);
     if (!target) return;
+    const linkedTargets = targetId === 'dailyCalendarPane'
+      ? [document.getElementById('dailySubSummary')].filter(Boolean)
+      : [];
+
+    function applyHeight(height) {
+      const px = `${Math.round(height)}px`;
+      target.style.height = px;
+      linkedTargets.forEach((el) => {
+        el.style.height = px;
+      });
+      if (targetId === 'dailyCalendarPane' && window.dailyShiftBoardCalendar) {
+        window.dailyShiftBoardCalendar.updateSize();
+      }
+    }
 
     const saved = Number(localStorage.getItem(storageKey));
     if (saved) {
-      target.style.height = `${Math.max(180, Math.min(saved, window.innerHeight * 0.78))}px`;
+      applyHeight(Math.max(180, Math.min(saved, window.innerHeight * 0.78)));
     }
 
     handle.addEventListener('mousedown', (e) => {
@@ -272,10 +286,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       const onMove = (ev) => {
         const next = Math.max(180, Math.min(startHeight + ev.clientY - startY, window.innerHeight * 0.78));
-        target.style.height = `${Math.round(next)}px`;
-        if (targetId === 'dailyCalendarPane' && window.dailyShiftBoardCalendar) {
-          window.dailyShiftBoardCalendar.updateSize();
-        }
+        applyHeight(next);
       };
 
       const onUp = () => {

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -532,6 +532,51 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  function setupEditorHorizontalScroll() {
+    const scroller = document.getElementById('dailyEditorScroll');
+    if (!scroller) return;
+
+    const canScrollX = () => scroller.scrollWidth > scroller.clientWidth + 1;
+
+    scroller.addEventListener('wheel', (e) => {
+      if (!canScrollX()) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const isHorizontalGesture = Math.abs(e.deltaX) > Math.abs(e.deltaY);
+      const delta = isHorizontalGesture ? e.deltaX : e.deltaY;
+      scroller.scrollLeft += delta;
+    }, { passive: false });
+
+    const header = scroller.querySelector('thead');
+    if (!header) return;
+
+    header.addEventListener('mousedown', (e) => {
+      if (e.button !== 0 || !canScrollX()) return;
+
+      e.preventDefault();
+      scroller.classList.add('is-dragging');
+
+      const startX = e.clientX;
+      const startLeft = scroller.scrollLeft;
+
+      const onMove = (ev) => {
+        scroller.scrollLeft = startLeft - (ev.clientX - startX);
+      };
+
+      const onUp = () => {
+        scroller.classList.remove('is-dragging');
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+
   document.querySelectorAll('.dsb-resize-handle').forEach(setupResizeHandle);
   setupSubWidthHandle();
+  setupEditorHorizontalScroll();
 });

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -28,8 +28,17 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function failedMessage(rows, data) {
+    const results = Array.isArray(data.results) ? data.results : [];
+    const hasConflict = results.some((result) => result?.conflict);
     if (rows.length === 1) {
-      return `Event #${rows[0].dataset.eventId} failed to save.`;
+      const rowResult = results.find((result) => String(result.id) === String(rows[0].dataset.eventId));
+      if (rowResult?.conflict || hasConflict) {
+        return `Event #${rows[0].dataset.eventId} was already updated by others. Please reload.`;
+      }
+      return rowResult?.message || data.message || `Event #${rows[0].dataset.eventId} failed to save.`;
+    }
+    if (hasConflict) {
+      return 'Some events were already updated by others. Please reload before saving.';
     }
     return data.message || 'Some events failed to save.';
   }
@@ -69,6 +78,15 @@ document.addEventListener('DOMContentLoaded', function () {
     out.value = Math.floor(diff / 60) + ':' + pad2(diff % 60);
   }
 
+  function stableJson(data) {
+    return JSON.stringify(
+      Object.keys(data).sort().reduce((sorted, key) => {
+        sorted[key] = data[key];
+        return sorted;
+      }, {})
+    );
+  }
+
   function collectRow(row) {
     const data = { id: Number(row.dataset.eventId) };
     row.querySelectorAll('input[name], select[name], textarea[name]').forEach((field) => {
@@ -77,10 +95,53 @@ document.addEventListener('DOMContentLoaded', function () {
     return data;
   }
 
+  function rowComparableState(row) {
+    const data = collectRow(row);
+    delete data.updated_at;
+    return stableJson(data);
+  }
+
+  function setRowBaseline(row) {
+    row.dataset.originalState = rowComparableState(row);
+    row.classList.remove('is-dirty');
+  }
+
+  function rowIsDirty(row) {
+    return row.dataset.originalState !== rowComparableState(row);
+  }
+
+  function refreshRowDirtyState(row) {
+    row.classList.toggle('is-dirty', rowIsDirty(row));
+  }
+
+  function applySaveResults(rows, data) {
+    const results = Array.isArray(data.results) ? data.results : [];
+    const byId = new Map(results.map((result) => [String(result.id), result]));
+
+    rows.forEach((row) => {
+      const result = byId.get(String(row.dataset.eventId));
+      const ok = result ? result.ok !== false : data.ok !== false;
+
+      row.classList.remove('is-saving');
+      row.classList.add(ok ? 'is-saved' : 'is-error');
+
+      if (!ok) return;
+
+      const updatedAt = result?.updated_at;
+      const token = row.querySelector('[name="updated_at"]');
+      if (updatedAt && token) {
+        token.value = updatedAt;
+      }
+      setRowBaseline(row);
+    });
+  }
+
   async function saveRows(rows) {
-    const targetRows = Array.from(rows).filter(Boolean);
+    const candidates = Array.from(rows).filter(Boolean);
+    candidates.forEach(refreshRowDirtyState);
+    const targetRows = candidates.filter(rowIsDirty);
     if (!targetRows.length) {
-      setStatus('No rows to save.', 'warning', 3000);
+      setStatus('No changed rows to save.', 'warning', 3000);
       return false;
     }
 
@@ -107,12 +168,12 @@ document.addEventListener('DOMContentLoaded', function () {
       const data = await res.json().catch(() => ({}));
       const ok = res.ok && data.ok !== false;
 
-      targetRows.forEach((row) => {
-        row.classList.remove('is-saving');
-        row.classList.add(ok ? 'is-saved' : 'is-error');
-      });
+      applySaveResults(targetRows, data);
 
       if (!ok) {
+        if (Number(data.updated || 0) > 0 && window.dailyShiftBoardCalendar) {
+          window.dailyShiftBoardCalendar.refetchEvents();
+        }
         setStatus(failedMessage(targetRows, data), 'danger', 3000);
         return false;
       }
@@ -136,12 +197,30 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
-  document.querySelectorAll('.js-daily-event-row').forEach((row) => recalcTotal(row));
+  document.querySelectorAll('.js-daily-event-row').forEach((row) => {
+    recalcTotal(row);
+    setRowBaseline(row);
+  });
 
   document.addEventListener('input', (e) => {
     if (!e.target.classList.contains('js-dsb-time')) return;
     const row = e.target.closest('.js-daily-event-row');
-    if (row) recalcTotal(row, true);
+    if (row) {
+      recalcTotal(row, true);
+      refreshRowDirtyState(row);
+    }
+  });
+
+  document.addEventListener('input', (e) => {
+    const row = e.target.closest('.js-daily-event-row');
+    if (!row || !e.target.matches('input[name], select[name], textarea[name]')) return;
+    refreshRowDirtyState(row);
+  });
+
+  document.addEventListener('change', (e) => {
+    const row = e.target.closest('.js-daily-event-row');
+    if (!row || !e.target.matches('input[name], select[name], textarea[name]')) return;
+    refreshRowDirtyState(row);
   });
 
   document.addEventListener('click', (e) => {

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -25,6 +25,11 @@ document.addEventListener('DOMContentLoaded', function () {
     return String(n).padStart(2, '0');
   }
 
+  function minToHhmm(min) {
+    const normalized = ((min % 1440) + 1440) % 1440;
+    return `${pad2(Math.floor(normalized / 60))}:${pad2(normalized % 60)}`;
+  }
+
   function recalcTotal(row, force = false) {
     const start = row.querySelector('[name="start_time"]')?.value || '';
     const end = row.querySelector('[name="end_time"]')?.value || '';
@@ -216,8 +221,135 @@ document.addEventListener('DOMContentLoaded', function () {
     addGroup('Absence Extra Subs', absentUsers.subs || [], true);
   }
 
+  function appendText(parent, tag, text, className = '') {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    el.textContent = text;
+    parent.appendChild(el);
+    return el;
+  }
+
+  function appendMeta(parent, label, value) {
+    if (value == null || value === '') return;
+    const item = document.createElement('div');
+    item.className = 'dsb-modal-meta-item';
+    appendText(item, 'span', label, 'dsb-modal-meta-label');
+    appendText(item, 'span', value, 'dsb-modal-meta-value');
+    parent.appendChild(item);
+  }
+
+  function openDailyEventModal(event) {
+    const props = event.extendedProps || {};
+    if (props.category !== 'event') return;
+
+    const titleEl = document.getElementById('dailyEventModalTitle');
+    const bodyEl = document.getElementById('dailyEventModalBody');
+    const modalEl = document.getElementById('dailyEventModal');
+    if (!bodyEl || !modalEl) return;
+
+    if (titleEl) {
+      titleEl.textContent = event.title || 'Shift Details';
+    }
+
+    bodyEl.innerHTML = '';
+
+    const meta = document.createElement('div');
+    meta.className = 'dsb-modal-meta';
+    appendMeta(meta, 'Date', props.event_date || (event.start ? event.start.toISOString().slice(0, 10) : ''));
+    appendMeta(meta, 'Original', props.original_user_name || '');
+    appendMeta(meta, 'Assigned', props.assigned_user_name || (props.assigned_user_id != null ? `#${props.assigned_user_id}` : ''));
+    appendMeta(meta, 'School', props.school_name || props.school || '');
+    appendMeta(meta, 'Time', props.start_time && props.end_time ? `${props.start_time}-${props.end_time}` : (props.start_time || props.end_time || ''));
+    bodyEl.appendChild(meta);
+
+    appendText(bodyEl, 'div', 'Class Details', 'dsb-modal-section-title');
+
+    const details = Array.isArray(props.details) ? props.details : [];
+    if (!details.length) {
+      appendText(bodyEl, 'div', 'No class details.', 'text-muted small');
+    } else {
+      const list = document.createElement('div');
+      list.className = 'dsb-class-detail-list';
+
+      details.forEach((detail) => {
+        const row = document.createElement('div');
+        row.className = 'dsb-class-detail-row';
+
+        const start = detail?.start_hm || '';
+        const minutes = detail?.lesson_min != null ? Number(detail.lesson_min) : null;
+        const startMin = hhmmToMin(start);
+        const end = startMin != null && minutes != null ? minToHhmm(startMin + minutes) : '';
+        const range = start && end ? `${start}-${end}` : (start || '-');
+
+        appendText(row, 'span', range, 'dsb-class-detail-time');
+        appendText(row, 'span', detail?.lesson_code || '-', 'dsb-class-detail-code');
+        appendText(row, 'span', detail?.lesson_name || '-', 'dsb-class-detail-name');
+        appendText(row, 'span', minutes != null ? `${minutes} min` : (detail?.lesson_type || '-'), 'dsb-class-detail-min');
+
+        list.appendChild(row);
+      });
+
+      bodyEl.appendChild(list);
+    }
+
+    if (props.notes) {
+      appendText(bodyEl, 'div', 'Notes', 'dsb-modal-section-title');
+      const notes = document.createElement('div');
+      notes.className = 'dsb-modal-notes';
+      notes.textContent = props.notes;
+      bodyEl.appendChild(notes);
+    }
+
+    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+  }
+
   const calendarEl = document.getElementById('dailyCalendar');
   if (calendarEl && window.FullCalendar) {
+    function dailyEventContent(arg) {
+      const event = arg.event;
+      const props = event.extendedProps || {};
+      const wrap = document.createElement('div');
+      wrap.className = 'dsb-fc-event';
+
+      const title = document.createElement('div');
+      title.className = 'dsb-fc-event-title';
+      title.textContent = event.title || '';
+      wrap.appendChild(title);
+
+      if (props.category === 'event') {
+        const original = props.original_user_name || null;
+        const assigned = props.assigned_user_name || (props.assigned_user_id != null ? `#${props.assigned_user_id}` : null);
+        const metaParts = [];
+
+        if (original) metaParts.push(`Original: ${original}`);
+        if (assigned) metaParts.push(`Assigned: ${assigned}`);
+
+        if (metaParts.length) {
+          const meta = document.createElement('div');
+          meta.className = 'dsb-fc-event-meta';
+          meta.textContent = metaParts.join(' / ');
+          wrap.appendChild(meta);
+        }
+
+        if (Array.isArray(props.details) && props.details.length) {
+          const codes = [...new Set(props.details.map((detail) => detail?.lesson_code).filter(Boolean))];
+          if (codes.length) {
+            const codeWrap = document.createElement('div');
+            codeWrap.className = 'dsb-fc-event-codes';
+            codes.forEach((code) => {
+              const pill = document.createElement('span');
+              pill.className = 'dsb-fc-code';
+              pill.textContent = code;
+              codeWrap.appendChild(pill);
+            });
+            wrap.appendChild(codeWrap);
+          }
+        }
+      }
+
+      return { domNodes: [wrap] };
+    }
+
     const calendar = new FullCalendar.Calendar(calendarEl, {
       locale: 'en',
       initialView: 'listDay',
@@ -226,6 +358,7 @@ document.addEventListener('DOMContentLoaded', function () {
       displayEventTime: false,
       headerToolbar: { left: '', center: 'title', right: '' },
       noEventsContent: 'No forecast events.',
+      eventContent: dailyEventContent,
       events(fetchInfo, successCallback, failureCallback) {
         const url = new URL(config.eventsUrl, window.location.origin);
         url.searchParams.set('start', fetchInfo.startStr);
@@ -248,6 +381,7 @@ document.addEventListener('DOMContentLoaded', function () {
       },
       eventClick(info) {
         info.jsEvent?.preventDefault();
+        openDailyEventModal(info.event);
       },
     });
     calendar.render();

--- a/public/js/daily-shift-board.js
+++ b/public/js/daily-shift-board.js
@@ -4,11 +4,34 @@ document.addEventListener('DOMContentLoaded', function () {
   const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
     || document.querySelector('input[name="_token"]')?.value;
   const statusEl = document.getElementById('dailyBoardSaveStatus');
+  let statusTimer = null;
 
-  function setStatus(message, kind = 'muted') {
+  function setStatus(message, kind = 'muted', autoClearMs = null) {
     if (!statusEl) return;
+    clearTimeout(statusTimer);
     statusEl.textContent = message || '';
-    statusEl.className = `small text-${kind}`;
+    statusEl.className = message ? `small text-${kind}` : 'small text-muted d-none';
+    if (autoClearMs && message) {
+      statusTimer = setTimeout(() => {
+        statusEl.textContent = '';
+        statusEl.className = 'small text-muted d-none';
+      }, autoClearMs);
+    }
+  }
+
+  function savedMessage(rows, data) {
+    if (rows.length === 1) {
+      return `Event #${rows[0].dataset.eventId} saved.`;
+    }
+    const count = Number(data.updated || rows.length);
+    return `${count} events saved.`;
+  }
+
+  function failedMessage(rows, data) {
+    if (rows.length === 1) {
+      return `Event #${rows[0].dataset.eventId} failed to save.`;
+    }
+    return data.message || 'Some events failed to save.';
   }
 
   function hhmmToMin(t) {
@@ -57,7 +80,7 @@ document.addEventListener('DOMContentLoaded', function () {
   async function saveRows(rows) {
     const targetRows = Array.from(rows).filter(Boolean);
     if (!targetRows.length) {
-      setStatus('No rows to save.', 'warning');
+      setStatus('No rows to save.', 'warning', 3000);
       return false;
     }
 
@@ -75,6 +98,7 @@ document.addEventListener('DOMContentLoaded', function () {
         headers: {
           'Content-Type': 'application/json',
           'X-CSRF-TOKEN': csrf,
+          'X-Daily-Board': '1',
           'Accept': 'application/json',
         },
         body: JSON.stringify({ items: targetRows.map(collectRow) }),
@@ -89,11 +113,11 @@ document.addEventListener('DOMContentLoaded', function () {
       });
 
       if (!ok) {
-        setStatus(data.message || 'Save failed.', 'danger');
+        setStatus(failedMessage(targetRows, data), 'danger', 3000);
         return false;
       }
 
-      setStatus(data.message || 'Saved.', 'success');
+      setStatus(savedMessage(targetRows, data), 'success', 3000);
       if (window.dailyShiftBoardCalendar) {
         window.dailyShiftBoardCalendar.refetchEvents();
       }
@@ -107,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function () {
         row.classList.remove('is-saving');
         row.classList.add('is-error');
       });
-      setStatus('Network error.', 'danger');
+      setStatus('Network error.', 'danger', 3000);
       return false;
     }
   }

--- a/public/js/forecast.js
+++ b/public/js/forecast.js
@@ -206,6 +206,16 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             // end ★編集ボタンの初期化
 
+            // ★Daily Boardボタンを毎回初期化（非表示/無効化）
+            const dayBoardBtn = document.getElementById('dayBoardLink');
+            if (dayBoardBtn) {
+                dayBoardBtn.href = '#';
+                dayBoardBtn.style.display = 'none';
+                dayBoardBtn.classList.add('disabled');
+                dayBoardBtn.setAttribute('aria-disabled', 'true');
+            }
+            // end ★Daily Boardボタンの初期化
+
             // ★Leaveボタンの初期化
             const leaveBtn = document.getElementById('leaveEditLink');
             if (leaveBtn) {
@@ -290,6 +300,18 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             }
             // end ★ イベント枠の場合のみ編集リンクを設定して表示
+
+            // ★ イベント日付の Daily Board へのリンク
+            if (dayBoardBtn) {
+                const ymd = p?.event_date || (e.start ? e.start.toISOString().slice(0, 10) : null);
+                if (ymd) {
+                    dayBoardBtn.href = `/forecast/day-assigner?date=${encodeURIComponent(ymd)}`;
+                    dayBoardBtn.style.removeProperty('display');
+                    dayBoardBtn.classList.remove('disabled');
+                    dayBoardBtn.setAttribute('aria-disabled', 'false');
+                }
+            }
+            // end ★ イベント日付の Daily Board へのリンク
 
             // ★対応する Leave へのリンク設定（source_leave_id がある場合のみ）
             if (leaveBtn) {

--- a/public/js/generated-shift-confirmation.js
+++ b/public/js/generated-shift-confirmation.js
@@ -1,0 +1,185 @@
+(function () {
+  const ACTION_DETACH = 'detach';
+  const ACTION_DELETE = 'delete';
+
+  function generatedShiftsFromSource(sourceId) {
+    const source = sourceId ? document.getElementById(sourceId) : null;
+    return source ? JSON.parse(source.textContent || '[]') : [];
+  }
+
+  function renderCards(wrap, shifts) {
+    wrap.innerHTML = '';
+
+    shifts.forEach((shift) => {
+      const card = document.createElement('div');
+      card.className = 'generated-shift-card';
+
+      const title = document.createElement('div');
+      title.className = 'fw-semibold mb-2';
+      title.textContent = `Generated Shift #${shift.id || '-'}`;
+      card.appendChild(title);
+
+      const meta = document.createElement('div');
+      meta.className = 'generated-shift-meta';
+      [
+        ['Leave ID', 'leave_id'],
+        ['Date', 'date'],
+        ['Original', 'original'],
+        ['Assigned', 'assigned'],
+        ['School', 'school'],
+        ['Time', 'time'],
+        ['Status', 'status'],
+      ].forEach(([label, key]) => {
+        const field = document.createElement('div');
+        field.className = 'generated-shift-field';
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'generated-shift-label';
+        labelEl.textContent = label;
+
+        const valueEl = document.createElement('div');
+        valueEl.className = 'generated-shift-value';
+        valueEl.textContent = shift[key] || '-';
+
+        field.append(labelEl, valueEl);
+        meta.appendChild(field);
+      });
+      card.appendChild(meta);
+
+      ['lesson', 'notes'].forEach((key) => {
+        const wide = document.createElement('div');
+        wide.className = 'generated-shift-wide';
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'generated-shift-label';
+        labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
+
+        const valueEl = document.createElement('div');
+        valueEl.className = 'generated-shift-value';
+        valueEl.textContent = shift[key] || '-';
+
+        wide.append(labelEl, valueEl);
+        card.appendChild(wide);
+      });
+
+      wrap.appendChild(card);
+    });
+  }
+
+  function open(options) {
+    const modalEl = document.getElementById(options.modalId);
+    if (!modalEl) return;
+
+    const shifts = options.shifts || [];
+    const text = modalEl.querySelector('[data-generated-shift-text]');
+    const summary = modalEl.querySelector('[data-generated-shift-summary]');
+    const list = modalEl.querySelector('[data-generated-shift-list]');
+    const keepBtn = modalEl.querySelector('[data-generated-shift-keep]');
+    const deleteBtn = modalEl.querySelector('[data-generated-shift-delete]');
+
+    if (text) text.textContent = options.text || '';
+    if (summary) summary.textContent = options.summary || '';
+
+    if (list) {
+      if (shifts.length > 0) {
+        list.style.display = '';
+        renderCards(list, shifts);
+      } else {
+        list.innerHTML = '';
+        list.style.display = 'none';
+      }
+    }
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    modal.show();
+
+    if (keepBtn) {
+      keepBtn.onclick = () => {
+        options.onKeep?.();
+        modal.hide();
+      };
+    }
+
+    if (deleteBtn) {
+      deleteBtn.onclick = () => {
+        options.onDelete?.();
+        modal.hide();
+      };
+    }
+  }
+
+  function bindInactiveStatusForm(options) {
+    document.addEventListener('submit', (event) => {
+      const form = event.target.closest(options.formSelector);
+      if (!form) return;
+
+      const actionInput = form.querySelector(`input[name="${options.actionInputName || 'generated_shift_action'}"]`);
+      if (actionInput?.value) return;
+
+      const status = form.querySelector(options.statusSelector || 'select[name="status"]')?.value || '';
+      const inactiveStatuses = options.inactiveStatuses || ['rejected', 'cancelled'];
+      if (!inactiveStatuses.includes(status)) return;
+
+      const sourceId = form.querySelector(options.sourceSelector || '[data-shifts-source]')?.dataset.shiftsSource;
+      const shifts = generatedShiftsFromSource(sourceId);
+      if (shifts.length === 0) return;
+
+      event.preventDefault();
+
+      open({
+        modalId: options.modalId,
+        shifts,
+        text: options.textBuilder ? options.textBuilder({ status, shifts, form }) : `Please choose what to do with generated shift(s).`,
+        summary: options.summaryBuilder ? options.summaryBuilder({ status, shifts, form }) : `${shifts.length} generated shift(s) are linked.`,
+        onKeep: () => {
+          actionInput.value = ACTION_DETACH;
+          form.submit();
+        },
+        onDelete: () => {
+          actionInput.value = ACTION_DELETE;
+          form.submit();
+        },
+      });
+    });
+  }
+
+  function bindApprovalDenyForm(options) {
+    document.addEventListener('submit', (event) => {
+      const form = event.target.closest(options.formSelector);
+      if (!form) return;
+
+      const actionInput = form.querySelector(`input[name="${options.actionInputName || 'generated_shift_action'}"]`);
+      if (actionInput?.value) return;
+
+      const shifts = generatedShiftsFromSource(options.sourceId);
+      if (shifts.length === 0) return;
+
+      event.preventDefault();
+
+      open({
+        modalId: options.modalId,
+        shifts,
+        text: options.text || 'Please choose what to do with generated shift(s).',
+        summary: options.summaryBuilder ? options.summaryBuilder({ shifts, form }) : `${shifts.length} generated shift(s) are linked.`,
+        onKeep: () => {
+          actionInput.value = ACTION_DETACH;
+          form.submit();
+        },
+        onDelete: () => {
+          actionInput.value = ACTION_DELETE;
+          form.submit();
+        },
+      });
+    });
+  }
+
+  window.GeneratedShiftConfirmation = {
+    ACTION_DETACH,
+    ACTION_DELETE,
+    generatedShiftsFromSource,
+    renderCards,
+    open,
+    bindInactiveStatusForm,
+    bindApprovalDenyForm,
+  };
+})();

--- a/public/js/shift-copy-modal.js
+++ b/public/js/shift-copy-modal.js
@@ -1,0 +1,57 @@
+(function () {
+  const fieldNames = [
+    'event_date',
+    'title',
+    'original_user_id',
+    'Leave_type',
+    'school_name',
+    'start_time',
+    'end_time',
+    'total_duration',
+    'Lesson',
+    'assigned_user_id',
+    'type',
+    'status',
+    'notes',
+  ];
+
+  function sourceValues(source) {
+    const values = {};
+    source.querySelectorAll('input[name], select[name], textarea[name]').forEach((field) => {
+      if (!fieldNames.includes(field.name)) return;
+      values[field.name] = field.value;
+    });
+    return values;
+  }
+
+  function fillCopyForm(form, values) {
+    fieldNames.forEach((name) => {
+      const field = form.querySelector(`[name="${name}"]`);
+      if (!field) return;
+      field.value = values[name] || '';
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    const button = event.target.closest('.js-shift-copy');
+    if (!button) return;
+
+    const modalEl = document.getElementById('shiftCopyModal');
+    const form = document.getElementById('shiftCopyForm');
+    if (!modalEl || !form || !window.bootstrap) return;
+
+    const source = button.closest('.js-event-form, .js-daily-event-row');
+    if (!source) return;
+
+    form.action = button.dataset.store || form.action;
+    fillCopyForm(form, sourceValues(source));
+
+    const title = document.getElementById('shiftCopyModalTitle');
+    const eventId = source.dataset.eventId;
+    if (title) {
+      title.textContent = eventId ? `Copy Shift #${eventId}` : 'Copy Shift';
+    }
+
+    window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
+  });
+})();

--- a/public/js/user-autocomplete.js
+++ b/public/js/user-autocomplete.js
@@ -1,0 +1,89 @@
+(function () {
+  function labelFor(user) {
+    const name = [user.first_name, user.family_name].filter(Boolean).join(' ').trim()
+      || user.name
+      || user.email
+      || `User #${user.id}`;
+    return user.employee_code ? `${name} [${user.employee_code}]` : name;
+  }
+
+  function debounce(fn, wait = 180) {
+    let timer = null;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), wait);
+    };
+  }
+
+  function init(input) {
+    if (!input || input.dataset.userAutocompleteReady === '1') return;
+    input.dataset.userAutocompleteReady = '1';
+
+    const url = input.dataset.userAutocompleteUrl;
+    const hiddenSelector = input.dataset.userAutocompleteHidden || '';
+    if (!hiddenSelector) return;
+
+    const hidden = document.querySelector(hiddenSelector);
+    const listId = input.getAttribute('list') || input.dataset.userAutocompleteList;
+    const list = listId ? document.getElementById(listId) : null;
+    if (!url || !hidden || !list) return;
+
+    const selectedByLabel = new Map();
+
+    function clearSelection() {
+      hidden.value = '';
+    }
+
+    function syncSelection() {
+      const selected = selectedByLabel.get(input.value.trim());
+      hidden.value = selected ? selected.id : '';
+      input.setCustomValidity('');
+    }
+
+    async function search() {
+      const query = input.value.trim();
+      const endpoint = new URL(url, window.location.origin);
+      endpoint.searchParams.set('q', query);
+      endpoint.searchParams.set('limit', input.dataset.userAutocompleteLimit || '20');
+
+      const res = await fetch(endpoint.toString(), { headers: { Accept: 'application/json' } });
+      if (!res.ok) return;
+
+      const users = await res.json();
+      selectedByLabel.clear();
+      list.innerHTML = '';
+
+      users.forEach((user) => {
+        const label = labelFor(user);
+        selectedByLabel.set(label, user);
+
+        const option = document.createElement('option');
+        option.value = label;
+        list.appendChild(option);
+      });
+
+      syncSelection();
+    }
+
+    const debouncedSearch = debounce(search);
+
+    input.addEventListener('focus', search);
+    input.addEventListener('input', () => {
+      clearSelection();
+      debouncedSearch();
+    });
+    input.addEventListener('change', syncSelection);
+
+    input.form?.addEventListener('submit', (event) => {
+      syncSelection();
+      input.setCustomValidity('');
+    });
+  }
+
+  function initAll(root = document) {
+    root.querySelectorAll('[data-user-autocomplete]').forEach(init);
+  }
+
+  window.UserAutocomplete = { init, initAll };
+  document.addEventListener('DOMContentLoaded', () => initAll());
+})();

--- a/resources/views/approvals/show.blade.php
+++ b/resources/views/approvals/show.blade.php
@@ -192,11 +192,7 @@
 @if($isLeave)
 <script type="application/json" id="approval-generated-shifts">@json($generatedShiftDetails)</script>
 
-<x-generated-shift-confirm-modal
-    id="denyGeneratedShiftConfirmModal"
-    title="Deny Confirmation"
-    message="This leave request has generated shift(s). Please choose what to do before denying it."
-/>
+<x-generated-shift-confirm-modal />
 @endif
 
 <link href="{{ asset('css/generated-shift-confirmation.css') }}?v={{ filemtime(public_path('css/generated-shift-confirmation.css')) }}" rel="stylesheet">
@@ -218,7 +214,7 @@
 GeneratedShiftConfirmation.bindApprovalDenyForm({
     formSelector: '.js-approval-deny-form',
     sourceId: 'approval-generated-shifts',
-    modalId: 'denyGeneratedShiftConfirmModal',
+    modalId: 'generatedShiftConfirmModal',
     text: 'This leave request has generated shift(s). Please choose what to do before denying it.',
     summaryBuilder: ({ shifts }) => `${shifts.length} generated shift(s) are linked to this request.`,
 });

--- a/resources/views/approvals/show.blade.php
+++ b/resources/views/approvals/show.blade.php
@@ -10,6 +10,7 @@
             $meta       = $approvalRequest->metadata ?? [];
             $approvable = $approvalRequest->approvable;
             $isLeave    = $approvable instanceof \App\Models\Leave;
+            $generatedShiftDetails = collect($generatedShiftDetails ?? []);
             @endphp
 
             <table class="table table-bordered">
@@ -176,8 +177,9 @@
                 <button type="submit" class="btn btn-success mb-2">Approve</button>
             </form>
 
-            <form action="{{ route('approvals.deny', $approvalRequest) }}" method="POST" class="d-inline ms-2">
+            <form action="{{ route('approvals.deny', $approvalRequest) }}" method="POST" class="d-inline ms-2 js-approval-deny-form">
                 @csrf
+                <input type="hidden" name="inactive_generated_shift_action" value="">
                 <input type="text" name="comment" class="form-control mb-2" placeholder="Denial reason (optional)">
                 <button type="submit" class="btn btn-danger mb-2">Deny</button>
             </form>
@@ -186,6 +188,31 @@
         </div>
     </div>
 </div>
+
+@if($isLeave)
+<script type="application/json" id="approval-generated-shifts">@json($generatedShiftDetails)</script>
+
+<div class="modal fade" id="denyGeneratedShiftConfirmModal" tabindex="-1" aria-labelledby="denyGeneratedShiftConfirmLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content border-0 shadow-sm">
+            <div class="modal-header bg-warning py-2">
+                <h6 class="modal-title" id="denyGeneratedShiftConfirmLabel">Deny Confirmation</h6>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-2">This leave request has generated shift(s). Please choose what to do before denying it.</p>
+                <div class="small text-muted mb-2" id="denyGeneratedShiftSummary"></div>
+                <div class="generated-shift-list" id="denyGeneratedShiftWrap"></div>
+            </div>
+            <div class="modal-footer py-2">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="denyKeepGeneratedShiftsBtn">Keep Shift</button>
+                <button type="button" class="btn btn-danger btn-sm" id="denyDeleteGeneratedShiftsBtn">Delete Shift</button>
+            </div>
+        </div>
+    </div>
+</div>
+@endif
 
 <style>
 .approval-show-panel {
@@ -196,5 +223,154 @@
 .approval-show-panel .form-select {
     background-color: #fff;
 }
+
+.generated-shift-list {
+    max-height: min(52vh, 31rem);
+    overflow-y: auto;
+    padding-right: .25rem;
+}
+
+.generated-shift-card {
+    background: #f8fbff;
+    border: 1px solid #c8d8ec;
+    border-radius: 6px;
+    padding: .75rem;
+}
+
+.generated-shift-card + .generated-shift-card {
+    margin-top: .5rem;
+}
+
+.generated-shift-meta {
+    display: grid;
+    gap: .5rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.generated-shift-field {
+    min-width: 0;
+}
+
+.generated-shift-label {
+    color: #6c757d;
+    display: block;
+    font-size: .75rem;
+    line-height: 1.1;
+}
+
+.generated-shift-value {
+    overflow-wrap: anywhere;
+}
+
+.generated-shift-wide {
+    background: #fff;
+    border: 1px solid #dce6f2;
+    border-radius: 4px;
+    margin-top: .5rem;
+    padding: .5rem;
+    white-space: pre-wrap;
+}
+
+@media (max-width: 576px) {
+    .generated-shift-meta {
+        grid-template-columns: 1fr;
+    }
+}
 </style>
+
+@if($isLeave)
+<script>
+function renderApprovalGeneratedShiftCards(wrap, shifts) {
+    wrap.innerHTML = '';
+
+    shifts.forEach((shift) => {
+        const card = document.createElement('div');
+        card.className = 'generated-shift-card';
+
+        const title = document.createElement('div');
+        title.className = 'fw-semibold mb-2';
+        title.textContent = `Generated Shift #${shift.id || '-'}`;
+        card.appendChild(title);
+
+        const meta = document.createElement('div');
+        meta.className = 'generated-shift-meta';
+        [
+            ['Leave ID', 'leave_id'],
+            ['Date', 'date'],
+            ['Original', 'original'],
+            ['Assigned', 'assigned'],
+            ['School', 'school'],
+            ['Time', 'time'],
+            ['Status', 'status'],
+        ].forEach(([label, key]) => {
+            const field = document.createElement('div');
+            field.className = 'generated-shift-field';
+
+            const labelEl = document.createElement('span');
+            labelEl.className = 'generated-shift-label';
+            labelEl.textContent = label;
+
+            const valueEl = document.createElement('div');
+            valueEl.className = 'generated-shift-value';
+            valueEl.textContent = shift[key] || '-';
+
+            field.append(labelEl, valueEl);
+            meta.appendChild(field);
+        });
+        card.appendChild(meta);
+
+        ['lesson', 'notes'].forEach((key) => {
+            const wide = document.createElement('div');
+            wide.className = 'generated-shift-wide';
+
+            const labelEl = document.createElement('span');
+            labelEl.className = 'generated-shift-label';
+            labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
+
+            const valueEl = document.createElement('div');
+            valueEl.className = 'generated-shift-value';
+            valueEl.textContent = shift[key] || '-';
+
+            wide.append(labelEl, valueEl);
+            card.appendChild(wide);
+        });
+
+        wrap.appendChild(card);
+    });
+}
+
+document.addEventListener('submit', (e) => {
+    const form = e.target.closest('.js-approval-deny-form');
+    if (!form) return;
+
+    const actionInput = form.querySelector('input[name="inactive_generated_shift_action"]');
+    if (actionInput?.value) return;
+
+    const source = document.getElementById('approval-generated-shifts');
+    const shifts = source ? JSON.parse(source.textContent || '[]') : [];
+    if (shifts.length === 0) return;
+
+    e.preventDefault();
+
+    document.getElementById('denyGeneratedShiftSummary').textContent = `${shifts.length} generated shift(s) are linked to this request.`;
+    renderApprovalGeneratedShiftCards(document.getElementById('denyGeneratedShiftWrap'), shifts);
+
+    const modalEl = document.getElementById('denyGeneratedShiftConfirmModal');
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    modal.show();
+
+    document.getElementById('denyKeepGeneratedShiftsBtn').onclick = () => {
+        actionInput.value = 'detach';
+        modal.hide();
+        form.submit();
+    };
+
+    document.getElementById('denyDeleteGeneratedShiftsBtn').onclick = () => {
+        actionInput.value = 'delete';
+        modal.hide();
+        form.submit();
+    };
+});
+</script>
+@endif
 @endsection

--- a/resources/views/approvals/show.blade.php
+++ b/resources/views/approvals/show.blade.php
@@ -192,27 +192,14 @@
 @if($isLeave)
 <script type="application/json" id="approval-generated-shifts">@json($generatedShiftDetails)</script>
 
-<div class="modal fade" id="denyGeneratedShiftConfirmModal" tabindex="-1" aria-labelledby="denyGeneratedShiftConfirmLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-centered">
-        <div class="modal-content border-0 shadow-sm">
-            <div class="modal-header bg-warning py-2">
-                <h6 class="modal-title" id="denyGeneratedShiftConfirmLabel">Deny Confirmation</h6>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <p class="mb-2">This leave request has generated shift(s). Please choose what to do before denying it.</p>
-                <div class="small text-muted mb-2" id="denyGeneratedShiftSummary"></div>
-                <div class="generated-shift-list" id="denyGeneratedShiftWrap"></div>
-            </div>
-            <div class="modal-footer py-2">
-                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-outline-secondary btn-sm" id="denyKeepGeneratedShiftsBtn">Keep Shift</button>
-                <button type="button" class="btn btn-danger btn-sm" id="denyDeleteGeneratedShiftsBtn">Delete Shift</button>
-            </div>
-        </div>
-    </div>
-</div>
+<x-generated-shift-confirm-modal
+    id="denyGeneratedShiftConfirmModal"
+    title="Deny Confirmation"
+    message="This leave request has generated shift(s). Please choose what to do before denying it."
+/>
 @endif
+
+<link href="{{ asset('css/generated-shift-confirmation.css') }}?v={{ filemtime(public_path('css/generated-shift-confirmation.css')) }}" rel="stylesheet">
 
 <style>
 .approval-show-panel {
@@ -223,153 +210,17 @@
 .approval-show-panel .form-select {
     background-color: #fff;
 }
-
-.generated-shift-list {
-    max-height: min(52vh, 31rem);
-    overflow-y: auto;
-    padding-right: .25rem;
-}
-
-.generated-shift-card {
-    background: #f8fbff;
-    border: 1px solid #c8d8ec;
-    border-radius: 6px;
-    padding: .75rem;
-}
-
-.generated-shift-card + .generated-shift-card {
-    margin-top: .5rem;
-}
-
-.generated-shift-meta {
-    display: grid;
-    gap: .5rem;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.generated-shift-field {
-    min-width: 0;
-}
-
-.generated-shift-label {
-    color: #6c757d;
-    display: block;
-    font-size: .75rem;
-    line-height: 1.1;
-}
-
-.generated-shift-value {
-    overflow-wrap: anywhere;
-}
-
-.generated-shift-wide {
-    background: #fff;
-    border: 1px solid #dce6f2;
-    border-radius: 4px;
-    margin-top: .5rem;
-    padding: .5rem;
-    white-space: pre-wrap;
-}
-
-@media (max-width: 576px) {
-    .generated-shift-meta {
-        grid-template-columns: 1fr;
-    }
-}
 </style>
 
 @if($isLeave)
+<script src="{{ asset('js/generated-shift-confirmation.js') }}?v={{ filemtime(public_path('js/generated-shift-confirmation.js')) }}"></script>
 <script>
-function renderApprovalGeneratedShiftCards(wrap, shifts) {
-    wrap.innerHTML = '';
-
-    shifts.forEach((shift) => {
-        const card = document.createElement('div');
-        card.className = 'generated-shift-card';
-
-        const title = document.createElement('div');
-        title.className = 'fw-semibold mb-2';
-        title.textContent = `Generated Shift #${shift.id || '-'}`;
-        card.appendChild(title);
-
-        const meta = document.createElement('div');
-        meta.className = 'generated-shift-meta';
-        [
-            ['Leave ID', 'leave_id'],
-            ['Date', 'date'],
-            ['Original', 'original'],
-            ['Assigned', 'assigned'],
-            ['School', 'school'],
-            ['Time', 'time'],
-            ['Status', 'status'],
-        ].forEach(([label, key]) => {
-            const field = document.createElement('div');
-            field.className = 'generated-shift-field';
-
-            const labelEl = document.createElement('span');
-            labelEl.className = 'generated-shift-label';
-            labelEl.textContent = label;
-
-            const valueEl = document.createElement('div');
-            valueEl.className = 'generated-shift-value';
-            valueEl.textContent = shift[key] || '-';
-
-            field.append(labelEl, valueEl);
-            meta.appendChild(field);
-        });
-        card.appendChild(meta);
-
-        ['lesson', 'notes'].forEach((key) => {
-            const wide = document.createElement('div');
-            wide.className = 'generated-shift-wide';
-
-            const labelEl = document.createElement('span');
-            labelEl.className = 'generated-shift-label';
-            labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
-
-            const valueEl = document.createElement('div');
-            valueEl.className = 'generated-shift-value';
-            valueEl.textContent = shift[key] || '-';
-
-            wide.append(labelEl, valueEl);
-            card.appendChild(wide);
-        });
-
-        wrap.appendChild(card);
-    });
-}
-
-document.addEventListener('submit', (e) => {
-    const form = e.target.closest('.js-approval-deny-form');
-    if (!form) return;
-
-    const actionInput = form.querySelector('input[name="generated_shift_action"]');
-    if (actionInput?.value) return;
-
-    const source = document.getElementById('approval-generated-shifts');
-    const shifts = source ? JSON.parse(source.textContent || '[]') : [];
-    if (shifts.length === 0) return;
-
-    e.preventDefault();
-
-    document.getElementById('denyGeneratedShiftSummary').textContent = `${shifts.length} generated shift(s) are linked to this request.`;
-    renderApprovalGeneratedShiftCards(document.getElementById('denyGeneratedShiftWrap'), shifts);
-
-    const modalEl = document.getElementById('denyGeneratedShiftConfirmModal');
-    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
-    modal.show();
-
-    document.getElementById('denyKeepGeneratedShiftsBtn').onclick = () => {
-        actionInput.value = 'detach';
-        modal.hide();
-        form.submit();
-    };
-
-    document.getElementById('denyDeleteGeneratedShiftsBtn').onclick = () => {
-        actionInput.value = 'delete';
-        modal.hide();
-        form.submit();
-    };
+GeneratedShiftConfirmation.bindApprovalDenyForm({
+    formSelector: '.js-approval-deny-form',
+    sourceId: 'approval-generated-shifts',
+    modalId: 'denyGeneratedShiftConfirmModal',
+    text: 'This leave request has generated shift(s). Please choose what to do before denying it.',
+    summaryBuilder: ({ shifts }) => `${shifts.length} generated shift(s) are linked to this request.`,
 });
 </script>
 @endif

--- a/resources/views/approvals/show.blade.php
+++ b/resources/views/approvals/show.blade.php
@@ -179,7 +179,7 @@
 
             <form action="{{ route('approvals.deny', $approvalRequest) }}" method="POST" class="d-inline ms-2 js-approval-deny-form">
                 @csrf
-                <input type="hidden" name="inactive_generated_shift_action" value="">
+                <input type="hidden" name="generated_shift_action" value="">
                 <input type="text" name="comment" class="form-control mb-2" placeholder="Denial reason (optional)">
                 <button type="submit" class="btn btn-danger mb-2">Deny</button>
             </form>
@@ -343,7 +343,7 @@ document.addEventListener('submit', (e) => {
     const form = e.target.closest('.js-approval-deny-form');
     if (!form) return;
 
-    const actionInput = form.querySelector('input[name="inactive_generated_shift_action"]');
+    const actionInput = form.querySelector('input[name="generated_shift_action"]');
     if (actionInput?.value) return;
 
     const source = document.getElementById('approval-generated-shifts');

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -116,7 +116,7 @@
                 @endforeach
             </datalist>
 
-            <div class="table-responsive">
+            <div id="dailyEditorScroll" class="table-responsive dsb-editor-scroll">
                 <table class="table table-sm table-bordered align-middle daily-shift-table">
                     <thead class="table-light">
                         <tr>

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -113,6 +113,9 @@
                 data-user-autocomplete-limit="20">
             <button type="submit" class="btn btn-sm btn-warning text-nowrap">Create Absence for {{ $selectedDate }}</button>
         </form>
+        <button type="button" class="btn btn-sm btn-success text-nowrap" data-bs-toggle="modal" data-bs-target="#shiftCreateModal">
+            + Add Shift
+        </button>
         <div class="d-flex align-items-center gap-2 ms-auto">
             <span id="dailyBoardSaveStatus" class="small text-muted d-none"></span>
             <button type="button"
@@ -275,6 +278,123 @@
             class="btn btn-sm btn-outline-primary js-daily-sublist-preview">
             Final Sublist Preview
         </a>
+    </div>
+</div>
+
+<div class="modal fade" id="shiftCreateModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <form method="POST" action="{{ route('events.store') }}" class="modal-content shift-copy-form">
+            @csrf
+            <input type="hidden" name="redirect_to" value="{{ route('calendar.daily_assigner', ['date' => $selectedDate]) }}">
+            <div class="modal-header">
+                <h5 class="modal-title mb-0">New Shift for {{ $selectedDate }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body shift-copy-modal-body">
+                <datalist id="dailyCreateTitleOptions">
+                    @foreach($titleOptions as $opt)
+                        <option value="{{ $opt }}">
+                    @endforeach
+                </datalist>
+                <datalist id="dailyCreateSchoolOptions">
+                    @foreach($schoolNames as $s)
+                        <option value="{{ $s }}">
+                    @endforeach
+                </datalist>
+                <datalist id="dailyCreateOriginalUserOptions"></datalist>
+                <datalist id="dailyCreateAssignedUserOptions"></datalist>
+
+                <div class="row g-2">
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Date</label>
+                        <input type="date" name="event_date" class="form-control form-control-sm" value="{{ $selectedDate }}" readonly required>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Title</label>
+                        <input list="dailyCreateTitleOptions" name="title" class="form-control form-control-sm">
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Leave</label>
+                        <input type="text" name="Leave_type" class="form-control form-control-sm">
+                    </div>
+
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small mb-1">Original User</label>
+                        <input type="hidden" name="original_user_id" id="dailyCreateOriginalUserId">
+                        <input type="text"
+                            name="original_user_lookup"
+                            class="form-control form-control-sm"
+                            list="dailyCreateOriginalUserOptions"
+                            autocomplete="off"
+                            data-user-autocomplete
+                            data-user-autocomplete-url="{{ route('api.users.search') }}"
+                            data-user-autocomplete-hidden="#dailyCreateOriginalUserId"
+                            data-user-autocomplete-limit="20">
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small mb-1">Assigned User</label>
+                        <input type="hidden" name="assigned_user_id" id="dailyCreateAssignedUserId">
+                        <input type="text"
+                            name="assigned_user_lookup"
+                            class="form-control form-control-sm"
+                            list="dailyCreateAssignedUserOptions"
+                            autocomplete="off"
+                            data-user-autocomplete
+                            data-user-autocomplete-url="{{ route('api.users.search') }}"
+                            data-user-autocomplete-hidden="#dailyCreateAssignedUserId"
+                            data-user-autocomplete-limit="20">
+                    </div>
+
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small mb-1">School</label>
+                        <input list="dailyCreateSchoolOptions" name="school_name" class="form-control form-control-sm">
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label class="form-label small mb-1">Start</label>
+                        <input type="time" name="start_time" class="form-control form-control-sm" step="60">
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label class="form-label small mb-1">End</label>
+                        <input type="time" name="end_time" class="form-control form-control-sm" step="60">
+                    </div>
+
+                    <div class="col-12">
+                        <label class="form-label small mb-1">Lesson</label>
+                        <textarea name="Lesson" class="form-control form-control-sm" rows="2"></textarea>
+                    </div>
+
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Type</label>
+                        <select name="type" class="form-select form-select-sm">
+                            @foreach($typeOptions as $v => $label)
+                                <option value="{{ $v }}" @selected($v === \App\Enums\ShiftType::RegularTime->value)>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Status</label>
+                        <select name="status" class="form-select form-select-sm">
+                            @foreach($statusOptions as $v => $label)
+                                <option value="{{ $v }}" @selected($v === \App\Enums\EventStatus::Pending->value)>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Total</label>
+                        <input type="text" name="total_duration" class="form-control form-control-sm" placeholder="Auto">
+                    </div>
+
+                    <div class="col-12">
+                        <label class="form-label small mb-1">Notes</label>
+                        <textarea name="notes" class="form-control form-control-sm" rows="2"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-sm btn-success">Create</button>
+            </div>
+        </form>
     </div>
 </div>
 

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -206,7 +206,15 @@
                                 <textarea name="notes" class="form-control form-control-sm" rows="1" style="min-width:17rem">{{ $event->notes }}</textarea>
                             </td>
                             <td>
+                                <div class="d-inline-flex align-items-center gap-2">
                                 <button type="button" class="btn btn-sm btn-success js-dsb-row-save">Save</button>
+                                <div class="form-check mb-0">
+                                    <input class="form-check-input js-daily-exclude-event" type="checkbox" value="{{ $event->id }}" id="dailyEx{{ $event->id }}">
+                                    <label class="form-check-label small" for="dailyEx{{ $event->id }}">
+                                        Exclude
+                                    </label>
+                                </div>
+                                </div>
                             </td>
                         </tr>
                     @endforeach
@@ -218,6 +226,27 @@
 
     <div class="dsb-resize-handle" data-target="dailyEditorPane" data-storage-key="dailyShiftBoardEditorHeight">
         <span class="dsb-resize-grip">&#8942;&#8942;&#8942;</span>
+    </div>
+
+    <div class="d-flex flex-wrap gap-2 mt-2">
+        <a href="{{ route('calendar.edit.pdf.preview', ['mode' => 'tentative', 'event_date' => $selectedDate]) }}"
+            target="_blank"
+            rel="noopener"
+            class="btn btn-sm btn-outline-primary js-daily-sublist-preview">
+            Tentative Sublist Preview
+        </a>
+        <a href="{{ route('calendar.edit.pdf.preview', ['mode' => 'master', 'event_date' => $selectedDate]) }}"
+            target="_blank"
+            rel="noopener"
+            class="btn btn-sm btn-outline-primary js-daily-sublist-preview">
+            Master Sublist Preview
+        </a>
+        <a href="{{ route('calendar.edit.pdf.preview', ['mode' => 'final', 'event_date' => $selectedDate]) }}"
+            target="_blank"
+            rel="noopener"
+            class="btn btn-sm btn-outline-primary js-daily-sublist-preview">
+            Final Sublist Preview
+        </a>
     </div>
 </div>
 
@@ -248,6 +277,19 @@
         eventsUrl: @json(route('calendar.forecast.events')),
         bulkUpdateUrl: @json(route('events.bulk_update')),
     };
+</script>
+<script>
+    document.addEventListener('click', (e) => {
+        const link = e.target.closest('.js-daily-sublist-preview');
+        if (!link) return;
+
+        const url = new URL(link.href);
+        url.searchParams.delete('exclude_event_ids[]');
+        document.querySelectorAll('.js-daily-exclude-event:checked').forEach((checkbox) => {
+            url.searchParams.append('exclude_event_ids[]', checkbox.value);
+        });
+        link.href = url.toString();
+    });
 </script>
 <script src="{{ asset('js/daily-shift-board.js') }}?v={{ filemtime(public_path('js/daily-shift-board.js')) }}"></script>
 @endpush

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -69,6 +69,10 @@
             </div>
         </section>
 
+        <div class="dsb-width-handle" title="Resize SUB width" aria-hidden="true">
+            <span class="dsb-width-grip">&#8942;</span>
+        </div>
+
         <aside class="dsb-sub-section">
             <div class="dsb-section-head">
                 <span>SUB</span>

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -87,7 +87,7 @@
     <div class="d-flex align-items-center justify-content-between mt-2 mb-2">
         <div class="fw-semibold">Shift Editor</div>
         <div class="d-flex align-items-center gap-2">
-            <span id="dailyBoardSaveStatus" class="small text-muted"></span>
+            <span id="dailyBoardSaveStatus" class="small text-muted d-none"></span>
             <button type="button"
                 class="btn btn-sm btn-primary"
                 id="dailyBoardBulkSave"

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -231,6 +231,11 @@
                             <td>
                                 <div class="d-inline-flex align-items-center gap-2">
                                 <button type="button" class="btn btn-sm btn-success js-dsb-row-save">Save</button>
+                                <button type="button"
+                                    class="btn btn-sm btn-outline-secondary js-shift-copy"
+                                    data-store="{{ route('events.copy') }}">
+                                    Copy
+                                </button>
                                 <div class="form-check mb-0">
                                     <input class="form-check-input js-daily-exclude-event" type="checkbox" value="{{ $event->id }}" id="dailyEx{{ $event->id }}">
                                     <label class="form-check-label small" for="dailyEx{{ $event->id }}">
@@ -273,6 +278,112 @@
     </div>
 </div>
 
+<div class="modal fade" id="shiftCopyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <form method="POST" action="{{ route('events.copy') }}" class="modal-content shift-copy-form" id="shiftCopyForm">
+            @csrf
+            <div class="modal-header">
+                <h5 class="modal-title mb-0" id="shiftCopyModalTitle">Copy Shift</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body shift-copy-modal-body">
+                <datalist id="dailyCopyTitleOptions">
+                    @foreach($titleOptions as $opt)
+                        <option value="{{ $opt }}">
+                    @endforeach
+                </datalist>
+                <datalist id="dailyCopySchoolOptions">
+                    @foreach($schoolNames as $s)
+                        <option value="{{ $s }}">
+                    @endforeach
+                </datalist>
+
+                <div class="row g-2">
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Date</label>
+                        <input type="date" name="event_date" class="form-control form-control-sm" required>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Title</label>
+                        <input list="dailyCopyTitleOptions" name="title" class="form-control form-control-sm">
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Leave</label>
+                        <input type="text" name="Leave_type" class="form-control form-control-sm">
+                    </div>
+
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small mb-1">Original User</label>
+                        <select name="original_user_id" class="form-select form-select-sm">
+                            <option value="">-</option>
+                            @foreach($userOptions as $u)
+                                <option value="{{ $u->id }}">{{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small mb-1">Assigned User</label>
+                        <select name="assigned_user_id" class="form-select form-select-sm">
+                            <option value="">-</option>
+                            @foreach($userOptions as $u)
+                                <option value="{{ $u->id }}">{{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]</option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small mb-1">School</label>
+                        <input list="dailyCopySchoolOptions" name="school_name" class="form-control form-control-sm">
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label class="form-label small mb-1">Start</label>
+                        <input type="time" name="start_time" class="form-control form-control-sm" step="60">
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label class="form-label small mb-1">End</label>
+                        <input type="time" name="end_time" class="form-control form-control-sm" step="60">
+                    </div>
+
+                    <div class="col-12">
+                        <label class="form-label small mb-1">Lesson</label>
+                        <textarea name="Lesson" class="form-control form-control-sm" rows="2"></textarea>
+                    </div>
+
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Type</label>
+                        <select name="type" class="form-select form-select-sm" required>
+                            @foreach($typeOptions as $v => $label)
+                                <option value="{{ $v }}">{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Status</label>
+                        <select name="status" class="form-select form-select-sm" required>
+                            @foreach($statusOptions as $v => $label)
+                                <option value="{{ $v }}">{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Total</label>
+                        <input type="text" name="total_duration" class="form-control form-control-sm" placeholder="Auto">
+                    </div>
+
+                    <div class="col-12">
+                        <label class="form-label small mb-1">Notes</label>
+                        <textarea name="notes" class="form-control form-control-sm" rows="2"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-sm btn-primary">Create Copy</button>
+            </div>
+        </form>
+    </div>
+</div>
+
 <div class="modal fade" id="dailyEventModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
@@ -289,6 +400,7 @@
 @push('styles')
 <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.css" rel="stylesheet">
 <link href="{{ asset('css/forecast-custom.css') }}" rel="stylesheet">
+<link href="{{ asset('css/shift-copy-modal.css') }}?v={{ filemtime(public_path('css/shift-copy-modal.css')) }}" rel="stylesheet">
 <link href="{{ asset('css/daily-shift-board.css') }}?v={{ filemtime(public_path('css/daily-shift-board.css')) }}" rel="stylesheet">
 @endpush
 
@@ -302,6 +414,7 @@
     };
 </script>
 <script src="{{ asset('js/user-autocomplete.js') }}?v={{ filemtime(public_path('js/user-autocomplete.js')) }}"></script>
+<script src="{{ asset('js/shift-copy-modal.js') }}?v={{ filemtime(public_path('js/shift-copy-modal.js')) }}"></script>
 <script>
     document.addEventListener('click', (e) => {
         const link = e.target.closest('.js-daily-sublist-preview');

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -88,9 +88,32 @@
         <span class="dsb-resize-grip">&#8942;&#8942;&#8942;</span>
     </div>
 
-    <div class="d-flex align-items-center justify-content-between mt-2 mb-2">
+    <div class="d-flex align-items-center gap-2 mt-2 mb-2">
         <div class="fw-semibold">Shift Editor</div>
-        <div class="d-flex align-items-center gap-2">
+        <form method="POST" action="{{ route('leaves.store') }}" class="d-flex align-items-center gap-1">
+            @csrf
+            <input type="hidden" name="kind" value="absence">
+            <input type="hidden" name="excused" value="unexcused">
+            <input type="hidden" name="status" value="pending">
+            <input type="hidden" name="start_date" value="{{ $selectedDate }}">
+            <input type="hidden" name="redirect_to" value="{{ route('calendar.daily_assigner', ['date' => $selectedDate]) }}">
+            <input type="hidden" name="user_id" id="dailyAbsenceUserId">
+            <datalist id="dailyAbsenceUserOptions"></datalist>
+            <input type="text"
+                name="user_lookup"
+                class="form-control form-control-sm"
+                style="width: 16rem"
+                placeholder="Search user"
+                list="dailyAbsenceUserOptions"
+                autocomplete="off"
+                required
+                data-user-autocomplete
+                data-user-autocomplete-url="{{ route('api.users.search') }}"
+                data-user-autocomplete-hidden="#dailyAbsenceUserId"
+                data-user-autocomplete-limit="20">
+            <button type="submit" class="btn btn-sm btn-warning text-nowrap">Create Absence for {{ $selectedDate }}</button>
+        </form>
+        <div class="d-flex align-items-center gap-2 ms-auto">
             <span id="dailyBoardSaveStatus" class="small text-muted d-none"></span>
             <button type="button"
                 class="btn btn-sm btn-primary"
@@ -278,6 +301,7 @@
         bulkUpdateUrl: @json(route('events.bulk_update')),
     };
 </script>
+<script src="{{ asset('js/user-autocomplete.js') }}?v={{ filemtime(public_path('js/user-autocomplete.js')) }}"></script>
 <script>
     document.addEventListener('click', (e) => {
         const link = e.target.closest('.js-daily-sublist-preview');

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -161,7 +161,7 @@
                                 <input type="text" name="total_duration" class="form-control form-control-sm js-dsb-total" value="{{ $event->total_duration }}" placeholder="H:MM" readonly style="min-width:4.5rem">
                             </td>
                             <td>
-                                <textarea name="Lesson" class="form-control form-control-sm" rows="1" style="min-width:9rem">{{ $event->Lesson }}</textarea>
+                                <textarea name="Lesson" class="form-control form-control-sm" rows="1" style="min-width:16.2rem">{{ $event->Lesson }}</textarea>
                             </td>
                             <td>
                                 <select name="assigned_user_id" class="form-select form-select-sm" style="min-width:11rem">
@@ -174,21 +174,21 @@
                                 </select>
                             </td>
                             <td>
-                                <select name="type" class="form-select form-select-sm">
+                                <select name="type" class="form-select form-select-sm" style="min-width:4.8rem">
                                     @foreach($typeOptions as $v => $label)
                                         <option value="{{ $v }}" @selected($event->type === $v)>{{ $label }}</option>
                                     @endforeach
                                 </select>
                             </td>
                             <td>
-                                <select name="status" class="form-select form-select-sm js-dsb-status">
+                                <select name="status" class="form-select form-select-sm js-dsb-status" style="min-width:7rem">
                                     @foreach($statusOptions as $v => $label)
                                         <option value="{{ $v }}" @selected($event->status === $v)>{{ $label }}</option>
                                     @endforeach
                                 </select>
                             </td>
                             <td>
-                                <textarea name="notes" class="form-control form-control-sm" rows="1" style="min-width:10rem">{{ $event->notes }}</textarea>
+                                <textarea name="notes" class="form-control form-control-sm" rows="1" style="min-width:17rem">{{ $event->notes }}</textarea>
                             </td>
                             <td>
                                 <button type="button" class="btn btn-sm btn-success js-dsb-row-save">Save</button>

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -1,0 +1,226 @@
+{{-- resources/views/calendar/dailyBoard.blade.php --}}
+
+@extends('layouts.app')
+@section('title', 'Daily Shift Board')
+
+@section('content')
+@php
+    $fmtDate = function ($v) {
+        if (!$v) return '';
+        try { return \Illuminate\Support\Carbon::parse($v)->format('Y-m-d'); } catch (\Throwable $e) { return ''; }
+    };
+    $fmtTime = function ($v) {
+        if (empty($v)) return '';
+        if ($v instanceof \DateTimeInterface) return $v->format('H:i');
+        $s = (string) $v;
+        if (preg_match('/^\s*(\d{2}:\d{2})/', $s, $m)) return $m[1];
+        return '';
+    };
+    $titleOptions = ['Support Shift', 'OPPT/ML', '#Memo', 'Cover Shift'];
+@endphp
+
+<div class="daily-shift-board">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <div>
+            <h2 class="mb-0">Daily Shift Board</h2>
+            <div class="text-muted small">Forecast List + Shift Assigner</div>
+        </div>
+        <div class="d-flex align-items-center gap-2">
+            <span class="badge text-bg-info">Admin View</span>
+            <a href="{{ route('calendar.forecast', ['month' => substr($selectedDate, 0, 7)]) }}" class="btn btn-sm btn-outline-secondary">Forecast</a>
+            <a href="{{ route('calendar.edit', ['event_date' => $selectedDate]) }}" class="btn btn-sm btn-outline-secondary">Full Assigner</a>
+        </div>
+    </div>
+
+    <form method="GET" action="{{ route('calendar.daily_assigner') }}" class="dsb-date-form mb-2">
+        <div class="row g-2 align-items-end">
+            <div class="col-7 col-sm-4 col-lg-2">
+                <label class="form-label small mb-1">Date</label>
+                <input type="date" name="date" class="form-control form-control-sm" value="{{ $selectedDate }}" required>
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-sm btn-primary">Select</button>
+            </div>
+            <div class="col-auto">
+                <a href="{{ route('calendar.daily_assigner', ['date' => now()->toDateString()]) }}" class="btn btn-sm btn-outline-secondary">Today</a>
+            </div>
+            <div class="col text-end">
+                <span class="text-muted small">{{ $events->count() }} Shift(s)</span>
+            </div>
+        </div>
+    </form>
+
+    <div class="dsb-top-grid">
+        <section class="dsb-calendar-section">
+            <div class="dsb-section-head">
+                <span>Forecast List</span>
+                <span class="text-muted small">{{ $selectedDate }}</span>
+            </div>
+            <div id="dailyCalendarPane" class="dsb-calendar-pane">
+                <div id="dailyCalendar"></div>
+            </div>
+        </section>
+
+        <aside class="dsb-sub-section">
+            <div class="dsb-section-head">
+                <span>SUB</span>
+                <span id="dailySubCount" class="badge text-bg-secondary">0</span>
+            </div>
+            <div id="dailySubSummary" class="dsb-sub-summary">
+                <div class="text-muted small">Loading...</div>
+            </div>
+        </aside>
+    </div>
+
+    <div class="dsb-resize-handle" data-target="dailyCalendarPane" data-storage-key="dailyShiftBoardCalendarHeight">
+        <span class="dsb-resize-grip">&#8942;&#8942;&#8942;</span>
+    </div>
+
+    <div class="d-flex align-items-center justify-content-between mt-2 mb-2">
+        <div class="fw-semibold">Shift Editor</div>
+        <div class="d-flex align-items-center gap-2">
+            <span id="dailyBoardSaveStatus" class="small text-muted"></span>
+            <button type="button"
+                class="btn btn-sm btn-primary"
+                id="dailyBoardBulkSave"
+                data-url="{{ route('events.bulk_update') }}">
+                Bulk Save
+            </button>
+        </div>
+    </div>
+
+    <div id="dailyEditorPane" class="dsb-editor-pane">
+        @if($events->isEmpty())
+            <div class="alert alert-light border mb-0">No event matches this date.</div>
+        @else
+            <datalist id="dailyTitleOptions">
+                @foreach($titleOptions as $opt)
+                    <option value="{{ $opt }}">
+                @endforeach
+            </datalist>
+            <datalist id="dailySchoolOptions">
+                @foreach($schoolNames as $s)
+                    <option value="{{ $s }}">
+                @endforeach
+            </datalist>
+
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle daily-shift-table">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>Title</th>
+                            <th>Original</th>
+                            <th>Leave</th>
+                            <th>School</th>
+                            <th>Date</th>
+                            <th>Start</th>
+                            <th>End</th>
+                            <th>Total</th>
+                            <th>Lesson</th>
+                            <th>Assigned</th>
+                            <th>Type</th>
+                            <th>Status</th>
+                            <th>Notes</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach($events as $event)
+                        <tr class="js-daily-event-row" data-event-id="{{ $event->id }}">
+                            <td class="text-muted">#{{ $event->id }}</td>
+                            <td>
+                                <input list="dailyTitleOptions" name="title" class="form-control form-control-sm" value="{{ $event->title }}" style="min-width:9rem">
+                            </td>
+                            <td>
+                                <select name="original_user_id" class="form-select form-select-sm" style="min-width:11rem">
+                                    <option value="">-</option>
+                                    @foreach($userOptions as $u)
+                                        <option value="{{ $u->id }}" @selected($event->original_user_id === $u->id)>
+                                            {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </td>
+                            <td>
+                                <input type="text" name="Leave_type" class="form-control form-control-sm" value="{{ $event->Leave_type }}" style="min-width:7rem">
+                            </td>
+                            <td>
+                                <input list="dailySchoolOptions" name="school_name" class="form-control form-control-sm" value="{{ $event->school_name }}" style="min-width:9rem">
+                            </td>
+                            <td>
+                                <input type="date" name="event_date" class="form-control form-control-sm" value="{{ $fmtDate($event->event_date) }}" style="min-width:8.5rem">
+                            </td>
+                            <td>
+                                <input type="time" name="start_time" class="form-control form-control-sm js-dsb-time" value="{{ $fmtTime($event->start_time) }}" step="60">
+                            </td>
+                            <td>
+                                <input type="time" name="end_time" class="form-control form-control-sm js-dsb-time" value="{{ $fmtTime($event->end_time) }}" step="60">
+                            </td>
+                            <td>
+                                <input type="text" name="total_duration" class="form-control form-control-sm js-dsb-total" value="{{ $event->total_duration }}" placeholder="H:MM" readonly style="min-width:4.5rem">
+                            </td>
+                            <td>
+                                <textarea name="Lesson" class="form-control form-control-sm" rows="1" style="min-width:9rem">{{ $event->Lesson }}</textarea>
+                            </td>
+                            <td>
+                                <select name="assigned_user_id" class="form-select form-select-sm" style="min-width:11rem">
+                                    <option value="">-</option>
+                                    @foreach($userOptions as $u)
+                                        <option value="{{ $u->id }}" @selected($event->assigned_user_id === $u->id)>
+                                            {{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </td>
+                            <td>
+                                <select name="type" class="form-select form-select-sm">
+                                    @foreach($typeOptions as $v => $label)
+                                        <option value="{{ $v }}" @selected($event->type === $v)>{{ $label }}</option>
+                                    @endforeach
+                                </select>
+                            </td>
+                            <td>
+                                <select name="status" class="form-select form-select-sm js-dsb-status">
+                                    @foreach($statusOptions as $v => $label)
+                                        <option value="{{ $v }}" @selected($event->status === $v)>{{ $label }}</option>
+                                    @endforeach
+                                </select>
+                            </td>
+                            <td>
+                                <textarea name="notes" class="form-control form-control-sm" rows="1" style="min-width:10rem">{{ $event->notes }}</textarea>
+                            </td>
+                            <td>
+                                <button type="button" class="btn btn-sm btn-success js-dsb-row-save">Save</button>
+                            </td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </div>
+
+    <div class="dsb-resize-handle" data-target="dailyEditorPane" data-storage-key="dailyShiftBoardEditorHeight">
+        <span class="dsb-resize-grip">&#8942;&#8942;&#8942;</span>
+    </div>
+</div>
+@endsection
+
+@push('styles')
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.css" rel="stylesheet">
+<link href="{{ asset('css/forecast-custom.css') }}" rel="stylesheet">
+<link href="{{ asset('css/daily-shift-board.css') }}?v={{ filemtime(public_path('css/daily-shift-board.css')) }}" rel="stylesheet">
+@endpush
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js"></script>
+<script>
+    window.dailyShiftBoard = {
+        selectedDate: @json($selectedDate),
+        eventsUrl: @json(route('calendar.forecast.events')),
+        bulkUpdateUrl: @json(route('events.bulk_update')),
+    };
+</script>
+<script src="{{ asset('js/daily-shift-board.js') }}?v={{ filemtime(public_path('js/daily-shift-board.js')) }}"></script>
+@endpush

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -140,7 +140,10 @@
                     <tbody>
                     @foreach($events as $event)
                         <tr class="js-daily-event-row" data-event-id="{{ $event->id }}">
-                            <td class="text-muted">#{{ $event->id }}</td>
+                            <td class="text-muted">
+                                #{{ $event->id }}
+                                <input type="hidden" name="updated_at" value="{{ $event->updated_at?->format('Y-m-d H:i:s') }}">
+                            </td>
                             <td>
                                 <input list="dailyTitleOptions" name="title" class="form-control form-control-sm" value="{{ $event->title }}" style="min-width:9rem">
                             </td>

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -239,6 +239,21 @@
                                     data-store="{{ route('events.copy') }}">
                                     Copy
                                 </button>
+                                @if($event->source_leave_id)
+                                    <button type="button"
+                                        class="btn btn-sm btn-secondary"
+                                        disabled
+                                        title="Managed by absence">
+                                        Delete
+                                    </button>
+                                @else
+                                    <button type="button"
+                                        class="btn btn-sm btn-outline-danger js-delete"
+                                        data-url="{{ route('events.destroy', $event) }}"
+                                        data-date="{{ $event->event_date?->format('Y-m-d') ?? 'not set' }}">
+                                        Delete
+                                    </button>
+                                @endif
                                 <div class="form-check mb-0">
                                     <input class="form-check-input js-daily-exclude-event" type="checkbox" value="{{ $event->id }}" id="dailyEx{{ $event->id }}">
                                     <label class="form-check-label small" for="dailyEx{{ $event->id }}">
@@ -254,6 +269,11 @@
             </div>
         @endif
     </div>
+
+    <form id="js-delete-form" method="POST" style="display:none;">
+        @csrf
+        @method('DELETE')
+    </form>
 
     <div class="dsb-resize-handle" data-target="dailyEditorPane" data-storage-key="dailyShiftBoardEditorHeight">
         <span class="dsb-resize-grip">&#8942;&#8942;&#8942;</span>
@@ -515,6 +535,24 @@
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content border-0 shadow-sm">
+            <div class="modal-header bg-danger text-white py-2">
+                <h6 class="modal-title" id="deleteConfirmLabel">Delete Confirmation</h6>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0" id="deleteConfirmText">Are you sure you want to delete this shift?</p>
+            </div>
+            <div class="modal-footer py-2">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger btn-sm" id="confirmDeleteBtn">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
 @endsection
 
 @push('styles')
@@ -535,6 +573,28 @@
 </script>
 <script src="{{ asset('js/user-autocomplete.js') }}?v={{ filemtime(public_path('js/user-autocomplete.js')) }}"></script>
 <script src="{{ asset('js/shift-copy-modal.js') }}?v={{ filemtime(public_path('js/shift-copy-modal.js')) }}"></script>
+<script>
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('.js-delete');
+        if (!btn) return;
+
+        const modalText = document.getElementById('deleteConfirmText');
+        modalText.textContent = `Are you sure you want to delete ${btn.dataset.date || 'this shift'}?`;
+
+        const form = document.getElementById('js-delete-form');
+        form.action = btn.dataset.url;
+
+        const modalEl = document.getElementById('deleteConfirmModal');
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+
+        const confirmBtn = document.getElementById('confirmDeleteBtn');
+        confirmBtn.onclick = () => {
+            modal.hide();
+            form.submit();
+        };
+    });
+</script>
 <script>
     document.addEventListener('click', (e) => {
         const link = e.target.closest('.js-daily-sublist-preview');

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -16,6 +16,8 @@
         if (preg_match('/^\s*(\d{2}:\d{2})/', $s, $m)) return $m[1];
         return '';
     };
+    $previousDate = \Illuminate\Support\Carbon::parse($selectedDate)->subDay()->toDateString();
+    $nextDate = \Illuminate\Support\Carbon::parse($selectedDate)->addDay()->toDateString();
     $titleOptions = ['Support Shift', 'OPPT/ML', '#Memo', 'Cover Shift'];
 @endphp
 
@@ -40,6 +42,12 @@
             </div>
             <div class="col-auto">
                 <button type="submit" class="btn btn-sm btn-primary">Select</button>
+            </div>
+            <div class="col-auto">
+                <div class="btn-group btn-group-sm" role="group" aria-label="Daily navigation">
+                    <a href="{{ route('calendar.daily_assigner', ['date' => $previousDate]) }}" class="btn btn-outline-secondary">&lt;</a>
+                    <a href="{{ route('calendar.daily_assigner', ['date' => $nextDate]) }}" class="btn btn-outline-secondary">&gt;</a>
+                </div>
             </div>
             <div class="col-auto">
                 <a href="{{ route('calendar.daily_assigner', ['date' => now()->toDateString()]) }}" class="btn btn-sm btn-outline-secondary">Today</a>

--- a/resources/views/calendar/dailyBoard.blade.php
+++ b/resources/views/calendar/dailyBoard.blade.php
@@ -205,6 +205,18 @@
         <span class="dsb-resize-grip">&#8942;&#8942;&#8942;</span>
     </div>
 </div>
+
+<div class="modal fade" id="dailyEventModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title mb-0" id="dailyEventModalTitle">Shift Details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body" id="dailyEventModalBody">Reading...</div>
+        </div>
+    </div>
+</div>
 @endsection
 
 @push('styles')

--- a/resources/views/calendar/edit.blade.php
+++ b/resources/views/calendar/edit.blade.php
@@ -250,6 +250,7 @@
             data-event-id="{{ $event->id }}">
           @csrf
           @method('PUT')
+          <input type="hidden" name="updated_at" value="{{ $event->updated_at?->format('Y-m-d H:i:s') }}">
 
           <div class="card-body py-1 px-2 light-blue">
             <div class="mb-0 d-grid gap-0"> {{-- gapは下記四項目すべてに適用する --}}
@@ -655,15 +656,78 @@ document.addEventListener('input', (e) => {
     return obj;
   }
 
+  function stableJson(data) {
+    return JSON.stringify(
+      Object.keys(data).sort().reduce((sorted, key) => {
+        sorted[key] = data[key];
+        return sorted;
+      }, {})
+    );
+  }
+
+  function formComparableState(form) {
+    const data = formToObject(form);
+    delete data.updated_at;
+    return stableJson(data);
+  }
+
+  function setFormBaseline(form) {
+    form.dataset.originalState = formComparableState(form);
+    form.classList.remove('is-dirty');
+  }
+
+  function isFormDirty(form) {
+    return form.dataset.originalState !== formComparableState(form);
+  }
+
+  function refreshFormDirtyState(form) {
+    form.classList.toggle('is-dirty', isFormDirty(form));
+  }
+
+  function currentEventForms() {
+    let forms = document.querySelectorAll('.js-event-form');
+    if (!forms.length) {
+      forms = document.querySelectorAll('.row .card form'); // 従来の対象（後方互換）
+    }
+    return Array.from(forms);
+  }
+
+  function initFormBaselines() {
+    currentEventForms().forEach((form) => {
+      const card = form.closest('.card');
+      if (card) recalcTotal(card);
+      setFormBaseline(form);
+    });
+  }
+
+  document.addEventListener('input', (e) => {
+    const form = e.target.closest('.js-event-form');
+    if (!form || !e.target.matches('input[name], select[name], textarea[name]')) return;
+    refreshFormDirtyState(form);
+  });
+
+  document.addEventListener('change', (e) => {
+    const form = e.target.closest('.js-event-form');
+    if (!form || !e.target.matches('input[name], select[name], textarea[name]')) return;
+    refreshFormDirtyState(form);
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initFormBaselines);
+  } else {
+    initFormBaselines();
+  }
+
   bulkBtn.addEventListener('click', async () => {
     // まずはイベント編集フォーム（識別クラス）を優先的に取得。無ければ従来セレクタを使用。
-    let cards = document.querySelectorAll('.js-event-form');
-    if (!cards.length) {
-      cards = document.querySelectorAll('.row .card form'); // 従来の対象（後方互換）
-    }
+    const cards = currentEventForms();
     const items = [];
 
     cards.forEach(form => {
+      if (!isFormDirty(form)) return;
+      const card = form.closest('.card');
+      if (card) recalcTotal(card, { force: true });
+
       // data-event-id を優先、無ければ従来の URL 解析で補完
       const dataId = form.dataset?.eventId ? parseInt(form.dataset.eventId, 10) : null;
       const urlId  = parseEventIdFromAction(form.action);
@@ -675,7 +739,7 @@ document.addEventListener('input', (e) => {
     });
 
     if (!items.length) {
-      alert('保存対象がありません。');
+      alert('No changed shifts to save.');
       return;
     }
 
@@ -690,9 +754,12 @@ document.addEventListener('input', (e) => {
         },
         body: JSON.stringify({ items }),
       });
-      if (!res.ok) {
-        const json = await res.json().catch(() => ({}));
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json?.ok === false) {
         alert(json?.message || '保存に失敗しました。');
+        if (json?.updated > 0) {
+          location.reload();
+        }
         return;
       }
       // ✅ 成功時はアラートを出さず、フラッシュ表示のために即リロード

--- a/resources/views/calendar/edit.blade.php
+++ b/resources/views/calendar/edit.blade.php
@@ -384,12 +384,21 @@
                 data-store="{{ route('events.copy') }}">
                 Copy
               </button>
-              <button type="button"
-                class="btn btn-sm btn-outline-danger js-delete"
-                data-url="{{ route('events.destroy', $event) }}"
-                data-date="{{ $event->event_date?->format('Y-m-d') ?? '未設定' }}">
-                Delete
-              </button>
+              @if($event->source_leave_id)
+                <button type="button"
+                  class="btn btn-sm btn-secondary"
+                  disabled
+                  title="Managed by absence">
+                  Delete
+                </button>
+              @else
+                <button type="button"
+                  class="btn btn-sm btn-outline-danger js-delete"
+                  data-url="{{ route('events.destroy', $event) }}"
+                  data-date="{{ $event->event_date?->format('Y-m-d') ?? '未設定' }}">
+                  Delete
+                </button>
+              @endif
               <button type="submit" class="btn btn-sm btn-primary">Save</button>
             </div>
             <small class="{{ $cls }} text-left d-block mt-1">

--- a/resources/views/calendar/edit.blade.php
+++ b/resources/views/calendar/edit.blade.php
@@ -384,7 +384,7 @@
             {{-- 9 --}}
             <div class="card-footer bg-white d-flex justify-content-between align-items-center py-2 px-2 gap-1">             
               <button type="button"
-                class="btn btn-sm btn-outline-secondary js-duplicate"
+                class="btn btn-sm btn-outline-secondary js-shift-copy"
                 data-store="{{ route('events.copy') }}">
                 Copy
               </button>
@@ -436,6 +436,112 @@
           <button type="button" class="btn btn-danger btn-sm" id="confirmDeleteBtn">Delete</button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="shiftCopyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <form method="POST" action="{{ route('events.copy') }}" class="modal-content shift-copy-form" id="shiftCopyForm">
+        @csrf
+        <div class="modal-header">
+          <h5 class="modal-title mb-0" id="shiftCopyModalTitle">Copy Shift</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body shift-copy-modal-body">
+          <datalist id="copyTitleOptions">
+            @foreach (['Support Shift', 'OPPT/ML', '#Memo', 'Cover Shift'] as $opt)
+              <option value="{{ $opt }}">
+            @endforeach
+          </datalist>
+          <datalist id="copySchoolOptions">
+            @foreach ($schoolNames as $s)
+              <option value="{{ $s }}">
+            @endforeach
+          </datalist>
+
+          <div class="row g-2">
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Date</label>
+              <input type="date" name="event_date" class="form-control form-control-sm" required>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Title</label>
+              <input list="copyTitleOptions" name="title" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Leave</label>
+              <input type="text" name="Leave_type" class="form-control form-control-sm">
+            </div>
+
+            <div class="col-12 col-md-6">
+              <label class="form-label small mb-1">Original User</label>
+              <select name="original_user_id" class="form-select form-select-sm">
+                <option value="">-</option>
+                @foreach($userOptions as $u)
+                  <option value="{{ $u->id }}">{{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]</option>
+                @endforeach
+              </select>
+            </div>
+            <div class="col-12 col-md-6">
+              <label class="form-label small mb-1">Assigned User</label>
+              <select name="assigned_user_id" class="form-select form-select-sm">
+                <option value="">-</option>
+                @foreach($userOptions as $u)
+                  <option value="{{ $u->id }}">{{ $u->first_name }} {{ $u->family_name }} [{{ $u->employee_code }}]</option>
+                @endforeach
+              </select>
+            </div>
+
+            <div class="col-12 col-md-6">
+              <label class="form-label small mb-1">School</label>
+              <input list="copySchoolOptions" name="school_name" class="form-control form-control-sm">
+            </div>
+            <div class="col-6 col-md-3">
+              <label class="form-label small mb-1">Start</label>
+              <input type="time" name="start_time" class="form-control form-control-sm" step="60">
+            </div>
+            <div class="col-6 col-md-3">
+              <label class="form-label small mb-1">End</label>
+              <input type="time" name="end_time" class="form-control form-control-sm" step="60">
+            </div>
+
+            <div class="col-12">
+              <label class="form-label small mb-1">Lesson</label>
+              <textarea name="Lesson" class="form-control form-control-sm" rows="2"></textarea>
+            </div>
+
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Type</label>
+              <select name="type" class="form-select form-select-sm" required>
+                @foreach($typeOptions as $v => $label)
+                  <option value="{{ $v }}">{{ $label }}</option>
+                @endforeach
+              </select>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Status</label>
+              <select name="status" class="form-select form-select-sm" required>
+                @foreach($statusOptions as $v => $label)
+                  <option value="{{ $v }}">{{ $label }}</option>
+                @endforeach
+              </select>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Total</label>
+              <input type="text" name="total_duration" class="form-control form-control-sm" placeholder="Auto">
+            </div>
+
+            <div class="col-12">
+              <label class="form-label small mb-1">Notes</label>
+              <textarea name="notes" class="form-control form-control-sm" rows="2"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-sm btn-primary">Create Copy</button>
+        </div>
+      </form>
     </div>
   </div>
 
@@ -494,6 +600,7 @@
 @endsection
 
 @push('styles')
+<link href="{{ asset('css/shift-copy-modal.css') }}?v={{ filemtime(public_path('css/shift-copy-modal.css')) }}" rel="stylesheet">
 <style>
   .card-body.light-blue {
     background-color: #eef6ff;
@@ -597,35 +704,7 @@ document.addEventListener('input', (e) => {
   });
 </script>
 
-<script>
-  // 複写：現在のフォーム値で /events に POST
-  document.addEventListener('click', (e) => {
-    const btn = e.target.closest('.js-duplicate');
-    if (!btn) return;
-
-    const form = btn.closest('form');
-    if (!form) return;
-
-    // PUT のメソッド偽装を外す
-    const spoof = form.querySelector('input[name="_method"]');
-    if (spoof) spoof.remove();
-
-    // 送信先を store に差し替え、method を POST に
-    form.action = btn.dataset.store;
-    form.method = 'POST';
-
-    // 複写フラグ（必要ならコントローラで分岐可能）
-    if (!form.querySelector('input[name="_duplicate"]')) {
-      const f = document.createElement('input');
-      f.type = 'hidden';
-      f.name = '_duplicate';
-      f.value = '1';
-      form.appendChild(f);
-    }
-
-    form.submit();
-  });
-</script>
+<script src="{{ asset('js/shift-copy-modal.js') }}?v={{ filemtime(public_path('js/shift-copy-modal.js')) }}"></script>
 
 <script>
 // 一括保存

--- a/resources/views/calendar/edit.blade.php
+++ b/resources/views/calendar/edit.blade.php
@@ -198,13 +198,9 @@
   
   <div class="d-flex align-items-center gap-1 mb-2">
     {{-- 空白イベント追加 -------------------------------------------------------------------------------------------}}
-    <form method="POST" action="{{ route('events.store') }}" class="m-0 p-0">
-      @csrf
-      <input type="hidden" name="event_date" value="{{ request('event_date', now()->toDateString()) }}">
-      <button type="submit" class="btn btn-sm btn-success">
-        ＋ Add Blank
-      </button>
-    </form>
+    <button type="button" class="btn btn-sm btn-success" data-bs-toggle="modal" data-bs-target="#shiftCreateModal">
+      + Add Shift
+    </button>
     <button type="button"
       class="btn btn-sm btn-primary"
       id="js-bulk-save"
@@ -436,6 +432,123 @@
           <button type="button" class="btn btn-danger btn-sm" id="confirmDeleteBtn">Delete</button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="shiftCreateModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <form method="POST" action="{{ route('events.store') }}" class="modal-content shift-copy-form">
+        @csrf
+        <input type="hidden" name="redirect_to" value="{{ url()->full() }}">
+        <div class="modal-header">
+          <h5 class="modal-title mb-0">New Shift</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body shift-copy-modal-body">
+          <datalist id="createTitleOptions">
+            @foreach (['Support Shift', 'OPPT/ML', '#Memo', 'Cover Shift'] as $opt)
+              <option value="{{ $opt }}">
+            @endforeach
+          </datalist>
+          <datalist id="createSchoolOptions">
+            @foreach ($schoolNames as $s)
+              <option value="{{ $s }}">
+            @endforeach
+          </datalist>
+          <datalist id="createOriginalUserOptions"></datalist>
+          <datalist id="createAssignedUserOptions"></datalist>
+
+          <div class="row g-2">
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Date</label>
+              <input type="date" name="event_date" class="form-control form-control-sm" value="{{ request('event_date', now()->toDateString()) }}" required>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Title</label>
+              <input list="createTitleOptions" name="title" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Leave</label>
+              <input type="text" name="Leave_type" class="form-control form-control-sm">
+            </div>
+
+            <div class="col-12 col-md-6">
+              <label class="form-label small mb-1">Original User</label>
+              <input type="hidden" name="original_user_id" id="createOriginalUserId">
+              <input type="text"
+                name="original_user_lookup"
+                class="form-control form-control-sm"
+                list="createOriginalUserOptions"
+                autocomplete="off"
+                data-user-autocomplete
+                data-user-autocomplete-url="{{ route('api.users.search') }}"
+                data-user-autocomplete-hidden="#createOriginalUserId"
+                data-user-autocomplete-limit="20">
+            </div>
+            <div class="col-12 col-md-6">
+              <label class="form-label small mb-1">Assigned User</label>
+              <input type="hidden" name="assigned_user_id" id="createAssignedUserId">
+              <input type="text"
+                name="assigned_user_lookup"
+                class="form-control form-control-sm"
+                list="createAssignedUserOptions"
+                autocomplete="off"
+                data-user-autocomplete
+                data-user-autocomplete-url="{{ route('api.users.search') }}"
+                data-user-autocomplete-hidden="#createAssignedUserId"
+                data-user-autocomplete-limit="20">
+            </div>
+
+            <div class="col-12 col-md-6">
+              <label class="form-label small mb-1">School</label>
+              <input list="createSchoolOptions" name="school_name" class="form-control form-control-sm">
+            </div>
+            <div class="col-6 col-md-3">
+              <label class="form-label small mb-1">Start</label>
+              <input type="time" name="start_time" class="form-control form-control-sm" step="60">
+            </div>
+            <div class="col-6 col-md-3">
+              <label class="form-label small mb-1">End</label>
+              <input type="time" name="end_time" class="form-control form-control-sm" step="60">
+            </div>
+
+            <div class="col-12">
+              <label class="form-label small mb-1">Lesson</label>
+              <textarea name="Lesson" class="form-control form-control-sm" rows="2"></textarea>
+            </div>
+
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Type</label>
+              <select name="type" class="form-select form-select-sm">
+                @foreach($typeOptions as $v => $label)
+                  <option value="{{ $v }}" @selected($v === \App\Enums\ShiftType::RegularTime->value)>{{ $label }}</option>
+                @endforeach
+              </select>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Status</label>
+              <select name="status" class="form-select form-select-sm">
+                @foreach($statusOptions as $v => $label)
+                  <option value="{{ $v }}" @selected($v === \App\Enums\EventStatus::Pending->value)>{{ $label }}</option>
+                @endforeach
+              </select>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label small mb-1">Total</label>
+              <input type="text" name="total_duration" class="form-control form-control-sm" placeholder="Auto">
+            </div>
+
+            <div class="col-12">
+              <label class="form-label small mb-1">Notes</label>
+              <textarea name="notes" class="form-control form-control-sm" rows="2"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-sm btn-success">Create</button>
+        </div>
+      </form>
     </div>
   </div>
 
@@ -704,6 +817,7 @@ document.addEventListener('input', (e) => {
   });
 </script>
 
+<script src="{{ asset('js/user-autocomplete.js') }}?v={{ filemtime(public_path('js/user-autocomplete.js')) }}"></script>
 <script src="{{ asset('js/shift-copy-modal.js') }}?v={{ filemtime(public_path('js/shift-copy-modal.js')) }}"></script>
 
 <script>

--- a/resources/views/calendar/forecast.blade.php
+++ b/resources/views/calendar/forecast.blade.php
@@ -38,6 +38,10 @@
                       class="btn btn-sm btn-outline-secondary"
                       style="display:none; color:#6c757d;"
                       rel="noopener">Edit</a> {{--target="_blank" (タブの管理大変の為、削除)--}}
+                    <a id="dayBoardLink" href="#"
+                      class="btn btn-sm btn-outline-secondary"
+                      style="display:none; color:#6c757d;"
+                      rel="noopener">Day Board</a>
                     <!-- 対応するLeave編集へのショートカット（JSでhrefをセット） -->
                     <a id="leaveEditLink" href="#"
                       class="btn btn-sm btn-outline-secondary"

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -137,12 +137,14 @@
         <form method="POST"
               action="{{ route('leaves.update', $leave) }}"
               class="h-100 d-flex flex-column js-leave-form"
-              data-user-id="{{ $leave->user_id }}">
+              data-user-id="{{ $leave->user_id }}"
+              data-current-status="{{ $leave->status }}">
           @csrf
           @method('PUT')
 
           {{-- Add Bulk 用ID隠しフィールド (JS用？) --}}
           <input type="hidden" name="id" value="{{ $leave->id }}">
+          <input type="hidden" name="inactive_generated_shift_action" value="">
 
           <div class="card-body py-1 px-2">
             <div class="mb-0 d-grid gap-0">
@@ -329,6 +331,27 @@
   </div>
 </div>
 
+<div class="modal fade" id="inactiveStatusConfirmModal" tabindex="-1" aria-labelledby="inactiveStatusConfirmLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content border-0 shadow-sm">
+      <div class="modal-header bg-warning py-2">
+        <h6 class="modal-title" id="inactiveStatusConfirmLabel">Status Change Confirmation</h6>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-2" id="inactiveStatusConfirmText">This absence has generated shift(s).</p>
+        <div class="small text-muted mb-2" id="inactiveGeneratedShiftSummary"></div>
+        <div class="generated-shift-list" id="inactiveGeneratedShiftWrap" style="display:none;"></div>
+      </div>
+      <div class="modal-footer py-2">
+        <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="inactiveKeepGeneratedShiftsBtn">Keep Shift</button>
+        <button type="button" class="btn btn-danger btn-sm" id="inactiveDeleteGeneratedShiftsBtn">Delete Shift</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 @endsection
 
 @push('styles')
@@ -397,6 +420,69 @@
 
 @push('scripts')
 <script>
+  function renderGeneratedShiftCards(wrap, shifts) {
+    wrap.innerHTML = '';
+
+    shifts.forEach((shift) => {
+      const card = document.createElement('div');
+      card.className = 'generated-shift-card';
+
+      const title = document.createElement('div');
+      title.className = 'fw-semibold mb-2';
+      title.textContent = `Generated Shift #${shift.id || '-'}`;
+      card.appendChild(title);
+
+      const meta = document.createElement('div');
+      meta.className = 'generated-shift-meta';
+      [
+        ['Date', 'date'],
+        ['Original', 'original'],
+        ['Assigned', 'assigned'],
+        ['School', 'school'],
+        ['Time', 'time'],
+        ['Status', 'status'],
+      ].forEach(([label, key]) => {
+        const field = document.createElement('div');
+        field.className = 'generated-shift-field';
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'generated-shift-label';
+        labelEl.textContent = label;
+
+        const valueEl = document.createElement('div');
+        valueEl.className = 'generated-shift-value';
+        valueEl.textContent = shift[key] || '-';
+
+        field.append(labelEl, valueEl);
+        meta.appendChild(field);
+      });
+      card.appendChild(meta);
+
+      ['lesson', 'notes'].forEach((key) => {
+        const wide = document.createElement('div');
+        wide.className = 'generated-shift-wide';
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'generated-shift-label';
+        labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
+
+        const valueEl = document.createElement('div');
+        valueEl.className = 'generated-shift-value';
+        valueEl.textContent = shift[key] || '-';
+
+        wide.append(labelEl, valueEl);
+        card.appendChild(wide);
+      });
+
+      wrap.appendChild(card);
+    });
+  }
+
+  function generatedShiftsFromSource(sourceId) {
+    const source = document.getElementById(sourceId);
+    return source ? JSON.parse(source.textContent || '[]') : [];
+  }
+
   // 削除確認ダイアログ（日付表示） → Bootstrap Modal に置き換え（英語UI）
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.js-delete');
@@ -407,71 +493,17 @@
     const modalText = document.getElementById('deleteConfirmText');
     modalText.textContent = `Are you sure you want to delete the absence for ${date}?`;
 
-    const shiftsSource = document.getElementById(btn.dataset.shiftsSource);
-    const shifts = shiftsSource ? JSON.parse(shiftsSource.textContent || '[]') : [];
+    const shifts = generatedShiftsFromSource(btn.dataset.shiftsSource);
     const summary = document.getElementById('deleteGeneratedShiftSummary');
     const wrap = document.getElementById('deleteGeneratedShiftWrap');
-    wrap.innerHTML = '';
 
     if (shifts.length > 0) {
       summary.textContent = `${shifts.length} generated shift(s) are linked to this absence. They will also be deleted unless you choose Keep Shift.`;
       wrap.style.display = '';
-
-      shifts.forEach((shift) => {
-        const card = document.createElement('div');
-        card.className = 'generated-shift-card';
-
-        const title = document.createElement('div');
-        title.className = 'fw-semibold mb-2';
-        title.textContent = `Generated Shift #${shift.id || '-'}`;
-        card.appendChild(title);
-
-        const meta = document.createElement('div');
-        meta.className = 'generated-shift-meta';
-        [
-          ['Date', 'date'],
-          ['Original', 'original'],
-          ['Assigned', 'assigned'],
-          ['School', 'school'],
-          ['Time', 'time'],
-          ['Status', 'status'],
-        ].forEach(([label, key]) => {
-          const field = document.createElement('div');
-          field.className = 'generated-shift-field';
-
-          const labelEl = document.createElement('span');
-          labelEl.className = 'generated-shift-label';
-          labelEl.textContent = label;
-
-          const valueEl = document.createElement('div');
-          valueEl.className = 'generated-shift-value';
-          valueEl.textContent = shift[key] || '-';
-
-          field.append(labelEl, valueEl);
-          meta.appendChild(field);
-        });
-        card.appendChild(meta);
-
-        ['lesson', 'notes'].forEach((key) => {
-          const wide = document.createElement('div');
-          wide.className = 'generated-shift-wide';
-
-          const labelEl = document.createElement('span');
-          labelEl.className = 'generated-shift-label';
-          labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
-
-          const valueEl = document.createElement('div');
-          valueEl.className = 'generated-shift-value';
-          valueEl.textContent = shift[key] || '-';
-
-          wide.append(labelEl, valueEl);
-          card.appendChild(wide);
-        });
-
-        wrap.appendChild(card);
-      });
+      renderGeneratedShiftCards(wrap, shifts);
     } else {
       summary.textContent = 'No generated shifts are linked to this absence.';
+      wrap.innerHTML = '';
       wrap.style.display = 'none';
     }
 
@@ -497,6 +529,49 @@
     const keepBtn = document.getElementById('keepGeneratedShiftsBtn');
     keepBtn.onclick = () => {
       keepInput.value = '1';
+      modal.hide();
+      form.submit();
+    };
+  });
+
+  document.addEventListener('submit', (e) => {
+    const form = e.target.closest('form.js-leave-form');
+    if (!form) return;
+
+    const actionInput = form.querySelector('input[name="inactive_generated_shift_action"]');
+    if (actionInput?.value) return;
+
+    const status = form.querySelector('select[name="status"]')?.value || '';
+    if (!['rejected', 'cancelled'].includes(status)) return;
+
+    const sourceId = form.querySelector('.js-delete')?.dataset.shiftsSource;
+    const shifts = generatedShiftsFromSource(sourceId);
+    if (shifts.length === 0) return;
+
+    e.preventDefault();
+
+    const text = document.getElementById('inactiveStatusConfirmText');
+    text.textContent = `You are changing this absence to ${status}. Please choose what to do with the linked generated shift(s).`;
+
+    const summary = document.getElementById('inactiveGeneratedShiftSummary');
+    summary.textContent = `${shifts.length} generated shift(s) are linked to this absence.`;
+
+    const wrap = document.getElementById('inactiveGeneratedShiftWrap');
+    wrap.style.display = '';
+    renderGeneratedShiftCards(wrap, shifts);
+
+    const modalEl = document.getElementById('inactiveStatusConfirmModal');
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    modal.show();
+
+    document.getElementById('inactiveKeepGeneratedShiftsBtn').onclick = () => {
+      actionInput.value = 'detach';
+      modal.hide();
+      form.submit();
+    };
+
+    document.getElementById('inactiveDeleteGeneratedShiftsBtn').onclick = () => {
+      actionInput.value = 'delete';
       modal.hide();
       form.submit();
     };

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -294,52 +294,24 @@
 
 </div>
 
-<!-- ✅ Delete Confirmation Modal -->
-<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered">
-    <div class="modal-content border-0 shadow-sm">
-      <div class="modal-header bg-danger text-white py-2">
-        <h6 class="modal-title" id="deleteConfirmLabel">Delete Confirmation</h6>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p class="mb-2" id="deleteConfirmText">Are you sure you want to delete this absence?</p>
-        <div class="small text-muted mb-2" id="deleteGeneratedShiftSummary"></div>
-        <div class="generated-shift-list" id="deleteGeneratedShiftWrap" style="display:none;"></div>
-      </div>
-      <div class="modal-footer py-2">
-        <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-outline-secondary btn-sm" id="keepGeneratedShiftsBtn">Keep Shift</button>
-        <button type="button" class="btn btn-danger btn-sm" id="confirmDeleteBtn">Delete Absence & Shift</button>
-      </div>
-    </div>
-  </div>
-</div>
+<x-generated-shift-confirm-modal
+  id="deleteConfirmModal"
+  title="Delete Confirmation"
+  header-class="bg-danger text-white"
+  message="Are you sure you want to delete this absence?"
+  delete-label="Delete Absence & Shift"
+/>
 
-<div class="modal fade" id="inactiveStatusConfirmModal" tabindex="-1" aria-labelledby="inactiveStatusConfirmLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered">
-    <div class="modal-content border-0 shadow-sm">
-      <div class="modal-header bg-warning py-2">
-        <h6 class="modal-title" id="inactiveStatusConfirmLabel">Status Change Confirmation</h6>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p class="mb-2" id="inactiveStatusConfirmText">This absence has generated shift(s).</p>
-        <div class="small text-muted mb-2" id="inactiveGeneratedShiftSummary"></div>
-        <div class="generated-shift-list" id="inactiveGeneratedShiftWrap" style="display:none;"></div>
-      </div>
-      <div class="modal-footer py-2">
-        <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-outline-secondary btn-sm" id="inactiveKeepGeneratedShiftsBtn">Keep Shift</button>
-        <button type="button" class="btn btn-danger btn-sm" id="inactiveDeleteGeneratedShiftsBtn">Delete Shift</button>
-      </div>
-    </div>
-  </div>
-</div>
+<x-generated-shift-confirm-modal
+  id="inactiveStatusConfirmModal"
+  title="Status Change Confirmation"
+  message="This absence has generated shift(s)."
+/>
 
 @endsection
 
 @push('styles')
+<link href="{{ asset('css/generated-shift-confirmation.css') }}?v={{ filemtime(public_path('css/generated-shift-confirmation.css')) }}" rel="stylesheet">
 <style>
 /* Leaveカード・検索フォームカード共通デザイン */
 .card {
@@ -347,127 +319,12 @@
   border: 1px solid #c1c5caff;
   border-radius: 6px;
 }
-
-.generated-shift-list {
-  max-height: min(52vh, 31rem);
-  overflow-y: auto;
-  padding-right: .25rem;
-}
-
-.generated-shift-card {
-  background: #f8fbff;
-  border: 1px solid #c8d8ec;
-  border-radius: 6px;
-  padding: .75rem;
-}
-
-.generated-shift-card + .generated-shift-card {
-  margin-top: .5rem;
-}
-
-.generated-shift-meta {
-  display: grid;
-  gap: .5rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.generated-shift-field {
-  min-width: 0;
-}
-
-.generated-shift-label {
-  color: #6c757d;
-  display: block;
-  font-size: .75rem;
-  line-height: 1.1;
-}
-
-.generated-shift-value {
-  overflow-wrap: anywhere;
-}
-
-.generated-shift-wide {
-  background: #fff;
-  border: 1px solid #dce6f2;
-  border-radius: 4px;
-  margin-top: .5rem;
-  padding: .5rem;
-  white-space: pre-wrap;
-}
-
-@media (max-width: 576px) {
-  .generated-shift-meta {
-    grid-template-columns: 1fr;
-  }
-}
 </style>
 @endpush
 
 @push('scripts')
+<script src="{{ asset('js/generated-shift-confirmation.js') }}?v={{ filemtime(public_path('js/generated-shift-confirmation.js')) }}"></script>
 <script>
-  function renderGeneratedShiftCards(wrap, shifts) {
-    wrap.innerHTML = '';
-
-    shifts.forEach((shift) => {
-      const card = document.createElement('div');
-      card.className = 'generated-shift-card';
-
-      const title = document.createElement('div');
-      title.className = 'fw-semibold mb-2';
-      title.textContent = `Generated Shift #${shift.id || '-'}`;
-      card.appendChild(title);
-
-      const meta = document.createElement('div');
-      meta.className = 'generated-shift-meta';
-      [
-        ['Date', 'date'],
-        ['Original', 'original'],
-        ['Assigned', 'assigned'],
-        ['School', 'school'],
-        ['Time', 'time'],
-        ['Status', 'status'],
-      ].forEach(([label, key]) => {
-        const field = document.createElement('div');
-        field.className = 'generated-shift-field';
-
-        const labelEl = document.createElement('span');
-        labelEl.className = 'generated-shift-label';
-        labelEl.textContent = label;
-
-        const valueEl = document.createElement('div');
-        valueEl.className = 'generated-shift-value';
-        valueEl.textContent = shift[key] || '-';
-
-        field.append(labelEl, valueEl);
-        meta.appendChild(field);
-      });
-      card.appendChild(meta);
-
-      ['lesson', 'notes'].forEach((key) => {
-        const wide = document.createElement('div');
-        wide.className = 'generated-shift-wide';
-
-        const labelEl = document.createElement('span');
-        labelEl.className = 'generated-shift-label';
-        labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
-
-        const valueEl = document.createElement('div');
-        valueEl.className = 'generated-shift-value';
-        valueEl.textContent = shift[key] || '-';
-
-        wide.append(labelEl, valueEl);
-        card.appendChild(wide);
-      });
-
-      wrap.appendChild(card);
-    });
-  }
-
-  function generatedShiftsFromSource(sourceId) {
-    const source = document.getElementById(sourceId);
-    return source ? JSON.parse(source.textContent || '[]') : [];
-  }
-
   // 削除確認ダイアログ（日付表示） → Bootstrap Modal に置き換え（英語UI）
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.js-delete');
@@ -475,91 +332,37 @@
 
     // 対象休暇情報をモーダルに反映
     const date = btn.dataset.date || 'this leave';
-    const modalText = document.getElementById('deleteConfirmText');
-    modalText.textContent = `Are you sure you want to delete the absence for ${date}?`;
-
-    const shifts = generatedShiftsFromSource(btn.dataset.shiftsSource);
-    const summary = document.getElementById('deleteGeneratedShiftSummary');
-    const wrap = document.getElementById('deleteGeneratedShiftWrap');
-
-    if (shifts.length > 0) {
-      summary.textContent = `${shifts.length} generated shift(s) are linked to this absence. They will also be deleted unless you choose Keep Shift.`;
-      wrap.style.display = '';
-      renderGeneratedShiftCards(wrap, shifts);
-    } else {
-      summary.textContent = 'No generated shifts are linked to this absence.';
-      wrap.innerHTML = '';
-      wrap.style.display = 'none';
-    }
+    const shifts = GeneratedShiftConfirmation.generatedShiftsFromSource(btn.dataset.shiftsSource);
 
     const form = document.getElementById('js-delete-form');
     form.action = btn.dataset.url;
     const actionInput = document.getElementById('js-delete-generated-shift-action');
     actionInput.value = 'delete';
 
-    // モーダル表示
-    const modalEl = document.getElementById('deleteConfirmModal');
-    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
-    modal.show();
-
-    // Shiftごと削除する通常ルート
-    const confirmBtn = document.getElementById('confirmDeleteBtn');
-    confirmBtn.onclick = () => {
-      actionInput.value = 'delete';
-      modal.hide();
-      form.submit();
-    };
-
-    // Shiftを手動シフトとして残す拡張ルート
-    const keepBtn = document.getElementById('keepGeneratedShiftsBtn');
-    keepBtn.onclick = () => {
-      actionInput.value = 'detach';
-      modal.hide();
-      form.submit();
-    };
+    GeneratedShiftConfirmation.open({
+      modalId: 'deleteConfirmModal',
+      shifts,
+      text: `Are you sure you want to delete the absence for ${date}?`,
+      summary: shifts.length > 0
+        ? `${shifts.length} generated shift(s) are linked to this absence. They will also be deleted unless you choose Keep Shift.`
+        : 'No generated shifts are linked to this absence.',
+      onKeep: () => {
+        actionInput.value = 'detach';
+        form.submit();
+      },
+      onDelete: () => {
+        actionInput.value = 'delete';
+        form.submit();
+      },
+    });
   });
 
-  document.addEventListener('submit', (e) => {
-    const form = e.target.closest('form.js-leave-form');
-    if (!form) return;
-
-    const actionInput = form.querySelector('input[name="generated_shift_action"]');
-    if (actionInput?.value) return;
-
-    const status = form.querySelector('select[name="status"]')?.value || '';
-    if (!['rejected', 'cancelled'].includes(status)) return;
-
-    const sourceId = form.querySelector('.js-delete')?.dataset.shiftsSource;
-    const shifts = generatedShiftsFromSource(sourceId);
-    if (shifts.length === 0) return;
-
-    e.preventDefault();
-
-    const text = document.getElementById('inactiveStatusConfirmText');
-    text.textContent = `You are changing this absence to ${status}. Please choose what to do with the linked generated shift(s).`;
-
-    const summary = document.getElementById('inactiveGeneratedShiftSummary');
-    summary.textContent = `${shifts.length} generated shift(s) are linked to this absence.`;
-
-    const wrap = document.getElementById('inactiveGeneratedShiftWrap');
-    wrap.style.display = '';
-    renderGeneratedShiftCards(wrap, shifts);
-
-    const modalEl = document.getElementById('inactiveStatusConfirmModal');
-    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
-    modal.show();
-
-    document.getElementById('inactiveKeepGeneratedShiftsBtn').onclick = () => {
-      actionInput.value = 'detach';
-      modal.hide();
-      form.submit();
-    };
-
-    document.getElementById('inactiveDeleteGeneratedShiftsBtn').onclick = () => {
-      actionInput.value = 'delete';
-      modal.hide();
-      form.submit();
-    };
+  GeneratedShiftConfirmation.bindInactiveStatusForm({
+    formSelector: 'form.js-leave-form',
+    sourceSelector: '.js-delete',
+    modalId: 'inactiveStatusConfirmModal',
+    textBuilder: ({ status }) => `You are changing this absence to ${status}. Please choose what to do with the linked generated shift(s).`,
+    summaryBuilder: ({ shifts }) => `${shifts.length} generated shift(s) are linked to this absence.`,
   });
 </script>
 

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -247,11 +247,33 @@
 
             {{-- フッタ操作 --}}
             <div class="card-footer bg-white d-flex justify-content-between align-items-center py-2 px-2 gap-1">
+              @php
+                $deleteShifts = $leave->generatedEvents->map(function ($event) use ($fmtDate, $fmtTime) {
+                    $original = trim(($event->originalUser?->first_name ?? '') . ' ' . ($event->originalUser?->family_name ?? ''));
+                    $assigned = trim(($event->assignedUser?->first_name ?? '') . ' ' . ($event->assignedUser?->family_name ?? ''));
+
+                    return [
+                        'id' => $event->id,
+                        'date' => $fmtDate($event->event_date),
+                        'original' => $original !== '' ? $original : '-',
+                        'assigned' => $assigned !== '' ? $assigned : '-',
+                        'school' => $event->school_name ?: '-',
+                        'time' => trim($fmtTime($event->start_time) . ' - ' . $fmtTime($event->end_time), ' -') ?: '-',
+                        'lesson' => $event->Lesson ?: '-',
+                        'status' => $event->status ?: '-',
+                        'notes' => $event->notes ?: '-',
+                    ];
+                })->values();
+                $deleteShiftPayloadId = 'leave-delete-shifts-' . $leave->id;
+              @endphp
+              <script type="application/json" id="{{ $deleteShiftPayloadId }}">@json($deleteShifts)</script>
+
               {{-- 削除ボタン：クラスとdata属性をJSに合わせる --}}
               <button type="button"
                       class="btn btn-sm btn-outline-danger js-delete"
                       data-url="{{ route('leaves.destroy', $leave) }}"
-                      data-date="{{ $leave->start_date?->format('Y-m-d') ?? 'この休暇' }}">
+                      data-date="{{ $leave->start_date?->format('Y-m-d') ?? 'this absence' }}"
+                      data-shifts-source="{{ $deleteShiftPayloadId }}">
                 Delete
               </button>
 
@@ -271,6 +293,7 @@
   <form id="js-delete-form" method="POST" style="display:none;">
     @csrf
     @method('DELETE')
+    <input type="hidden" name="keep_generated_shifts" id="js-keep-generated-shifts" value="0">
   </form>
 
   <div class="mt-3">
@@ -286,18 +309,21 @@
 
 <!-- ✅ Delete Confirmation Modal -->
 <div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
     <div class="modal-content border-0 shadow-sm">
       <div class="modal-header bg-danger text-white py-2">
         <h6 class="modal-title" id="deleteConfirmLabel">Delete Confirmation</h6>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <p class="mb-0" id="deleteConfirmText">Are you sure you want to delete this leave?</p>
+        <p class="mb-2" id="deleteConfirmText">Are you sure you want to delete this absence?</p>
+        <div class="small text-muted mb-2" id="deleteGeneratedShiftSummary"></div>
+        <div class="generated-shift-list" id="deleteGeneratedShiftWrap" style="display:none;"></div>
       </div>
       <div class="modal-footer py-2">
         <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-danger btn-sm" id="confirmDeleteBtn">Delete</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="keepGeneratedShiftsBtn">Keep Shift</button>
+        <button type="button" class="btn btn-danger btn-sm" id="confirmDeleteBtn">Delete Absence & Shift</button>
       </div>
     </div>
   </div>
@@ -313,6 +339,59 @@
   border: 1px solid #c1c5caff;
   border-radius: 6px;
 }
+
+.generated-shift-list {
+  max-height: min(52vh, 31rem);
+  overflow-y: auto;
+  padding-right: .25rem;
+}
+
+.generated-shift-card {
+  background: #f8fbff;
+  border: 1px solid #c8d8ec;
+  border-radius: 6px;
+  padding: .75rem;
+}
+
+.generated-shift-card + .generated-shift-card {
+  margin-top: .5rem;
+}
+
+.generated-shift-meta {
+  display: grid;
+  gap: .5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.generated-shift-field {
+  min-width: 0;
+}
+
+.generated-shift-label {
+  color: #6c757d;
+  display: block;
+  font-size: .75rem;
+  line-height: 1.1;
+}
+
+.generated-shift-value {
+  overflow-wrap: anywhere;
+}
+
+.generated-shift-wide {
+  background: #fff;
+  border: 1px solid #dce6f2;
+  border-radius: 4px;
+  margin-top: .5rem;
+  padding: .5rem;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 576px) {
+  .generated-shift-meta {
+    grid-template-columns: 1fr;
+  }
+}
 </style>
 @endpush
 
@@ -326,19 +405,98 @@
     // 対象休暇情報をモーダルに反映
     const date = btn.dataset.date || 'this leave';
     const modalText = document.getElementById('deleteConfirmText');
-    modalText.textContent = `Are you sure you want to delete ${date}?`;
+    modalText.textContent = `Are you sure you want to delete the absence for ${date}?`;
+
+    const shiftsSource = document.getElementById(btn.dataset.shiftsSource);
+    const shifts = shiftsSource ? JSON.parse(shiftsSource.textContent || '[]') : [];
+    const summary = document.getElementById('deleteGeneratedShiftSummary');
+    const wrap = document.getElementById('deleteGeneratedShiftWrap');
+    wrap.innerHTML = '';
+
+    if (shifts.length > 0) {
+      summary.textContent = `${shifts.length} generated shift(s) are linked to this absence. They will also be deleted unless you choose Keep Shift.`;
+      wrap.style.display = '';
+
+      shifts.forEach((shift) => {
+        const card = document.createElement('div');
+        card.className = 'generated-shift-card';
+
+        const title = document.createElement('div');
+        title.className = 'fw-semibold mb-2';
+        title.textContent = `Generated Shift #${shift.id || '-'}`;
+        card.appendChild(title);
+
+        const meta = document.createElement('div');
+        meta.className = 'generated-shift-meta';
+        [
+          ['Date', 'date'],
+          ['Original', 'original'],
+          ['Assigned', 'assigned'],
+          ['School', 'school'],
+          ['Time', 'time'],
+          ['Status', 'status'],
+        ].forEach(([label, key]) => {
+          const field = document.createElement('div');
+          field.className = 'generated-shift-field';
+
+          const labelEl = document.createElement('span');
+          labelEl.className = 'generated-shift-label';
+          labelEl.textContent = label;
+
+          const valueEl = document.createElement('div');
+          valueEl.className = 'generated-shift-value';
+          valueEl.textContent = shift[key] || '-';
+
+          field.append(labelEl, valueEl);
+          meta.appendChild(field);
+        });
+        card.appendChild(meta);
+
+        ['lesson', 'notes'].forEach((key) => {
+          const wide = document.createElement('div');
+          wide.className = 'generated-shift-wide';
+
+          const labelEl = document.createElement('span');
+          labelEl.className = 'generated-shift-label';
+          labelEl.textContent = key === 'lesson' ? 'Lesson' : 'Notes';
+
+          const valueEl = document.createElement('div');
+          valueEl.className = 'generated-shift-value';
+          valueEl.textContent = shift[key] || '-';
+
+          wide.append(labelEl, valueEl);
+          card.appendChild(wide);
+        });
+
+        wrap.appendChild(card);
+      });
+    } else {
+      summary.textContent = 'No generated shifts are linked to this absence.';
+      wrap.style.display = 'none';
+    }
 
     const form = document.getElementById('js-delete-form');
     form.action = btn.dataset.url;
+    const keepInput = document.getElementById('js-keep-generated-shifts');
+    keepInput.value = '0';
 
     // モーダル表示
     const modalEl = document.getElementById('deleteConfirmModal');
     const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
     modal.show();
 
-    // 削除ボタンで実行
+    // Shiftごと削除する通常ルート
     const confirmBtn = document.getElementById('confirmDeleteBtn');
     confirmBtn.onclick = () => {
+      keepInput.value = '0';
+      modal.hide();
+      form.submit();
+    };
+
+    // Shiftを手動シフトとして残す拡張ルート
+    const keepBtn = document.getElementById('keepGeneratedShiftsBtn');
+    keepBtn.onclick = () => {
+      keepInput.value = '1';
       modal.hide();
       form.submit();
     };

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -144,7 +144,7 @@
 
           {{-- Add Bulk 用ID隠しフィールド (JS用？) --}}
           <input type="hidden" name="id" value="{{ $leave->id }}">
-          <input type="hidden" name="inactive_generated_shift_action" value="">
+          <input type="hidden" name="generated_shift_action" value="">
 
           <div class="card-body py-1 px-2">
             <div class="mb-0 d-grid gap-0">
@@ -250,22 +250,7 @@
             {{-- フッタ操作 --}}
             <div class="card-footer bg-white d-flex justify-content-between align-items-center py-2 px-2 gap-1">
               @php
-                $deleteShifts = $leave->generatedEvents->map(function ($event) use ($fmtDate, $fmtTime) {
-                    $original = trim(($event->originalUser?->first_name ?? '') . ' ' . ($event->originalUser?->family_name ?? ''));
-                    $assigned = trim(($event->assignedUser?->first_name ?? '') . ' ' . ($event->assignedUser?->family_name ?? ''));
-
-                    return [
-                        'id' => $event->id,
-                        'date' => $fmtDate($event->event_date),
-                        'original' => $original !== '' ? $original : '-',
-                        'assigned' => $assigned !== '' ? $assigned : '-',
-                        'school' => $event->school_name ?: '-',
-                        'time' => trim($fmtTime($event->start_time) . ' - ' . $fmtTime($event->end_time), ' -') ?: '-',
-                        'lesson' => $event->Lesson ?: '-',
-                        'status' => $event->status ?: '-',
-                        'notes' => $event->notes ?: '-',
-                    ];
-                })->values();
+                $deleteShifts = $generatedShiftDetailsByLeaveId[$leave->id] ?? collect();
                 $deleteShiftPayloadId = 'leave-delete-shifts-' . $leave->id;
               @endphp
               <script type="application/json" id="{{ $deleteShiftPayloadId }}">@json($deleteShifts)</script>
@@ -295,7 +280,7 @@
   <form id="js-delete-form" method="POST" style="display:none;">
     @csrf
     @method('DELETE')
-    <input type="hidden" name="keep_generated_shifts" id="js-keep-generated-shifts" value="0">
+    <input type="hidden" name="generated_shift_action" id="js-delete-generated-shift-action" value="delete">
   </form>
 
   <div class="mt-3">
@@ -509,8 +494,8 @@
 
     const form = document.getElementById('js-delete-form');
     form.action = btn.dataset.url;
-    const keepInput = document.getElementById('js-keep-generated-shifts');
-    keepInput.value = '0';
+    const actionInput = document.getElementById('js-delete-generated-shift-action');
+    actionInput.value = 'delete';
 
     // モーダル表示
     const modalEl = document.getElementById('deleteConfirmModal');
@@ -520,7 +505,7 @@
     // Shiftごと削除する通常ルート
     const confirmBtn = document.getElementById('confirmDeleteBtn');
     confirmBtn.onclick = () => {
-      keepInput.value = '0';
+      actionInput.value = 'delete';
       modal.hide();
       form.submit();
     };
@@ -528,7 +513,7 @@
     // Shiftを手動シフトとして残す拡張ルート
     const keepBtn = document.getElementById('keepGeneratedShiftsBtn');
     keepBtn.onclick = () => {
-      keepInput.value = '1';
+      actionInput.value = 'detach';
       modal.hide();
       form.submit();
     };
@@ -538,7 +523,7 @@
     const form = e.target.closest('form.js-leave-form');
     if (!form) return;
 
-    const actionInput = form.querySelector('input[name="inactive_generated_shift_action"]');
+    const actionInput = form.querySelector('input[name="generated_shift_action"]');
     if (actionInput?.value) return;
 
     const status = form.querySelector('select[name="status"]')?.value || '';

--- a/resources/views/calendar/leaveEdit.blade.php
+++ b/resources/views/calendar/leaveEdit.blade.php
@@ -294,19 +294,7 @@
 
 </div>
 
-<x-generated-shift-confirm-modal
-  id="deleteConfirmModal"
-  title="Delete Confirmation"
-  header-class="bg-danger text-white"
-  message="Are you sure you want to delete this absence?"
-  delete-label="Delete Absence & Shift"
-/>
-
-<x-generated-shift-confirm-modal
-  id="inactiveStatusConfirmModal"
-  title="Status Change Confirmation"
-  message="This absence has generated shift(s)."
-/>
+<x-generated-shift-confirm-modal />
 
 @endsection
 
@@ -340,7 +328,7 @@
     actionInput.value = 'delete';
 
     GeneratedShiftConfirmation.open({
-      modalId: 'deleteConfirmModal',
+      modalId: 'generatedShiftConfirmModal',
       shifts,
       text: `Are you sure you want to delete the absence for ${date}?`,
       summary: shifts.length > 0
@@ -360,7 +348,7 @@
   GeneratedShiftConfirmation.bindInactiveStatusForm({
     formSelector: 'form.js-leave-form',
     sourceSelector: '.js-delete',
-    modalId: 'inactiveStatusConfirmModal',
+    modalId: 'generatedShiftConfirmModal',
     textBuilder: ({ status }) => `You are changing this absence to ${status}. Please choose what to do with the linked generated shift(s).`,
     summaryBuilder: ({ shifts }) => `${shifts.length} generated shift(s) are linked to this absence.`,
   });

--- a/resources/views/components/generated-shift-confirm-modal.blade.php
+++ b/resources/views/components/generated-shift-confirm-modal.blade.php
@@ -1,28 +1,23 @@
 @props([
-    'id',
-    'title',
-    'headerClass' => 'bg-warning',
-    'message' => 'This action affects generated shift(s). Please choose what to do.',
-    'keepLabel' => 'Keep Shift',
-    'deleteLabel' => 'Delete Shift',
+    'id' => 'generatedShiftConfirmModal',
 ])
 
 <div class="modal fade generated-shift-confirm-modal" id="{{ $id }}" tabindex="-1" aria-labelledby="{{ $id }}Label" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content border-0 shadow-sm">
-            <div class="modal-header {{ $headerClass }} py-2">
-                <h6 class="modal-title" id="{{ $id }}Label">{{ $title }}</h6>
-                <button type="button" class="btn-close @if(str_contains($headerClass, 'text-white')) btn-close-white @endif" data-bs-dismiss="modal" aria-label="Close"></button>
+            <div class="modal-header bg-warning py-2">
+                <h6 class="modal-title" id="{{ $id }}Label">Generated Shift Confirmation</h6>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <p class="mb-2" data-generated-shift-text>{{ $message }}</p>
+                <p class="mb-2" data-generated-shift-text>This action affects generated shift(s). Please choose what to do.</p>
                 <div class="small text-muted mb-2" data-generated-shift-summary></div>
                 <div class="generated-shift-list" data-generated-shift-list style="display:none;"></div>
             </div>
             <div class="modal-footer py-2">
                 <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-outline-secondary btn-sm" data-generated-shift-keep>{{ $keepLabel }}</button>
-                <button type="button" class="btn btn-danger btn-sm" data-generated-shift-delete>{{ $deleteLabel }}</button>
+                <button type="button" class="btn btn-outline-secondary btn-sm" data-generated-shift-keep>Keep Shift</button>
+                <button type="button" class="btn btn-danger btn-sm" data-generated-shift-delete>Delete Shift</button>
             </div>
         </div>
     </div>

--- a/resources/views/components/generated-shift-confirm-modal.blade.php
+++ b/resources/views/components/generated-shift-confirm-modal.blade.php
@@ -1,0 +1,29 @@
+@props([
+    'id',
+    'title',
+    'headerClass' => 'bg-warning',
+    'message' => 'This action affects generated shift(s). Please choose what to do.',
+    'keepLabel' => 'Keep Shift',
+    'deleteLabel' => 'Delete Shift',
+])
+
+<div class="modal fade generated-shift-confirm-modal" id="{{ $id }}" tabindex="-1" aria-labelledby="{{ $id }}Label" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content border-0 shadow-sm">
+            <div class="modal-header {{ $headerClass }} py-2">
+                <h6 class="modal-title" id="{{ $id }}Label">{{ $title }}</h6>
+                <button type="button" class="btn-close @if(str_contains($headerClass, 'text-white')) btn-close-white @endif" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-2" data-generated-shift-text>{{ $message }}</p>
+                <div class="small text-muted mb-2" data-generated-shift-summary></div>
+                <div class="generated-shift-list" data-generated-shift-list style="display:none;"></div>
+            </div>
+            <div class="modal-footer py-2">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-outline-secondary btn-sm" data-generated-shift-keep>{{ $keepLabel }}</button>
+                <button type="button" class="btn btn-danger btn-sm" data-generated-shift-delete>{{ $deleteLabel }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -226,6 +226,7 @@ use App\Http\Controllers\EventAssignController;
 use App\Http\Controllers\LeaveController;
 
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
+    Route::get('/forecast/day-assigner', [EventAssignController::class, 'dailyBoard'])->name('calendar.daily_assigner');
     Route::get('/shift_assigner', [EventAssignController::class, 'edit'])->name('calendar.edit');
     // PDF（モード: tentative|final|master）
     // Vue プレビュー画面

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\CalendarController;
 use App\Http\Controllers\CalendarPatternController;
 use App\Http\Controllers\LeaveApplyController;
 use App\Http\Controllers\LeaveAttachmentController;
+use App\Http\Controllers\LeaveController;
 use App\Http\Controllers\CurrentScopeController;
 use App\Http\Controllers\UserAttendanceSearchController;
 
@@ -103,6 +104,8 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('/leaves/{leave}/attachments/{attachment}', [LeaveAttachmentController::class, 'show'])
         ->name('leaves.attachments.show');
+    Route::post('/leaves/{leave}/cancel', [LeaveController::class, 'cancel'])
+        ->name('leaves.cancel');
 });
 
 
@@ -223,7 +226,6 @@ Route::middleware(['auth', 'role:admin|super_admin']) // 権限ミドルウェ�
     ->name('expenses.admin.report');
 
 use App\Http\Controllers\EventAssignController;
-use App\Http\Controllers\LeaveController;
 
 Route::middleware(['auth', 'role:admin|super_admin'])->group(function () {
     Route::get('/forecast/day-assigner', [EventAssignController::class, 'dailyBoard'])->name('calendar.daily_assigner');

--- a/tests/Feature/ApprovalControllerTest.php
+++ b/tests/Feature/ApprovalControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ApprovalRequest;
+use App\Models\Department;
+use App\Models\District;
+use App\Models\Event;
+use App\Models\Leave;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApprovalControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeLeaveApprovalWithGeneratedShift(): array
+    {
+        $district = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $requester = User::factory()->general()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id' => $requester->id,
+            'start_date' => '2026-06-13',
+            'kind' => 'paid',
+            'excused' => 'excused',
+            'status' => 'pending',
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $event = Event::factory()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+            'event_date' => '2026-06-13',
+            'original_user_id' => $requester->id,
+            'school_name' => 'Approval Generated School',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'Lesson' => 'ALP L1',
+            'status' => 'pending',
+            'type' => 'regular_time',
+            'source_leave_id' => $leave->id,
+        ]);
+
+        $approval = ApprovalRequest::create([
+            'approvable_type' => Leave::class,
+            'approvable_id' => $leave->id,
+            'title' => 'Paid Leave Request',
+            'requested_by_id' => $requester->id,
+            'current_state' => 'pending',
+            'metadata' => [
+                'kind' => 'paid',
+                'date' => '2026-06-13',
+                'target_user_id' => $requester->id,
+            ],
+        ]);
+
+        return [$approval, $leave, $event];
+    }
+
+    public function test_super_admin_can_confirm_generated_shifts_before_denying_leave_request(): void
+    {
+        $superAdmin = User::factory()->superAdmin()->create();
+        [$approval] = $this->makeLeaveApprovalWithGeneratedShift();
+
+        $this->actingAs($superAdmin)
+            ->get(route('approvals.show', $approval))
+            ->assertOk()
+            ->assertSee('Deny Confirmation')
+            ->assertSee('Keep Shift')
+            ->assertSee('Delete Shift')
+            ->assertSee('inactive_generated_shift_action')
+            ->assertSee('Approval Generated School')
+            ->assertSee('ALP L1');
+    }
+
+    public function test_super_admin_must_confirm_generated_shift_action_before_denying_leave_request(): void
+    {
+        $superAdmin = User::factory()->superAdmin()->create();
+        [$approval, $leave, $event] = $this->makeLeaveApprovalWithGeneratedShift();
+
+        $this->actingAs($superAdmin)
+            ->post(route('approvals.deny', $approval), [
+                'comment' => 'Not approved.',
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('toast_errors');
+
+        $this->assertDatabaseHas('approval_requests', [
+            'id' => $approval->id,
+            'current_state' => 'pending',
+        ]);
+        $this->assertDatabaseHas('leaves', [
+            'id' => $leave->id,
+            'status' => 'pending',
+        ]);
+        $this->assertDatabaseHas('events', [
+            'id' => $event->id,
+            'source_leave_id' => $leave->id,
+        ]);
+    }
+}

--- a/tests/Feature/ApprovalControllerTest.php
+++ b/tests/Feature/ApprovalControllerTest.php
@@ -73,7 +73,7 @@ class ApprovalControllerTest extends TestCase
         $this->actingAs($superAdmin)
             ->get(route('approvals.show', $approval))
             ->assertOk()
-            ->assertSee('Deny Confirmation')
+            ->assertSee('Generated Shift Confirmation')
             ->assertSee('Keep Shift')
             ->assertSee('Delete Shift')
             ->assertSee('generated_shift_action')

--- a/tests/Feature/ApprovalControllerTest.php
+++ b/tests/Feature/ApprovalControllerTest.php
@@ -76,7 +76,7 @@ class ApprovalControllerTest extends TestCase
             ->assertSee('Deny Confirmation')
             ->assertSee('Keep Shift')
             ->assertSee('Delete Shift')
-            ->assertSee('inactive_generated_shift_action')
+            ->assertSee('generated_shift_action')
             ->assertSee('Approval Generated School')
             ->assertSee('ALP L1');
     }

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -382,6 +382,7 @@ class EventAssignControllerTest extends TestCase
             ->postJson(route('events.bulk_update'), [
                 'items' => [[
                     'id'         => $event->id,
+                    'updated_at' => $event->updated_at?->format('Y-m-d H:i:s'),
                     'event_date' => '2026-05-31',
                     'status'     => 'fixed',
                     'type'       => 'regular_time',
@@ -396,6 +397,49 @@ class EventAssignControllerTest extends TestCase
         $this->assertDatabaseHas('events', [
             'id'     => $event->id,
             'status' => 'fixed',
+        ]);
+    }
+
+    /**
+     * シナリオ 9d: 古い画面からの一括更新は updated_at の不一致で拒否される
+     */
+    public function test_bulk_update_rejects_stale_event_payload(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $event = Event::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'event_date'    => '2026-05-31',
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+        ]);
+
+        $staleUpdatedAt = $event->updated_at?->copy()->subMinute()->format('Y-m-d H:i:s');
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('events.bulk_update'), [
+                'items' => [[
+                    'id'         => $event->id,
+                    'updated_at' => $staleUpdatedAt,
+                    'event_date' => '2026-05-31',
+                    'status'     => 'fixed',
+                    'type'       => 'regular_time',
+                ]],
+            ])
+            ->assertOk()
+            ->assertJson([
+                'ok'      => false,
+                'updated' => 0,
+                'failed'  => 1,
+                'message' => 'Some shifts were already updated by others. Please reload before saving.',
+            ])
+            ->assertJsonPath('results.0.conflict', true);
+
+        $this->assertDatabaseHas('events', [
+            'id'     => $event->id,
+            'status' => 'pending',
         ]);
     }
 

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -256,7 +256,14 @@ class EventAssignControllerTest extends TestCase
             ->get(route('calendar.daily_assigner', ['date' => '2026-05-31']))
             ->assertOk()
             ->assertSee('Daily Shift Board')
-            ->assertSee('Scope School');
+            ->assertSee('Scope School')
+            ->assertSee('Tentative Sublist Preview')
+            ->assertSee('Master Sublist Preview')
+            ->assertSee('Final Sublist Preview')
+            ->assertSee(route('calendar.edit.pdf.preview', [
+                'mode' => 'tentative',
+                'event_date' => '2026-05-31',
+            ]));
     }
 
     // =========================================================================

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -233,7 +233,10 @@ class EventAssignControllerTest extends TestCase
             ->withSession(['selected_scope_id' => $scope->id])
             ->get(route('calendar.edit'))
             ->assertOk()
+            ->assertSee('+ Add Shift')
+            ->assertSee('New Shift')
             ->assertSee('Copy Shift')
+            ->assertSee(asset('js/user-autocomplete.js'))
             ->assertSee(asset('js/shift-copy-modal.js'));
     }
 
@@ -260,6 +263,8 @@ class EventAssignControllerTest extends TestCase
             ->assertSee('Daily Shift Board')
             ->assertSee('Scope School')
             ->assertSee('Create Absence')
+            ->assertSee('+ Add Shift')
+            ->assertSee('New Shift for 2026-05-31')
             ->assertSee('Copy Shift')
             ->assertSee(asset('js/shift-copy-modal.js'))
             ->assertSee(route('api.users.search'))
@@ -299,6 +304,65 @@ class EventAssignControllerTest extends TestCase
             'type'          => 'regular_time',
             'district_id'   => $district->id,
             'department_id' => $department->id,
+        ]);
+    }
+
+    /**
+     * シナリオ 8b: 入力モーダル用の項目付き Event を作成できる
+     */
+    public function test_admin_can_store_event_from_create_modal_payload(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $originalUser = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'first_name'    => 'Original',
+            'family_name'   => 'Teacher',
+            'employee_code' => 'O12345',
+        ]);
+        $assignedUser = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'first_name'    => 'Assigned',
+            'family_name'   => 'Teacher',
+            'employee_code' => 'A12345',
+        ]);
+
+        $date = '2026-05-31';
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('events.store'), [
+                'event_date'           => $date,
+                'title'                => 'Cover Shift',
+                'original_user_lookup' => 'Original Teacher [O12345]',
+                'assigned_user_lookup' => 'Assigned Teacher [A12345]',
+                'school_name'          => 'Modal School',
+                'start_time'           => '09:00',
+                'end_time'             => '12:30',
+                'Lesson'               => 'G1 Math',
+                'type'                 => 'regular_time',
+                'status'               => 'pending',
+                'notes'                => 'Created from modal',
+            ])
+            ->assertRedirect(route('calendar.edit', ['event_date' => $date]));
+
+        $this->assertDatabaseHas('events', [
+            'event_date'       => $date,
+            'title'            => 'Cover Shift',
+            'original_user_id' => $originalUser->id,
+            'assigned_user_id' => $assignedUser->id,
+            'school_name'      => 'Modal School',
+            'start_time'       => '09:00:00',
+            'end_time'         => '12:30:00',
+            'total_duration'   => '3:30',
+            'Lesson'           => 'G1 Math',
+            'type'             => 'regular_time',
+            'status'           => 'pending',
+            'notes'            => 'Created from modal',
+            'district_id'      => $district->id,
+            'department_id'    => $department->id,
         ]);
     }
 

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -232,7 +232,9 @@ class EventAssignControllerTest extends TestCase
         $this->actingAs($admin)
             ->withSession(['selected_scope_id' => $scope->id])
             ->get(route('calendar.edit'))
-            ->assertOk();
+            ->assertOk()
+            ->assertSee('Copy Shift')
+            ->assertSee(asset('js/shift-copy-modal.js'));
     }
 
     /**
@@ -258,6 +260,8 @@ class EventAssignControllerTest extends TestCase
             ->assertSee('Daily Shift Board')
             ->assertSee('Scope School')
             ->assertSee('Create Absence')
+            ->assertSee('Copy Shift')
+            ->assertSee(asset('js/shift-copy-modal.js'))
             ->assertSee(route('api.users.search'))
             ->assertSee('Tentative Sublist Preview')
             ->assertSee('Master Sublist Preview')

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -257,6 +257,8 @@ class EventAssignControllerTest extends TestCase
             ->assertOk()
             ->assertSee('Daily Shift Board')
             ->assertSee('Scope School')
+            ->assertSee('Create Absence')
+            ->assertSee(route('api.users.search'))
             ->assertSee('Tentative Sublist Preview')
             ->assertSee('Master Sublist Preview')
             ->assertSee('Final Sublist Preview')
@@ -294,6 +296,103 @@ class EventAssignControllerTest extends TestCase
             'district_id'   => $district->id,
             'department_id' => $department->id,
         ]);
+    }
+
+    /**
+     * シナリオ 7c: daily shift board から選択日の Absence を作成でき、Daily に戻る
+     */
+    public function test_admin_can_create_absence_from_daily_shift_board(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $selectedDate = '2026-05-31';
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('leaves.store'), [
+                'user_id'     => $targetUser->id,
+                'start_date'  => $selectedDate,
+                'kind'        => 'absence',
+                'excused'     => 'unexcused',
+                'status'      => 'pending',
+                'redirect_to' => route('calendar.daily_assigner', ['date' => $selectedDate]),
+            ])
+            ->assertRedirect(route('calendar.daily_assigner', ['date' => $selectedDate]));
+
+        $this->assertDatabaseHas('leaves', [
+            'user_id'    => $targetUser->id,
+            'start_date' => $selectedDate,
+            'kind'       => 'absence',
+            'status'     => 'pending',
+        ]);
+    }
+
+    /**
+     * シナリオ 7d: hidden user_id が空でも補完表示文字列からユーザーを特定して Absence を作成できる
+     */
+    public function test_daily_absence_create_resolves_user_from_lookup_text(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = User::factory()->create([
+            'district_id'    => $district->id,
+            'department_id'  => $department->id,
+            'first_name'     => 'Jane',
+            'family_name'    => 'Teacher',
+            'employee_code'  => 'T12345',
+        ]);
+
+        $selectedDate = '2026-05-31';
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('leaves.store'), [
+                'user_id'     => '',
+                'user_lookup' => 'Jane Teacher [T12345]',
+                'start_date'  => $selectedDate,
+                'kind'        => 'absence',
+                'excused'     => 'unexcused',
+                'status'      => 'pending',
+                'redirect_to' => route('calendar.daily_assigner', ['date' => $selectedDate]),
+            ])
+            ->assertRedirect(route('calendar.daily_assigner', ['date' => $selectedDate]));
+
+        $this->assertDatabaseHas('leaves', [
+            'user_id'    => $targetUser->id,
+            'start_date' => $selectedDate,
+            'kind'       => 'absence',
+        ]);
+    }
+
+    /**
+     * シナリオ 7e: ユーザーを特定できない場合は Absence を作成せず Toast error を返す
+     */
+    public function test_daily_absence_create_returns_toast_error_when_target_user_is_not_found(): void
+    {
+        [$admin, $scope] = $this->makeAdmin();
+
+        $selectedDate = '2026-05-31';
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->post(route('leaves.store'), [
+                'user_id'     => '',
+                'user_lookup' => 'Unknown User',
+                'start_date'  => $selectedDate,
+                'kind'        => 'absence',
+                'excused'     => 'unexcused',
+                'status'      => 'pending',
+                'redirect_to' => route('calendar.daily_assigner', ['date' => $selectedDate]),
+            ])
+            ->assertRedirect(route('calendar.daily_assigner', ['date' => $selectedDate]))
+            ->assertSessionHas('toast_errors', ['Target not found. Please select a user from the suggestions.']);
+
+        $this->assertDatabaseCount('leaves', 0);
     }
 
     // =========================================================================

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Department;
 use App\Models\District;
 use App\Models\Event;
+use App\Models\Leave;
 use App\Models\User;
 use App\Models\UserManagementScope;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -266,6 +267,8 @@ class EventAssignControllerTest extends TestCase
             ->assertSee('+ Add Shift')
             ->assertSee('New Shift for 2026-05-31')
             ->assertSee('Copy Shift')
+            ->assertSee('Delete')
+            ->assertSee('Delete Confirmation')
             ->assertSee(asset('js/shift-copy-modal.js'))
             ->assertSee(route('api.users.search'))
             ->assertSee('Tentative Sublist Preview')
@@ -644,6 +647,76 @@ class EventAssignControllerTest extends TestCase
             ->assertRedirect();
 
         $this->assertDatabaseMissing('events', ['id' => $event->id]);
+    }
+
+    /**
+     * シナリオ 10b: admin でも Leave snapshot 由来の Event は直接削除できない
+     *
+     * - source_leave_id がある Event は Leave が正本なので Event 側から削除しない
+     * - 削除したい場合は Absence / Leave 側を編集・削除する
+     */
+    public function test_admin_cannot_delete_event_managed_by_absence(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $leave = Leave::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'start_date'    => now()->toDateString(),
+            'status'        => 'approved',
+        ]);
+
+        $event = Event::factory()->create([
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+            'event_date'      => now()->toDateString(),
+            'status'          => 'pending',
+            'type'            => 'regular_time',
+            'source_leave_id' => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('events.destroy', $event))
+            ->assertRedirect()
+            ->assertSessionHas('toast_errors');
+
+        $this->assertDatabaseHas('events', [
+            'id'              => $event->id,
+            'source_leave_id' => $leave->id,
+        ]);
+    }
+
+    /**
+     * シナリオ 10c: Leave snapshot 由来の Event は画面上でも削除不可として表示する
+     */
+    public function test_absence_managed_event_delete_button_is_disabled_on_shift_assigner(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $leave = Leave::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'start_date'    => '2026-05-31',
+            'status'        => 'approved',
+        ]);
+
+        Event::factory()->create([
+            'district_id'     => $district->id,
+            'department_id'   => $department->id,
+            'event_date'      => '2026-05-31',
+            'status'          => 'pending',
+            'type'            => 'regular_time',
+            'school_name'     => 'Managed School',
+            'source_leave_id' => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.edit', ['event_date' => '2026-05-31']))
+            ->assertOk()
+            ->assertSee('Managed School')
+            ->assertSee('Managed by absence');
     }
 
     // =========================================================================

--- a/tests/Feature/EventAssignControllerTest.php
+++ b/tests/Feature/EventAssignControllerTest.php
@@ -29,6 +29,7 @@ use Tests\TestCase;
  *
  * [権限: admin ユーザー（正常系）]
  *   7. shift_assigner (edit) を表示できる → 200
+ *   7b. daily shift board を表示できる → 200
  *   8. store でスコープ内に Event が作成される → DB確認
  *   9. update でスコープ内の Event を更新できる → DB確認
  *  10. destroy でスコープ内の Event を削除できる → DB確認
@@ -137,6 +138,18 @@ class EventAssignControllerTest extends TestCase
     }
 
     /**
+     * シナリオ 2b: general ユーザーは daily shift board を表示できず welcome へリダイレクト
+     */
+    public function test_general_user_cannot_view_daily_shift_board(): void
+    {
+        $user = User::factory()->general()->create();
+
+        $this->actingAs($user)
+            ->get(route('calendar.daily_assigner'))
+            ->assertRedirect(route('welcome'));
+    }
+
+    /**
      * シナリオ 3: general ユーザーは Event を新規作成できず welcome へリダイレクト
      */
     public function test_general_user_cannot_store_event(): void
@@ -220,6 +233,30 @@ class EventAssignControllerTest extends TestCase
             ->withSession(['selected_scope_id' => $scope->id])
             ->get(route('calendar.edit'))
             ->assertOk();
+    }
+
+    /**
+     * シナリオ 7b: admin は指定日の daily shift board を表示できる
+     */
+    public function test_admin_can_view_daily_shift_board(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        Event::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'event_date'    => '2026-05-31',
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+            'school_name'   => 'Scope School',
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('calendar.daily_assigner', ['date' => '2026-05-31']))
+            ->assertOk()
+            ->assertSee('Daily Shift Board')
+            ->assertSee('Scope School');
     }
 
     // =========================================================================
@@ -322,6 +359,43 @@ class EventAssignControllerTest extends TestCase
             'id'             => $event->id,
             'school_name'    => 'Test School',
             'total_duration' => '8:00',
+        ]);
+    }
+
+    /**
+     * シナリオ 9c: daily shift board 用の一括更新 API で status を即時更新できる
+     */
+    public function test_admin_can_bulk_update_event_status_for_daily_shift_board(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $event = Event::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+            'event_date'    => '2026-05-31',
+            'status'        => 'pending',
+            'type'          => 'regular_time',
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('events.bulk_update'), [
+                'items' => [[
+                    'id'         => $event->id,
+                    'event_date' => '2026-05-31',
+                    'status'     => 'fixed',
+                    'type'       => 'regular_time',
+                ]],
+            ])
+            ->assertOk()
+            ->assertJson([
+                'ok'      => true,
+                'updated' => 1,
+            ]);
+
+        $this->assertDatabaseHas('events', [
+            'id'     => $event->id,
+            'status' => 'fixed',
         ]);
     }
 

--- a/tests/Feature/LeaveCancelControllerTest.php
+++ b/tests/Feature/LeaveCancelControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\District;
+use App\Models\Event;
+use App\Models\Leave;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LeaveCancelControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeLeaveWithGeneratedShift(): array
+    {
+        $district = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $user = User::factory()->general()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id' => $user->id,
+            'start_date' => '2026-06-13',
+            'kind' => 'paid',
+            'excused' => 'excused',
+            'status' => 'pending',
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $event = Event::factory()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+            'event_date' => '2026-06-13',
+            'original_user_id' => $user->id,
+            'school_name' => 'Cancel Generated School',
+            'status' => 'pending',
+            'type' => 'regular_time',
+            'source_leave_id' => $leave->id,
+        ]);
+
+        return [$user, $leave, $event];
+    }
+
+    public function test_leave_cancel_requires_generated_shift_action_when_shift_exists(): void
+    {
+        [$user, $leave, $event] = $this->makeLeaveWithGeneratedShift();
+
+        $this->actingAs($user)
+            ->post(route('leaves.cancel', $leave))
+            ->assertRedirect()
+            ->assertSessionHas('toast_errors');
+
+        $this->assertDatabaseHas('leaves', [
+            'id' => $leave->id,
+            'status' => 'pending',
+        ]);
+        $this->assertDatabaseHas('events', [
+            'id' => $event->id,
+            'source_leave_id' => $leave->id,
+        ]);
+    }
+
+    public function test_leave_cancel_can_keep_generated_shift(): void
+    {
+        [$user, $leave, $event] = $this->makeLeaveWithGeneratedShift();
+
+        $this->actingAs($user)
+            ->post(route('leaves.cancel', $leave), [
+                'generated_shift_action' => 'detach',
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('toast');
+
+        $this->assertDatabaseHas('leaves', [
+            'id' => $leave->id,
+            'status' => 'cancelled',
+        ]);
+        $this->assertDatabaseHas('events', [
+            'id' => $event->id,
+            'source_leave_id' => null,
+        ]);
+    }
+
+    public function test_leave_cancel_can_delete_generated_shift(): void
+    {
+        [$user, $leave, $event] = $this->makeLeaveWithGeneratedShift();
+
+        $this->actingAs($user)
+            ->post(route('leaves.cancel', $leave), [
+                'generated_shift_action' => 'delete',
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('toast');
+
+        $this->assertDatabaseHas('leaves', [
+            'id' => $leave->id,
+            'status' => 'cancelled',
+        ]);
+        $this->assertDatabaseMissing('events', ['id' => $event->id]);
+    }
+}

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -407,7 +407,7 @@ class LeaveManageControllerTest extends TestCase
         $this->actingAs($admin)
             ->withSession(['selected_scope_id' => $scope->id])
             ->delete(route('leaves.destroy', $leave), [
-                'keep_generated_shifts' => '1',
+                'generated_shift_action' => 'detach',
             ])
             ->assertRedirect();
 
@@ -449,7 +449,7 @@ class LeaveManageControllerTest extends TestCase
             ->assertSee('Keep Shift')
             ->assertSee('Delete Absence & Shift', false)
             ->assertSee('Status Change Confirmation')
-            ->assertSee('inactive_generated_shift_action')
+            ->assertSee('generated_shift_action')
             ->assertSee('Delete Shift')
             ->assertSee('Generated School')
             ->assertSee('L1');
@@ -868,7 +868,7 @@ class LeaveManageControllerTest extends TestCase
         ]);
 
         $leave->status = 'cancelled';
-        $leave->generatedShiftInactiveAction = 'delete';
+        $leave->generatedShiftAction = 'delete';
         app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
 
         $this->assertDatabaseMissing('events', ['id' => $event->id]);

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -447,10 +447,9 @@ class LeaveManageControllerTest extends TestCase
             ->get(route('leaves.edit', ['leave_id' => $leave->id]))
             ->assertOk()
             ->assertSee('Keep Shift')
-            ->assertSee('Delete Absence &amp; Shift', false)
-            ->assertSee('Status Change Confirmation')
-            ->assertSee('generated_shift_action')
             ->assertSee('Delete Shift')
+            ->assertSee('Generated Shift Confirmation')
+            ->assertSee('generated_shift_action')
             ->assertSee('Generated School')
             ->assertSee('L1');
     }

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -447,7 +447,7 @@ class LeaveManageControllerTest extends TestCase
             ->get(route('leaves.edit', ['leave_id' => $leave->id]))
             ->assertOk()
             ->assertSee('Keep Shift')
-            ->assertSee('Delete Absence & Shift', false)
+            ->assertSee('Delete Absence &amp; Shift', false)
             ->assertSee('Status Change Confirmation')
             ->assertSee('generated_shift_action')
             ->assertSee('Delete Shift')

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -353,6 +353,105 @@ class LeaveManageControllerTest extends TestCase
         $this->assertDatabaseMissing('leaves', ['id' => $leave->id]);
     }
 
+    /**
+     * シナリオ 10b: Leave 削除時、デフォルトでは紐づく generated Event も削除される
+     */
+    public function test_admin_deletes_generated_event_with_leave_by_default(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        $event = Event::factory()->create([
+            'district_id'       => $district->id,
+            'department_id'     => $department->id,
+            'event_date'        => $leave->start_date->toDateString(),
+            'original_user_id'  => $targetUser->id,
+            'school_name'       => 'Generated School',
+            'status'            => 'pending',
+            'type'              => 'regular_time',
+            'source_leave_id'   => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('leaves.destroy', $leave))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('leaves', ['id' => $leave->id]);
+        $this->assertDatabaseMissing('events', ['id' => $event->id]);
+    }
+
+    /**
+     * シナリオ 10c: Keep Shift を選ぶと Leave だけ削除し、generated Event は手動シフトとして残る
+     */
+    public function test_admin_can_keep_generated_event_when_deleting_leave(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        $event = Event::factory()->create([
+            'district_id'       => $district->id,
+            'department_id'     => $department->id,
+            'event_date'        => $leave->start_date->toDateString(),
+            'original_user_id'  => $targetUser->id,
+            'school_name'       => 'Generated School',
+            'status'            => 'pending',
+            'type'              => 'regular_time',
+            'source_leave_id'   => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->delete(route('leaves.destroy', $leave), [
+                'keep_generated_shifts' => '1',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('leaves', ['id' => $leave->id]);
+        $this->assertDatabaseHas('events', [
+            'id'              => $event->id,
+            'source_leave_id' => null,
+        ]);
+    }
+
+    /**
+     * シナリオ 10d: Leave 削除モーダルで紐づく generated Event の確認情報を表示できる
+     */
+    public function test_leave_delete_modal_contains_generated_event_details(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        Event::factory()->create([
+            'district_id'       => $district->id,
+            'department_id'     => $department->id,
+            'event_date'        => $leave->start_date->toDateString(),
+            'original_user_id'  => $targetUser->id,
+            'school_name'       => 'Generated School',
+            'start_time'        => '09:00',
+            'end_time'          => '10:00',
+            'Lesson'            => 'L1',
+            'status'            => 'pending',
+            'type'              => 'regular_time',
+            'source_leave_id'   => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->get(route('leaves.edit', ['leave_id' => $leave->id]))
+            ->assertOk()
+            ->assertSee('Keep Shift')
+            ->assertSee('Delete Absence & Shift', false)
+            ->assertSee('Generated School')
+            ->assertSee('L1');
+    }
+
     // =========================================================================
     // 11. admin: bulkUpdate（一括更新）
     // =========================================================================

--- a/tests/Feature/LeaveManageControllerTest.php
+++ b/tests/Feature/LeaveManageControllerTest.php
@@ -448,8 +448,53 @@ class LeaveManageControllerTest extends TestCase
             ->assertOk()
             ->assertSee('Keep Shift')
             ->assertSee('Delete Absence & Shift', false)
+            ->assertSee('Status Change Confirmation')
+            ->assertSee('inactive_generated_shift_action')
+            ->assertSee('Delete Shift')
             ->assertSee('Generated School')
             ->assertSee('L1');
+    }
+
+    /**
+     * シナリオ 10e: generated Event がある Leave を inactive status にする場合は処理選択が必須
+     */
+    public function test_admin_must_confirm_generated_event_action_before_setting_leave_inactive(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        $event = Event::factory()->create([
+            'district_id'      => $district->id,
+            'department_id'    => $department->id,
+            'event_date'       => $leave->start_date->toDateString(),
+            'original_user_id' => $targetUser->id,
+            'status'           => 'pending',
+            'type'             => 'regular_time',
+            'source_leave_id'  => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->put(route('leaves.update', $leave), [
+                'user_id'    => $targetUser->id,
+                'start_date' => $leave->start_date->toDateString(),
+                'kind'       => 'paid',
+                'excused'    => 'excused',
+                'status'     => 'rejected',
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('toast_errors');
+
+        $this->assertDatabaseHas('leaves', [
+            'id'     => $leave->id,
+            'status' => 'approved',
+        ]);
+        $this->assertDatabaseHas('events', [
+            'id'              => $event->id,
+            'source_leave_id' => $leave->id,
+        ]);
     }
 
     // =========================================================================
@@ -488,6 +533,47 @@ class LeaveManageControllerTest extends TestCase
             'id'     => $leave->id,
             'kind'   => 'special',
             'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * シナリオ 11b: generated Event がある inactive 変更は Bulk 更新ではなく個別Save確認へ誘導する
+     */
+    public function test_bulk_update_rejects_inactive_status_without_generated_event_action(): void
+    {
+        [$admin, $scope, $district, $department] = $this->makeAdmin();
+
+        $targetUser = $this->makeUserInScope($district, $department);
+        $leave      = $this->makeLeaveInScope($district, $department, $targetUser);
+
+        Event::factory()->create([
+            'district_id'      => $district->id,
+            'department_id'    => $department->id,
+            'event_date'       => $leave->start_date->toDateString(),
+            'original_user_id' => $targetUser->id,
+            'status'           => 'pending',
+            'type'             => 'regular_time',
+            'source_leave_id'  => $leave->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->withSession(['selected_scope_id' => $scope->id])
+            ->postJson(route('leaves.bulk_update'), [
+                'items' => [[
+                    'id'         => $leave->id,
+                    'user_id'    => $targetUser->id,
+                    'start_date' => $leave->start_date->toDateString(),
+                    'kind'       => 'paid',
+                    'excused'    => 'excused',
+                    'status'     => 'cancelled',
+                ]],
+            ])
+            ->assertStatus(422)
+            ->assertJson(['ok' => false]);
+
+        $this->assertDatabaseHas('leaves', [
+            'id'     => $leave->id,
+            'status' => 'approved',
         ]);
     }
 
@@ -706,5 +792,85 @@ class LeaveManageControllerTest extends TestCase
         app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
 
         $this->assertDatabaseMissing('events', ['source_leave_id' => $leave->id]);
+    }
+
+    /**
+     * シナリオ 18: Leave が rejected / cancelled になる場合、既存 generated Event は削除せず手動シフトとして残す
+     */
+    public function test_snapshot_detaches_existing_events_when_leave_becomes_inactive(): void
+    {
+        foreach (['rejected', 'cancelled'] as $status) {
+            $district   = District::factory()->create();
+            $department = Department::factory()->create();
+
+            $user = User::factory()->create([
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+            ]);
+
+            $leave = Leave::factory()->create([
+                'user_id'       => $user->id,
+                'start_date'    => now()->toDateString(),
+                'status'        => 'approved',
+                'district_id'   => $district->id,
+                'department_id' => $department->id,
+            ]);
+
+            $event = Event::factory()->create([
+                'district_id'      => $district->id,
+                'department_id'    => $department->id,
+                'event_date'       => $leave->start_date->toDateString(),
+                'original_user_id' => $user->id,
+                'status'           => 'pending',
+                'type'             => 'regular_time',
+                'source_leave_id'  => $leave->id,
+            ]);
+
+            $leave->status = $status;
+            app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
+
+            $this->assertDatabaseHas('events', [
+                'id'              => $event->id,
+                'source_leave_id' => null,
+            ]);
+        }
+    }
+
+    /**
+     * シナリオ 19: inactive status 変更時に delete を選択した場合、既存 generated Event は削除される
+     */
+    public function test_snapshot_deletes_existing_events_when_inactive_action_is_delete(): void
+    {
+        $district   = District::factory()->create();
+        $department = Department::factory()->create();
+
+        $user = User::factory()->create([
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id'       => $user->id,
+            'start_date'    => now()->toDateString(),
+            'status'        => 'approved',
+            'district_id'   => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $event = Event::factory()->create([
+            'district_id'      => $district->id,
+            'department_id'    => $department->id,
+            'event_date'       => $leave->start_date->toDateString(),
+            'original_user_id' => $user->id,
+            'status'           => 'pending',
+            'type'             => 'regular_time',
+            'source_leave_id'  => $leave->id,
+        ]);
+
+        $leave->status = 'cancelled';
+        $leave->generatedShiftInactiveAction = 'delete';
+        app(LeaveSnapshotService::class)->rebuildSnapshotsForLeave($leave);
+
+        $this->assertDatabaseMissing('events', ['id' => $event->id]);
     }
 }


### PR DESCRIPTION
## Summary of [Shift daily assigner初版完成](https://github.com/Jin6hara/LaravelSprout/commit/893f4e38136c8793a0bb2ae92b9374e2fd247eaf)

Forecast 用の新画面として、日別の Shift 編集画面 `Day Assigner` を追加しました。

新画面:

```text
http://localhost:3030/forecast/day-assigner?date=2026-05-31
```

この画面では、上部に FullCalendar の `listDay` 表示、右上に SUB 情報、下部に `.vscode/⭐️lineEdit.blade.php` 系のテーブルスタイルを使った Shift 編集エリアを配置しています。

## Main Changes

主な変更は以下です。

* `EventAssignController.php` に `dailyBoard()` を追加
* `web.php` に `/forecast/day-assigner` ルートを追加
* `dailyBoard.blade.php` を新規作成
* `daily-shift-board.js` で status 即時保存、Bulk Save、カレンダー再取得、SUB表示、高さ調整を実装
* `daily-shift-board.css` を追加
* Forecast 詳細モーダルに、既存の `Edit` 導線を残したまま `Day Board` への導線を追加

## Implementation Details

### 1. Day Assigner 画面の追加

`EventAssignController.php` に `dailyBoard()` を追加し、指定日の Shift 編集画面を表示できるようにしました。

対象ルート:

```text
/forecast/day-assigner?date=2026-05-31
```

ルートは `web.php` に追加しています。

```text
route:list --name=calendar.daily_assigner
```

で確認できます。

### 2. 画面構成

`dailyBoard.blade.php` を新規作成し、以下の構成で表示しています。

```text
上部: FullCalendar listDay
右上: SUB 情報
下部: Shift 編集テーブル
```

Shift 編集テーブルは、`.vscode/⭐️lineEdit.blade.php` 系のテーブルスタイルを参考にしています。

### 3. Status 即時保存

`daily-shift-board.js` で、status を変更した行だけを即時保存する処理を追加しました。

status 変更後、保存に成功した場合は Forecast List と SUB 情報を `refetchEvents()` で再取得し、画面表示を同期します。

### 4. Bulk Save

Daily Shift Board 上で、複数行をまとめて保存できる Bulk Save 処理を追加しました。

行ごとの編集内容を保存し、保存後は必要に応じてカレンダー表示を再取得します。

### 5. Forecast List / SUB の同期

status 即時保存や Bulk Save の成功後に、Forecast List と SUB 情報を再取得するようにしました。

これにより、Editor 側の更新内容と上部の Forecast 表示がずれないようにしています。

### 6. SUB 表示

Daily Shift Board 上で、対象日の SUB 情報を確認できるようにしました。

Forecast 側の情報と連動し、保存後の再取得によって最新状態に同期されます。

### 7. 上下ペインの高さ調整

School Timetable と同じ方向性で、上部カレンダーエリアと下部編集エリアの高さをドラッグで調整できるようにしました。

## Changed Files

### `app/Http/Controllers/EventAssignController.php`

* `dailyBoard()` を追加
* Day Assigner 画面表示用のController処理を追加

### `routes/web.php`

* `/forecast/day-assigner` ルートを追加

### `resources/views/calendar/dailyBoard.blade.php`

* Daily Shift Board 画面を新規作成
* FullCalendar `listDay`、SUB表示、Shift編集テーブルを配置

### `public/js/daily-shift-board.js`

* status 即時保存を実装
* Bulk Save を実装
* 保存後のカレンダー再取得を実装
* SUB 表示を実装
* 上下ペインの高さ調整を実装

### `public/css/daily-shift-board.css`

* Daily Shift Board 用のCSSを追加
* テーブル表示、状態表示、レイアウト調整を追加

### `resources/views/calendar/forecast.blade.php`

* Forecast 詳細モーダルに `Day Board` 導線を追加
* 既存の `Edit` 導線はそのまま維持

## Authorization

認可は既存の Forecast / Event 編集系と同じ方針です。

* `auth`
* `role:admin|super_admin`
* Controller 側で `EventPolicy::viewAny`
* Controller 側で `EventPolicy::update`

これにより、admin / super_admin のみが Day Assigner 画面を利用できます。

## Tests

確認済みの内容は以下です。

```bash
docker exec -w /var/www/html/Jin_10 jin_app php artisan test --filter=EventAssignControllerTest
docker exec -w /var/www/html/Jin_10 jin_app php artisan test --filter=CalendarControllerTest
node --check public/js/daily-shift-board.js
node --check public/js/forecast.js
php -l app/Http/Controllers/EventAssignController.php
php artisan route:list --name=calendar.daily_assigner
```

Result:

```text
EventAssignControllerTest: 18 passed
CalendarControllerTest: 10 passed
node --check public/js/daily-shift-board.js: passed
node --check public/js/forecast.js: passed
php -l 対象 PHP ファイル: passed
route:list --name=calendar.daily_assigner: confirmed
```

## Suggested Commit Message

```text
Add daily shift board for forecast day assignment
```

## Summary of [同時編集競合防止対策](https://github.com/Jin6hara/LaravelSprout/commit/2aa08464cae6a6b5a8da975ad65012880335c819)

Shift Assigner / Daily Shift Board の Bulk Update に、同時編集による上書き防止を追加しました。

主な対応は以下です。

- `updated_at` を使った楽観ロック
- 画面上で変更された行だけをBulk更新対象にする dirty 管理
- 競合発生時に古い画面からの更新を拒否
- 保存成功行は緑、保存失敗行は赤で表示
- Daily画面では保存後にカレンダー表示を再取得して同期

## Background

これまでのBulk Saveでは、画面に表示されている複数Eventをまとめて送信していました。

そのため、以下のようなケースで問題が起きる可能性がありました。

```text
Aが Event 1,2,3,4 を開く
Bも Event 1,2,3,4 を開く
Aが Event 3,4 を更新
Bが Event 1 のみ変更してBulk Save
```

このとき、Bの画面上では Event 3,4 が古い情報のままなので、Bulk Saveで Event 3,4 まで送信してしまうと、Aの更新内容をBの古い情報で上書きしてしまう可能性がありました。

## Implementation Details

### 1. `updated_at` による楽観ロック

各Eventの画面表示時点の `updated_at` を hidden input として保持します。

保存時には、サーバ側で以下を比較します。

```text
画面が持っている updated_at
DB上の現在の updated_at
```

一致する場合のみ保存します。

一致しない場合は、他ユーザーが先に更新したと判断し、そのEventは保存しません。

競合時のメッセージ:

```text
Already updated by others. Please reload before saving.
```

### 2. Bulk Save は変更された行だけ送信

Daily Shift Board と Shift Assigner の両方で、画面ロード時の初期値をJS側に保持します。

保存時には現在値と初期値を比較し、変更がある行だけを送信します。

これにより、ユーザーが触っていないEventはBulk更新対象になりません。

```text
Bが Event 1 のみ変更
→ Bulk Saveでは Event 1 のみ送信
→ Event 3,4 は送信されない
→ Aの更新内容を戻さない
```

### 3. 競合した行は保存しない

変更された行であっても、保存時点で `updated_at` がDBと一致しない場合は保存を拒否します。

これにより、同じEventをAとBが同時に編集した場合でも、後から古い情報で上書きされません。

### 4. 成功行・失敗行の視覚表示

Daily Shift Board では保存結果に応じて行の表示状態を切り替えます。

- 保存成功: 緑表示
- 保存失敗: 赤表示
- 保存中: saving状態

Bulk Saveで複数行を保存した場合も、行ごとの結果を `results` で受け取り、それぞれの行に成功/失敗状態を反映します。

競合で失敗した場合は、単なる `failed to save` ではなく、以下のように原因が分かる文言を表示します。

```text
Event #123 was already updated by others. Please reload.
```

複数行で競合がある場合:

```text
Some events were already updated by others. Please reload before saving.
```

### 5. 保存成功後の `updated_at` 更新

保存に成功した行は、サーバから返された最新の `updated_at` に差し替えます。

これにより、同じ画面上で続けて編集しても、次回保存時に古い `updated_at` を使わないようにしています。

### 6. Daily画面のカレンダー同期

Daily Shift Board では保存成功後にカレンダーを再取得します。

部分成功の場合も、保存できた行があればカレンダーを再取得し、画面上のForecast表示とEditorの状態がずれないようにしています。

## Changed Files

### `app/Http/Controllers/EventAssignController.php`

- `bulkUpdate()` に `updated_at` 比較を追加
- 競合時は保存せず `conflict: true` を返却
- 保存成功時は最新の `updated_at` をJSONで返却
- 通常の `update()` にも楽観ロックを追加

### `app/Http/Requests/EventAssign/BulkUpdateEventRequest.php`

- Bulk更新時に `updated_at` を必須項目として追加
- Bulk Saveでは同時編集防止を必ず適用するため

### `app/Http/Requests/EventAssign/UpdateEventRequest.php`

- 個別更新でも `updated_at` を受け取れるように追加
- 既存リクエスト互換のため nullable

### `resources/views/calendar/dailyBoard.blade.php`

- Daily Editorの各行に hidden `updated_at` を追加

### `resources/views/calendar/edit.blade.php`

- Shift Assignerの各フォームに hidden `updated_at` を追加
- Bulk Save時に変更フォームだけ送る dirty 管理を追加

### `public/js/daily-shift-board.js`

- 行ごとの初期状態を保持
- 変更された行のみ保存対象にする処理を追加
- 保存結果に応じて成功行を緑、失敗行を赤で表示
- 競合時のメッセージを分かりやすく変更
- 保存成功後に最新 `updated_at` を反映
- 保存後にカレンダーを再取得

### `tests/Feature/EventAssignControllerTest.php`

- Bulk更新正常系に `updated_at` を追加
- 古い `updated_at` で保存した場合に更新拒否されるテストを追加

## Tests

```bash
node --check public/js/daily-shift-board.js
git diff --check
docker exec -w /var/www/html/Jin_10 jin_app php artisan test --filter=EventAssignControllerTest
```

Result:

```text
19 passed (43 assertions)
```

## Suggested Commit Message

```text
Prevent stale shift bulk updates with optimistic locking
```