### PR TITLE
承認通知と承認操作を現在選択中スコープに限定

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -2,12 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ApprovalRequest;
+use App\Services\Notifications\ScopedNotificationService;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\DatabaseNotification;
-use App\Models\ApprovalRequest;
 
 class NotificationController extends Controller
 {
+    public function __construct(private ScopedNotificationService $scopedNotifications) {}
+
     /**
      * 通知一覧画面
      * GET /notifications — 最新100件を「承認待ち」と「処理済み」に分けて表示。各承認申請の現在の状態も付与
@@ -16,11 +19,10 @@ class NotificationController extends Controller
     {
         $user = $request->user();
 
-        // 最新100件を対象（必要に応じて増減）
-        $all = $user->notifications()->latest()->take(100)->get();
+        $all = $this->scopedNotifications->visibleNotifications($user);
 
         // 通知に含まれる approval_request_id を一括取得
-        $arIds = $all->map(fn($n) => $n->data['approval_request_id'] ?? null)
+        $arIds = $all->map(fn ($n) => $n->data['approval_request_id'] ?? null)
             ->filter()->unique()->values();
 
         // id => current_state のマップ: pending|approved|denied
@@ -35,12 +37,12 @@ class NotificationController extends Controller
 
             // 未承認の定義：explicit に pending。state 不明（別種の通知）は上側に寄せる運用
             $isPending = ($state === 'pending') || is_null($state);
-            $isUnread  = is_null($n->read_at);
+            $isUnread = is_null($n->read_at);
 
             // Blade で使いやすいよう動的プロパティ付与
             $n->computed_state = $state;     // 'pending' | 'approved' | 'denied' | null
-            $n->is_pending     = $isPending; // 上
-            $n->is_unread      = $isUnread;
+            $n->is_pending = $isPending; // 上
+            $n->is_unread = $isUnread;
 
             return $n;
         });
@@ -48,19 +50,19 @@ class NotificationController extends Controller
         // 上（未承認）グループ：未読を先に、同順なら新しい順
         $top = $decorated->where('is_pending', true)
             ->sortBy([
-                fn($n) => $n->is_unread ? 0 : 1,
-                fn($n) => -$n->created_at->getTimestamp(),
+                fn ($n) => $n->is_unread ? 0 : 1,
+                fn ($n) => -$n->created_at->getTimestamp(),
             ])->values();
 
         // 下（承認済み/却下済み）グループ：未読を先に、同順なら新しい順
         $bottom = $decorated->where('is_pending', false)
             ->sortBy([
-                fn($n) => $n->is_unread ? 0 : 1,
-                fn($n) => -$n->created_at->getTimestamp(),
+                fn ($n) => $n->is_unread ? 0 : 1,
+                fn ($n) => -$n->created_at->getTimestamp(),
             ])->values();
 
         return view('notifications.index', [
-            'topNotifications'    => $top,
+            'topNotifications' => $top,
             'bottomNotifications' => $bottom,
         ]);
     }
@@ -73,6 +75,7 @@ class NotificationController extends Controller
     {
         $this->authorize('view-notification', $notification);
         $notification->markAsRead();
+
         return back();
     }
 
@@ -82,7 +85,8 @@ class NotificationController extends Controller
      */
     public function markAllAsRead(Request $request)
     {
-        $request->user()->unreadNotifications->markAsRead();
+        $this->scopedNotifications->markVisibleUnreadAsRead($request->user());
+
         return back();
     }
 

--- a/app/Models/ApprovalRequest.php
+++ b/app/Models/ApprovalRequest.php
@@ -4,9 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ApprovalRequest extends Model
 {
@@ -24,7 +24,8 @@ class ApprovalRequest extends Model
     protected $casts = [
         'metadata' => 'array',
     ];
-    //Role|Paid Leave|Overtime
+
+    // Role|Paid Leave|Overtime
     public function approvable(): MorphTo
     {
         return $this->morphTo();
@@ -34,9 +35,28 @@ class ApprovalRequest extends Model
     {
         return $this->belongsTo(User::class, 'requested_by_id');
     }
-    //Role|Paid Leave|Overtime
+
+    // Role|Paid Leave|Overtime
     public function actions(): HasMany
     {
         return $this->hasMany(ApprovalAction::class);
+    }
+
+    public function approvalDistrictId(): ?int
+    {
+        $approvable = $this->approvable;
+
+        return $approvable?->district_id
+            ?? ($this->metadata['district_id'] ?? null)
+            ?? ($this->metadata['requested_district_id'] ?? null);
+    }
+
+    public function approvalDepartmentId(): ?int
+    {
+        $approvable = $this->approvable;
+
+        return $approvable?->department_id
+            ?? ($this->metadata['department_id'] ?? null)
+            ?? ($this->metadata['requested_department_id'] ?? null);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,23 +4,24 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Enums\Gender;
+use App\Models\Pivots\PostViewer;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Laravel\Sanctum\HasApiTokens;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Carbon\Carbon;
-use Spatie\Permission\Traits\HasRoles;
-use App\Models\Pivots\PostViewer;
 use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 /**
  * @mixin \Spatie\Permission\Traits\HasRoles
  */
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable, SoftDeletes, HasRoles;
+    use HasApiTokens, HasFactory, HasRoles, Notifiable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -70,7 +71,6 @@ class User extends Authenticatable
      * The name of the guard used by this model.
      * This is used by Spatie's Permission package to determine the guard for roles and permissions.
      *
-     * @var string
      * @see https://spatie.be/docs/laravel-permission/v5/basic-usage/guards-and-multi-auth#guard_name
      */
     protected string $guard_name = 'web';
@@ -99,8 +99,8 @@ class User extends Authenticatable
      */
     protected function updateFullName(): void
     {
-        $last   = $this->attributes['family_name'] ?? '';
-        $first  = $this->attributes['first_name'] ?? '';
+        $last = $this->attributes['family_name'] ?? '';
+        $first = $this->attributes['first_name'] ?? '';
         $middle = $this->attributes['middle_name'] ?? '';
 
         // 順番: Last → First → Middle
@@ -118,7 +118,8 @@ class User extends Authenticatable
     {
         $defaults = config('user.default_profile_pictures');
         $file = $this->profile_picture ?: $defaults[$this->gender];
-        return asset('image/' . ltrim($file, '/'));
+
+        return asset('image/'.ltrim($file, '/'));
     }
 
     public function getGenderLabelAttribute(): string
@@ -136,19 +137,32 @@ class User extends Authenticatable
         return $this->hasRole('super_admin');
     }
 
+    public function scopeApprovalRecipientsForScope(Builder $query, ?int $districtId, ?int $departmentId): Builder
+    {
+        if ($districtId === null || $departmentId === null) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->role('super_admin')
+            ->whereHas('managementScopes', function (Builder $q) use ($districtId, $departmentId) {
+                $q->where('district_id', $districtId)
+                    ->where('department_id', $departmentId);
+            });
+    }
+
     public function getRoleLabelAttribute(): string
     {
         $role = $this->getRoleNames()->first();
 
-        if (!$role) {
+        if (! $role) {
             return '未設定';
         }
 
         $map = [
-            'general'      => '一般',
-            'trainer'      => 'トレーナー',
-            'admin'        => '管理者',
-            'super_admin'  => 'スーパー管理者',
+            'general' => '一般',
+            'trainer' => 'トレーナー',
+            'admin' => '管理者',
+            'super_admin' => 'スーパー管理者',
         ];
 
         return $map[$role] ?? $role; // 未定義ロールは英字のまま表示
@@ -173,6 +187,7 @@ class User extends Authenticatable
     public function currentEmploymentTerm(?Carbon $date = null)
     {
         $d = ($date ?? now())->toDateString();
+
         return $this->employmentTerms()
             ->whereDate('start_date', '<=', $d)
             ->where(function ($q) use ($d) {
@@ -190,7 +205,7 @@ class User extends Authenticatable
 
         return $q->whereHas('employmentTerms', function ($term) use ($d) {
             $term->currentAt($d)
-                ->whereDoesntHave('leavePeriods', fn($leave) => $leave->coversDate($d));
+                ->whereDoesntHave('leavePeriods', fn ($leave) => $leave->coversDate($d));
         });
     }
 
@@ -201,7 +216,7 @@ class User extends Authenticatable
 
         return $q->whereHas('employmentTerms', function ($term) use ($d) {
             $term->currentAt($d)
-                ->whereHas('leavePeriods', fn($leave) => $leave->coversDate($d));
+                ->whereHas('leavePeriods', fn ($leave) => $leave->coversDate($d));
         });
     }
 
@@ -209,17 +224,18 @@ class User extends Authenticatable
     public function scopePrehire($q, ?Carbon $date = null)
     {
         $d = ($date ?? today())->toDateString();
-        return $q->whereHas('employmentTerms', fn($t) => $t->whereDate('start_date', '>', $d));
+
+        return $q->whereHas('employmentTerms', fn ($t) => $t->whereDate('start_date', '>', $d));
     }
 
     /** 退職済（今日有効な雇用期間なし＆将来の開始もなし） */
     public function scopeTerminated($q, ?Carbon $date = null)
     {
         $d = ($date ?? today())->toDateString();
+
         return $q->whereDoesntHave(
             'employmentTerms',
-            fn($t) =>
-            $t->whereDate('start_date', '>', $d)
+            fn ($t) => $t->whereDate('start_date', '>', $d)
                 ->orWhere(function ($tt) use ($d) {
                     $tt->whereDate('start_date', '<=', $d)
                         ->where(function ($qq) use ($d) {
@@ -241,7 +257,7 @@ class User extends Authenticatable
 
         // 現在有効な雇用期間
         $term = $this->currentEmploymentTerm(today())->first();
-        if (!$term) {
+        if (! $term) {
             return '退職済み/terminated';
         }
 
@@ -257,6 +273,7 @@ class User extends Authenticatable
     public function shouldReceiveOperationalEmails(?Carbon $date = null): bool
     {
         $state = $this->employment_state; // 上のアクセサで取得
+
         return $state === 'active';
     }
 
@@ -294,6 +311,7 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class, 'user_id');
     }
+
     public function postsVisible()
     {
         return $this->belongsToMany(Post::class, 'post_user')

--- a/app/Policies/ApprovalRequestPolicy.php
+++ b/app/Policies/ApprovalRequestPolicy.php
@@ -2,8 +2,9 @@
 
 namespace App\Policies;
 
-use App\Models\User;
 use App\Models\ApprovalRequest;
+use App\Models\User;
+use App\Services\Notifications\ScopedNotificationService;
 
 class ApprovalRequestPolicy
 {
@@ -18,13 +19,24 @@ class ApprovalRequestPolicy
     public function view(User $actor, ApprovalRequest $ar): bool
     {
         // 対象者本人 or 承認者（super_admin 等）
-        if ($actor->id === ($ar->metadata['target_user_id'] ?? null)) return true;
-        return $actor->hasRole('super_admin');
+        if ($actor->id === ($ar->metadata['target_user_id'] ?? null)) {
+            return true;
+        }
+
+        return $this->canManageApprovalScope($actor, $ar);
     }
 
     public function act(User $actor, ApprovalRequest $ar): bool
     {
-        // 承認できるのは super_admin
-        return $actor->hasRole('super_admin');
+        return $this->canManageApprovalScope($actor, $ar);
+    }
+
+    private function canManageApprovalScope(User $actor, ApprovalRequest $ar): bool
+    {
+        if (! $actor->hasRole('super_admin')) {
+            return false;
+        }
+
+        return app(ScopedNotificationService::class)->matchesCurrentScope($ar);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,26 +2,26 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Pagination\Paginator;
-use Illuminate\Support\Facades\View;
-use App\Services\Calendar\CalendarResolver;
-use App\Services\Calendar\Contracts\CalendarEventProvider;
-use App\Models\Leave;
 use App\Models\Event;
-use App\Observers\LeaveObserver;
+use App\Models\Leave;
 use App\Observers\EventObserver;
+use App\Observers\LeaveObserver;
+use App\Services\Calendar\CalendarResolver;
 use App\Services\Calendar\ForecastResolver;
 use App\Services\Calendar\LeaveResolver;
-use App\Services\Calendar\Providers\HolidayProvider;
-use App\Services\Calendar\Providers\ClosureProvider;
-use App\Services\Calendar\Providers\SubCountProvider;
 use App\Services\Calendar\Providers\AllEventProvider;
 use App\Services\Calendar\Providers\AllLeaveProvider;
+use App\Services\Calendar\Providers\ClosureProvider;
+use App\Services\Calendar\Providers\HolidayProvider;
+use App\Services\Calendar\Providers\SubCountProvider;
+use App\Services\Notifications\ScopedNotificationService;
 use App\Support\DatabaseText;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -47,6 +47,7 @@ class AppServiceProvider extends ServiceProvider
         // Resolver をシングルトンで用意し、タグ経由で Provider 群を注入
         $this->app->singleton(CalendarResolver::class, function ($app) {
             $providers = $app->tagged('calendar.providers');
+
             return new CalendarResolver($providers);
         });
 
@@ -58,6 +59,7 @@ class AppServiceProvider extends ServiceProvider
                 $app->make(SubCountProvider::class),
                 $app->make(AllEventProvider::class),
             ];
+
             return new ForecastResolver($providers);
         });
 
@@ -68,6 +70,7 @@ class AppServiceProvider extends ServiceProvider
                 $app->make(ClosureProvider::class),
                 $app->make(AllLeaveProvider::class),
             ];
+
             return new LeaveResolver($providers);
         });
     }
@@ -79,36 +82,34 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->bootQueryTextMacros();
 
-        Paginator::useBootstrapFive(); //user.userListのpagination用に
+        Paginator::useBootstrapFive(); // user.userListのpagination用に
         Leave::observe(LeaveObserver::class);
         Event::observe(EventObserver::class);
 
         View::composer('layouts.app', function ($view) {
             $user = auth()->user();
-            if (!$user) {
+            if (! $user) {
                 return;
             }
 
             // 代理閲覧中でもヘッダーは「自分の未確認」を出す想定
             $inboxUnconfirmed = $user->inboxUnconfirmedCount();
 
-            $unreadNotificationsCount = $user->hasRole(['admin', 'super_admin'])
-                ? $user->unreadNotifications()->count()
-                : 0;
+            $unreadNotificationsCount = app(ScopedNotificationService::class)->unreadCount($user);
 
             // scope selector 用データ（admin / super_admin のみ）
             $scopeSelectorData = null;
             if ($user->isAdmin()) {
-                $scopeService    = app(\App\Services\CurrentScopeService::class);
-                $adminScopes     = $user->managementScopes()->with(['district', 'department'])->get();
+                $scopeService = app(\App\Services\CurrentScopeService::class);
+                $adminScopes = $user->managementScopes()->with(['district', 'department'])->get();
                 $selectedScopeId = $scopeService->currentScope()?->id;
                 $scopeSelectorData = compact('adminScopes', 'selectedScopeId');
             }
 
             $view->with([
-                'inboxUnconfirmed'         => $inboxUnconfirmed,
+                'inboxUnconfirmed' => $inboxUnconfirmed,
                 'unreadNotificationsCount' => $unreadNotificationsCount,
-                'scopeSelectorData'        => $scopeSelectorData,
+                'scopeSelectorData' => $scopeSelectorData,
             ]);
         });
 
@@ -119,25 +120,25 @@ class AppServiceProvider extends ServiceProvider
 
     private function bootQueryTextMacros(): void
     {
-        if (!QueryBuilder::hasMacro('whereLikeInsensitive')) {
+        if (! QueryBuilder::hasMacro('whereLikeInsensitive')) {
             QueryBuilder::macro('whereLikeInsensitive', function (string $column, ?string $value, string $boolean = 'and') {
                 return DatabaseText::whereContainsInsensitive($this, $column, $value, $boolean);
             });
         }
 
-        if (!QueryBuilder::hasMacro('orWhereLikeInsensitive')) {
+        if (! QueryBuilder::hasMacro('orWhereLikeInsensitive')) {
             QueryBuilder::macro('orWhereLikeInsensitive', function (string $column, ?string $value) {
                 return DatabaseText::whereContainsInsensitive($this, $column, $value, 'or');
             });
         }
 
-        if (!QueryBuilder::hasMacro('whereEqualsInsensitive')) {
+        if (! QueryBuilder::hasMacro('whereEqualsInsensitive')) {
             QueryBuilder::macro('whereEqualsInsensitive', function (string $column, ?string $value, string $boolean = 'and') {
                 return DatabaseText::whereEqualsInsensitive($this, $column, $value, $boolean);
             });
         }
 
-        if (!QueryBuilder::hasMacro('orWhereEqualsInsensitive')) {
+        if (! QueryBuilder::hasMacro('orWhereEqualsInsensitive')) {
             QueryBuilder::macro('orWhereEqualsInsensitive', function (string $column, ?string $value) {
                 return DatabaseText::whereEqualsInsensitive($this, $column, $value, 'or');
             });

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -26,8 +26,9 @@ use App\Policies\LessonPolicy;
 use App\Policies\ScheduleDetailPolicy;
 use App\Policies\ScheduleLinePolicy;
 use App\Policies\UserManagementScopePolicy;
-use Illuminate\Notifications\DatabaseNotification;
+use App\Services\Notifications\ScopedNotificationService;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
@@ -38,21 +39,21 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        \App\Models\User::class                => \App\Policies\UserPolicy::class,
-        \App\Models\Leave::class               => \App\Policies\LeavePolicy::class,
-        \App\Models\Post::class                => \App\Policies\PostPolicy::class,
-        ApprovalRequest::class                 => ApprovalRequestPolicy::class,
-        CommutePattern::class                  => CommutePatternPolicy::class,
-        CommuterPass::class                    => CommuterPassPolicy::class,
-        Department::class                      => DepartmentPolicy::class,
-        District::class                        => DistrictPolicy::class,
-        Event::class                           => EventPolicy::class,
-        ExpenseReport::class                   => ExpenseReportPolicy::class,
-        Expense::class                         => ExpensePolicy::class,
-        Lesson::class                          => LessonPolicy::class,
-        ScheduleLine::class                    => ScheduleLinePolicy::class,
-        ScheduleDetail::class                  => ScheduleDetailPolicy::class,
-        UserManagementScope::class             => UserManagementScopePolicy::class,
+        \App\Models\User::class => \App\Policies\UserPolicy::class,
+        \App\Models\Leave::class => \App\Policies\LeavePolicy::class,
+        \App\Models\Post::class => \App\Policies\PostPolicy::class,
+        ApprovalRequest::class => ApprovalRequestPolicy::class,
+        CommutePattern::class => CommutePatternPolicy::class,
+        CommuterPass::class => CommuterPassPolicy::class,
+        Department::class => DepartmentPolicy::class,
+        District::class => DistrictPolicy::class,
+        Event::class => EventPolicy::class,
+        ExpenseReport::class => ExpenseReportPolicy::class,
+        Expense::class => ExpensePolicy::class,
+        Lesson::class => LessonPolicy::class,
+        ScheduleLine::class => ScheduleLinePolicy::class,
+        ScheduleDetail::class => ScheduleDetailPolicy::class,
+        UserManagementScope::class => UserManagementScopePolicy::class,
     ];
 
     /**
@@ -63,8 +64,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         Gate::define('view-notification', function (\App\Models\User $user, DatabaseNotification $notification): bool {
-            return $notification->notifiable_type === \App\Models\User::class
-                && (int) $notification->notifiable_id === $user->id;
+            return app(ScopedNotificationService::class)->isVisible($user, $notification);
         });
     }
 }

--- a/app/Services/CurrentScopeService.php
+++ b/app/Services/CurrentScopeService.php
@@ -11,7 +11,12 @@ class CurrentScopeService
 {
     /** リクエスト内でキャッシュ済みかどうか */
     private ?UserManagementScope $resolvedScope = null;
+
     private bool $scopeLoaded = false;
+
+    private ?int $resolvedUserId = null;
+
+    private mixed $resolvedScopeId = null;
 
     /**
      * ログインユーザーの現在の管理スコープを返す。
@@ -23,18 +28,25 @@ class CurrentScopeService
      */
     public function currentScope(): ?UserManagementScope
     {
-        if ($this->scopeLoaded) {
+        $user = auth()->user();
+        $scopeId = session('selected_scope_id');
+
+        if (
+            $this->scopeLoaded
+            && $this->resolvedUserId === $user?->id
+            && $this->resolvedScopeId === $scopeId
+        ) {
             return $this->resolvedScope;
         }
 
         $this->scopeLoaded = true;
+        $this->resolvedUserId = $user?->id;
+        $this->resolvedScopeId = $scopeId;
+        $this->resolvedScope = null;
 
-        $user = auth()->user();
-        if (!$user || !$user->isAdmin()) {
+        if (! $user || ! $user->isAdmin()) {
             return null;
         }
-
-        $scopeId = session('selected_scope_id');
 
         $query = UserManagementScope::where('user_id', $user->id)
             ->with(['district', 'department']);
@@ -55,7 +67,7 @@ class CurrentScopeService
     public function currentDistrictId(): ?int
     {
         $user = auth()->user();
-        if (!$user) {
+        if (! $user) {
             return null;
         }
 
@@ -73,7 +85,7 @@ class CurrentScopeService
     public function currentDepartmentId(): ?int
     {
         $user = auth()->user();
-        if (!$user) {
+        if (! $user) {
             return null;
         }
 
@@ -94,7 +106,7 @@ class CurrentScopeService
      */
     public function targetUserQuery(): Builder
     {
-        $user   = auth()->user();
+        $user = auth()->user();
         $selfId = $user?->id;
 
         if ($user && $user->isAdmin()) {
@@ -103,7 +115,7 @@ class CurrentScopeService
 
             if ($did !== null && $dep !== null) {
                 return User::where('district_id', $did)
-                           ->where('department_id', $dep);
+                    ->where('department_id', $dep);
             }
         }
 

--- a/app/Services/LeaveApply/LeaveApplicationService.php
+++ b/app/Services/LeaveApply/LeaveApplicationService.php
@@ -7,7 +7,6 @@ use App\Enums\LeaveKind;
 use App\Enums\LeaveStatus;
 use App\Models\Leave;
 use App\Models\User;
-use App\Models\ApprovalRequest;
 use App\Notifications\ApprovalRequestedNotification;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -29,7 +28,7 @@ class LeaveApplicationService
         ?array $attachmentMeta = null
     ): array {
         $dates = collect($dates)
-            ->map(fn($d) => trim((string) $d))
+            ->map(fn ($d) => trim((string) $d))
             ->filter()
             ->unique()
             ->sort()
@@ -45,18 +44,23 @@ class LeaveApplicationService
             ? $this->applySpecial($userId, $dates, $reason, $requestedByUserId, $specialType, $attachmentMeta, $batchId)
             : $this->applyPaid($userId, $dates, $reason, $requestedByUserId, $batchId);
 
-        if (!empty($result['requests'])) {
-            $admins = User::role(['super_admin'])->get();
+        if (! empty($result['requests'])) {
+            $approvalRequest = $result['requests'][0];
+            $admins = User::approvalRecipientsForScope(
+                $approvalRequest->approvalDistrictId(),
+                $approvalRequest->approvalDepartmentId()
+            )->get();
+
             Notification::send(
                 $admins,
-                new ApprovalRequestedNotification($result['requests'][0], count($result['requests']), $batchId)
+                new ApprovalRequestedNotification($approvalRequest, count($result['requests']), $batchId)
             );
         }
 
         return [
             'created' => $result['created'],
             'skipped' => $result['skipped'],
-            'skips'   => $result['skips'],
+            'skips' => $result['skips'],
         ];
     }
 
@@ -67,9 +71,9 @@ class LeaveApplicationService
         int $requestedByUserId,
         string $batchId
     ): array {
-        $result   = ['created' => 0, 'skipped' => 0, 'skips' => [], 'requests' => []];
-        $user     = User::find($userId);
-        $code     = $user?->employee_code ?? '';
+        $result = ['created' => 0, 'skipped' => 0, 'skips' => [], 'requests' => []];
+        $user = User::find($userId);
+        $code = $user?->employee_code ?? '';
         $userLabel = $user ? ($code ? "{$user->name} [{$code}]" : $user->name) : "user#{$userId}";
         $titleBase = "**ALP** {$userLabel} ({$dates->implode(', ')})";
 
@@ -85,34 +89,37 @@ class LeaveApplicationService
                 if ($already) {
                     $result['skipped']++;
                     $result['skips'][$ymd] = '既に申請/承認済みです';
+
                     continue;
                 }
 
                 $leave = Leave::create([
-                    'user_id'       => $userId,
-                    'start_date'    => $ymd,
-                    'end_date'      => null,
-                    'kind'          => LeaveKind::Paid->value,
-                    'excused'       => LeaveExcused::Excused->value,
-                    'reason'        => $reason,
-                    'status'        => LeaveStatus::Pending->value,
-                    'special_type'  => null,
-                    'district_id'   => $user?->district_id,
+                    'user_id' => $userId,
+                    'start_date' => $ymd,
+                    'end_date' => null,
+                    'kind' => LeaveKind::Paid->value,
+                    'excused' => LeaveExcused::Excused->value,
+                    'reason' => $reason,
+                    'status' => LeaveStatus::Pending->value,
+                    'special_type' => null,
+                    'district_id' => $user?->district_id,
                     'department_id' => $user?->department_id,
                 ]);
 
                 $ar = $leave->approvalRequest()->create([
-                    'title'           => $titleBase,
+                    'title' => $titleBase,
                     'requested_by_id' => $requestedByUserId,
-                    'current_state'   => 'pending',
-                    'metadata'        => [
-                        'batch_id'     => $batchId,
-                        'leave_id'     => $leave->id,
-                        'user_id'      => $userId,
-                        'date'         => $ymd,
-                        'kind'         => LeaveKind::Paid->value,
-                        'reason'       => $reason,
+                    'current_state' => 'pending',
+                    'metadata' => [
+                        'batch_id' => $batchId,
+                        'leave_id' => $leave->id,
+                        'user_id' => $userId,
+                        'date' => $ymd,
+                        'kind' => LeaveKind::Paid->value,
+                        'reason' => $reason,
                         'special_type' => null,
+                        'district_id' => $user?->district_id,
+                        'department_id' => $user?->department_id,
                     ],
                 ]);
 
@@ -133,16 +140,16 @@ class LeaveApplicationService
         ?array $attachmentMeta,
         string $batchId
     ): array {
-        $result    = ['created' => 0, 'skipped' => 0, 'skips' => [], 'requests' => []];
-        $user      = User::find($userId);
-        $code      = $user?->employee_code ?? '';
+        $result = ['created' => 0, 'skipped' => 0, 'skips' => [], 'requests' => []];
+        $user = User::find($userId);
+        $code = $user?->employee_code ?? '';
         $userLabel = $user ? ($code ? "{$user->name} [{$code}]" : $user->name) : "user#{$userId}";
 
         DB::transaction(function () use ($userId, $user, $dates, $reason, $requestedByUserId, $specialType, $attachmentMeta, $batchId, $userLabel, &$result) {
             $start = $dates->min();
-            $end   = $dates->max();
+            $end = $dates->max();
 
-            if (!$start || !$end) {
+            if (! $start || ! $end) {
                 return;
             }
 
@@ -152,29 +159,30 @@ class LeaveApplicationService
                 ->whereIn('status', [LeaveStatus::Pending->value, LeaveStatus::Approved->value])
                 ->where(function ($q) use ($start, $end) {
                     $q->whereBetween('start_date', [$start, $end])
-                      ->orWhereBetween('end_date', [$start, $end])
-                      ->orWhere(function ($q2) use ($start, $end) {
-                          $q2->where('start_date', '<=', $start)->where('end_date', '>=', $end);
-                      });
+                        ->orWhereBetween('end_date', [$start, $end])
+                        ->orWhere(function ($q2) use ($start, $end) {
+                            $q2->where('start_date', '<=', $start)->where('end_date', '>=', $end);
+                        });
                 })
                 ->exists();
 
             if ($already) {
                 $result['skipped'] = 1;
                 $result['skips']["{$start}〜{$end}"] = '既に申請/承認済みです';
+
                 return;
             }
 
             $leave = Leave::create([
-                'user_id'       => $userId,
-                'start_date'    => $start,
-                'end_date'      => $end,
-                'kind'          => LeaveKind::Special->value,
-                'excused'       => LeaveExcused::Excused->value,
-                'reason'        => $reason,
-                'status'        => LeaveStatus::Pending->value,
-                'special_type'  => $specialType ?: null,
-                'district_id'   => $user?->district_id,
+                'user_id' => $userId,
+                'start_date' => $start,
+                'end_date' => $end,
+                'kind' => LeaveKind::Special->value,
+                'excused' => LeaveExcused::Excused->value,
+                'reason' => $reason,
+                'status' => LeaveStatus::Pending->value,
+                'special_type' => $specialType ?: null,
+                'district_id' => $user?->district_id,
                 'department_id' => $user?->department_id,
             ]);
 
@@ -184,22 +192,24 @@ class LeaveApplicationService
 
             $periodStr = "{$start}〜{$end}";
             $ar = $leave->approvalRequest()->create([
-                'title'           => "**Special Leave** {$userLabel} ({$periodStr})",
+                'title' => "**Special Leave** {$userLabel} ({$periodStr})",
                 'requested_by_id' => $requestedByUserId,
-                'current_state'   => 'pending',
-                'metadata'        => [
-                    'batch_id'     => $batchId,
-                    'leave_id'     => $leave->id,
-                    'user_id'      => $userId,
-                    'date_from'    => $start,
-                    'date_to'      => $end,
-                    'kind'         => LeaveKind::Special->value,
-                    'reason'       => $reason,
+                'current_state' => 'pending',
+                'metadata' => [
+                    'batch_id' => $batchId,
+                    'leave_id' => $leave->id,
+                    'user_id' => $userId,
+                    'date_from' => $start,
+                    'date_to' => $end,
+                    'kind' => LeaveKind::Special->value,
+                    'reason' => $reason,
                     'special_type' => $specialType ?: null,
+                    'district_id' => $user?->district_id,
+                    'department_id' => $user?->department_id,
                 ],
             ]);
 
-            $result['created']    = 1;
+            $result['created'] = 1;
             $result['requests'][] = $ar;
         });
 

--- a/app/Services/Notifications/ScopedNotificationService.php
+++ b/app/Services/Notifications/ScopedNotificationService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services\Notifications;
+
+use App\Models\ApprovalRequest;
+use App\Models\User;
+use App\Services\CurrentScopeService;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Collection;
+
+class ScopedNotificationService
+{
+    public function __construct(private CurrentScopeService $scopeService) {}
+
+    public function visibleNotifications(User $user, int $limit = 100): Collection
+    {
+        return $user->notifications()
+            ->latest()
+            ->get()
+            ->filter(fn (DatabaseNotification $notification) => $this->isVisible($user, $notification))
+            ->take($limit)
+            ->values();
+    }
+
+    public function unreadCount(User $user): int
+    {
+        if (! $user->hasRole(['admin', 'super_admin'])) {
+            return 0;
+        }
+
+        return $user->unreadNotifications()
+            ->get()
+            ->filter(fn (DatabaseNotification $notification) => $this->isVisible($user, $notification))
+            ->count();
+    }
+
+    public function markVisibleUnreadAsRead(User $user): void
+    {
+        $user->unreadNotifications()
+            ->get()
+            ->filter(fn (DatabaseNotification $notification) => $this->isVisible($user, $notification))
+            ->each->markAsRead();
+    }
+
+    public function isVisible(User $user, DatabaseNotification $notification): bool
+    {
+        if ($notification->notifiable_type !== User::class || (int) $notification->notifiable_id !== $user->id) {
+            return false;
+        }
+
+        $approvalRequest = $this->approvalRequestFor($notification);
+        if (! $approvalRequest) {
+            return true;
+        }
+
+        if (! $user->hasRole(['admin', 'super_admin'])) {
+            return true;
+        }
+
+        return $this->matchesCurrentScope($approvalRequest);
+    }
+
+    public function matchesCurrentScope(ApprovalRequest $approvalRequest): bool
+    {
+        $districtId = $approvalRequest->approvalDistrictId();
+        $departmentId = $approvalRequest->approvalDepartmentId();
+
+        return $districtId !== null
+            && $departmentId !== null
+            && $districtId === $this->scopeService->currentDistrictId()
+            && $departmentId === $this->scopeService->currentDepartmentId();
+    }
+
+    private function approvalRequestFor(DatabaseNotification $notification): ?ApprovalRequest
+    {
+        $approvalRequestId = $notification->data['approval_request_id'] ?? null;
+
+        return $approvalRequestId ? ApprovalRequest::find($approvalRequestId) : null;
+    }
+}

--- a/app/Services/RoleChange/RoleChangeApplicationService.php
+++ b/app/Services/RoleChange/RoleChangeApplicationService.php
@@ -8,74 +8,75 @@ use App\Models\RoleChange;
 use App\Models\User;
 use App\Notifications\ApprovalRequestedNotification;
 use Illuminate\Support\Facades\DB;
-use Spatie\Permission\Models\Role;
 
 class RoleChangeApplicationService
 {
     public function apply(
-        User   $targetUser,
-        User   $requester,
+        User $targetUser,
+        User $requester,
         string $role,
         string $reason,
-        int    $districtId,
-        int    $departmentId,
-        array  $scopes = []
+        int $districtId,
+        int $departmentId,
+        array $scopes = []
     ): void {
         DB::transaction(function () use ($targetUser, $requester, $role, $reason, $districtId, $departmentId, $scopes) {
             $rc = RoleChange::create([
-                'user_id'         => $targetUser->id,
-                'requested_role'  => $role,
-                'reason'          => $reason,
+                'user_id' => $targetUser->id,
+                'requested_role' => $role,
+                'reason' => $reason,
                 'requested_by_id' => $requester->id,
-                'status'          => 'pending',
-                'district_id'     => $districtId,
-                'department_id'   => $departmentId,
-                'scopes'          => $scopes,
+                'status' => 'pending',
+                'district_id' => $districtId,
+                'department_id' => $departmentId,
+                'scopes' => $scopes,
             ]);
 
             $currentRole = $targetUser->getRoleNames()->first() ?? 'none';
-            $title = 'Role / district / department change: ' . $currentRole . ' -> ' . $role;
+            $title = 'Role / district / department change: '.$currentRole.' -> '.$role;
 
             $targetUser->load(['district', 'department', 'managementScopes.district', 'managementScopes.department']);
 
-            $requestedDistrict   = District::find($districtId);
+            $requestedDistrict = District::find($districtId);
             $requestedDepartment = Department::find($departmentId);
 
             $resolvedScopes = collect($scopes)->map(function ($s) {
                 return [
-                    'district_id'   => $s['district_id'],
+                    'district_id' => $s['district_id'],
                     'department_id' => $s['department_id'],
-                    'district'      => District::find($s['district_id'])?->name,
-                    'department'    => Department::find($s['department_id'])?->name,
+                    'district' => District::find($s['district_id'])?->name,
+                    'department' => Department::find($s['department_id'])?->name,
                 ];
             })->toArray();
 
-            $rc->approvalRequest()->create([
-                'title'           => $title,
+            $approvalRequest = $rc->approvalRequest()->create([
+                'title' => $title,
                 'requested_by_id' => $requester->id,
-                'current_state'   => 'pending',
-                'metadata'        => [
-                    'target_user_id'       => $targetUser->id,
-                    'target_user_name'     => $targetUser->name,
-                    'requested_role'       => $role,
-                    'reason'               => $reason,
-                    'flow'                 => ['type' => 'any_of_role', 'role' => 'super_admin', 'min_approvals' => 1],
-                    'current_role'         => $targetUser->getRoleNames()->first(),
-                    'current_district'     => $targetUser->district?->name,
-                    'current_department'   => $targetUser->department?->name,
-                    'current_scopes'       => $targetUser->managementScopes->map(fn($s) => [
-                        'district'   => $s->district?->name,
+                'current_state' => 'pending',
+                'metadata' => [
+                    'target_user_id' => $targetUser->id,
+                    'target_user_name' => $targetUser->name,
+                    'requested_role' => $role,
+                    'reason' => $reason,
+                    'flow' => ['type' => 'any_of_role', 'role' => 'super_admin', 'min_approvals' => 1],
+                    'current_role' => $targetUser->getRoleNames()->first(),
+                    'current_district' => $targetUser->district?->name,
+                    'current_department' => $targetUser->department?->name,
+                    'current_scopes' => $targetUser->managementScopes->map(fn ($s) => [
+                        'district' => $s->district?->name,
                         'department' => $s->department?->name,
                     ])->toArray(),
-                    'requested_district'   => $requestedDistrict?->name,
+                    'requested_district' => $requestedDistrict?->name,
                     'requested_department' => $requestedDepartment?->name,
-                    'requested_scopes'     => $resolvedScopes,
+                    'requested_district_id' => $districtId,
+                    'requested_department_id' => $departmentId,
+                    'requested_scopes' => $resolvedScopes,
                 ],
             ]);
 
-            $approvers = Role::findByName('super_admin')->users()->get();
+            $approvers = User::approvalRecipientsForScope($districtId, $departmentId)->get();
             foreach ($approvers as $approver) {
-                $approver->notify(new ApprovalRequestedNotification($rc->approvalRequest));
+                $approver->notify(new ApprovalRequestedNotification($approvalRequest));
             }
         });
     }

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h2 class="mb-0">通知</h2>
-        @if(auth()->user()->unreadNotifications()->count() > 0)
+        @if(($unreadNotificationsCount ?? 0) > 0)
         <form method="POST" action="{{ route('notifications.readAll') }}">
             @csrf
             <button class="btn btn-sm btn-outline-primary">すべて既読にする</button>

--- a/tests/Feature/ApprovalControllerTest.php
+++ b/tests/Feature/ApprovalControllerTest.php
@@ -8,13 +8,80 @@ use App\Models\District;
 use App\Models\Event;
 use App\Models\Leave;
 use App\Models\User;
+use App\Models\UserManagementScope;
+use App\Notifications\ApprovalRequestedNotification;
+use App\Services\LeaveApply\LeaveApplicationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
+/**
+ * ApprovalController / NotificationController の承認通知スコープ制御テスト
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * カバーするシナリオ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * [承認詳細: Generated Shift を伴う Leave 承認]
+ *   1. super_admin は現在スコープ内の Leave 承認詳細で Generated Shift Confirmation を確認できる
+ *   2. Generated Shift がある Leave を却下する場合、shift の扱いを選ばないと却下できない
+ *
+ * [通知送信先: 管理範囲ベース]
+ *   3. Leave 申請時の承認通知は、申請者の district/department を管理範囲に持つ super_admin だけに送信される
+ *
+ * [承認操作: 現在選択中スコープベース]
+ *   4. super_admin が複数の管理範囲を持っていても、現在選択中でない district/department の承認詳細は開けない
+ *
+ * [通知一覧・既読操作: 現在選択中スコープベース]
+ *   5. 通知レコード自体を持っていても、現在選択中スコープ外の承認通知は一覧に表示しない
+ *   6. 「すべて既読」は現在選択中スコープで表示される通知だけを既読化する
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * テストのセットアップ方針
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - RefreshDatabase でテストごとに DB をリセット
+ * - TestCase::setUp() で RoleSeeder が実行済み（admin/super_admin/general ロール作成）
+ * - Leave / ApprovalRequest は district_id / department_id を持つ approvable からスコープを解決する
+ * - super_admin の担当範囲は UserManagementScope で表現する
+ * - CurrentScopeService は session('selected_scope_id') で現在スコープを解決するため、
+ *   現在スコープを検証する HTTP リクエストでは withSession(['selected_scope_id' => $scope->id]) を付与する
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 重要な仕様メモ
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * - 通知送信時は「担当できるスコープ」に送る。
+ *   ただし通知一覧・未読件数・一括既読・承認操作は「現在選択中スコープ」に限定する。
+ *
+ * - AuthorizationException は app/Exceptions/Handler.php で welcome へリダイレクトされる。
+ *   そのため HTTP レスポンスは 403 ではなく 302 になる。
+ *   Policy の判定そのものは $user->can(...) で false を確認する。
+ *
+ * - Notification::fake() を使うテストは送信対象の確認に集中する。
+ *   通知一覧・一括既読のテストは database notifications を直接作成し、既に通知を持っているが
+ *   現在スコープ外なら表示・既読対象にならないことを確認する。
+ */
 class ApprovalControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    // =========================================================================
+    // ヘルパー
+    // =========================================================================
+
+    /**
+     * Generated Shift を伴う pending Leave と ApprovalRequest を生成する。
+     *
+     * Leave と Event は同じ district/department に置き、
+     * ApprovalController::show() が GeneratedShiftDecisionService 経由で
+     * shift 確認 UI を表示できる状態を作る。
+     *
+     * @return array{0: ApprovalRequest, 1: Leave, 2: Event}
+     */
     private function makeLeaveApprovalWithGeneratedShift(): array
     {
         $district = District::factory()->create();
@@ -65,10 +132,97 @@ class ApprovalControllerTest extends TestCase
         return [$approval, $leave, $event];
     }
 
+    /**
+     * 指定ユーザーに ApprovalRequest と同じ district/department の管理範囲を付与する。
+     *
+     * super_admin が承認詳細を開くには、ロールだけでなく現在スコープも一致している必要がある。
+     * このヘルパーは既存テストの正常系で Policy 条件を満たすために使う。
+     */
+    private function giveApprovalScope(User $user, ApprovalRequest $approval): void
+    {
+        UserManagementScope::factory()->create([
+            'user_id' => $user->id,
+            'district_id' => $approval->approvalDistrictId(),
+            'department_id' => $approval->approvalDepartmentId(),
+        ]);
+    }
+
+    /**
+     * 任意の district/department に属する Leave ApprovalRequest を作る。
+     *
+     * 現在スコープの切り替えテストで、関東案件・関西案件のように
+     * 明示的に所属スコープが異なる承認案件を用意するために使う。
+     */
+    private function makeLeaveApprovalForScope(District $district, Department $department, string $title): ApprovalRequest
+    {
+        $requester = User::factory()->general()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $leave = Leave::factory()->create([
+            'user_id' => $requester->id,
+            'status' => 'pending',
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        return ApprovalRequest::create([
+            'approvable_type' => Leave::class,
+            'approvable_id' => $leave->id,
+            'title' => $title,
+            'requested_by_id' => $requester->id,
+            'current_state' => 'pending',
+            'metadata' => [
+                'kind' => 'paid',
+                'target_user_id' => $requester->id,
+            ],
+        ]);
+    }
+
+    /**
+     * database channel の通知レコードを直接作成する。
+     *
+     * Notification::fake() では notifications テーブルに保存されないため、
+     * 通知一覧・一括既読のテストでは実際の DatabaseNotification を作る。
+     * data.approval_request_id は ScopedNotificationService が承認案件スコープを解決するために必要。
+     */
+    private function createDatabaseNotification(User $user, ApprovalRequest $approval): DatabaseNotification
+    {
+        $id = (string) Str::uuid();
+
+        DB::table('notifications')->insert([
+            'id' => $id,
+            'type' => ApprovalRequestedNotification::class,
+            'notifiable_type' => User::class,
+            'notifiable_id' => $user->id,
+            'data' => json_encode([
+                'title' => $approval->title,
+                'approval_request_id' => $approval->id,
+                'url' => route('approvals.show', $approval),
+            ]),
+            'read_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return DatabaseNotification::findOrFail($id);
+    }
+
+    // =========================================================================
+    // 1〜2. 承認詳細: Generated Shift を伴う Leave 承認
+    // =========================================================================
+
+    /**
+     * シナリオ 1:
+     * super_admin は現在スコープ内の Leave 承認詳細を表示でき、
+     * Generated Shift Confirmation と対象 shift 情報を確認できる。
+     */
     public function test_super_admin_can_confirm_generated_shifts_before_denying_leave_request(): void
     {
         $superAdmin = User::factory()->superAdmin()->create();
         [$approval] = $this->makeLeaveApprovalWithGeneratedShift();
+        $this->giveApprovalScope($superAdmin, $approval);
 
         $this->actingAs($superAdmin)
             ->get(route('approvals.show', $approval))
@@ -81,10 +235,20 @@ class ApprovalControllerTest extends TestCase
             ->assertSee('ALP L1');
     }
 
+    /**
+     * シナリオ 2:
+     * Generated Shift がある Leave を却下する場合、
+     * generated_shift_action を選ばないリクエストは業務ルールで止められる。
+     *
+     * 期待結果:
+     * - toast_errors がセッションに入る
+     * - ApprovalRequest / Leave / Event は pending のまま残る
+     */
     public function test_super_admin_must_confirm_generated_shift_action_before_denying_leave_request(): void
     {
         $superAdmin = User::factory()->superAdmin()->create();
         [$approval, $leave, $event] = $this->makeLeaveApprovalWithGeneratedShift();
+        $this->giveApprovalScope($superAdmin, $approval);
 
         $this->actingAs($superAdmin)
             ->post(route('approvals.deny', $approval), [
@@ -105,5 +269,192 @@ class ApprovalControllerTest extends TestCase
             'id' => $event->id,
             'source_leave_id' => $leave->id,
         ]);
+    }
+
+    // =========================================================================
+    // 3. 通知送信先: 管理範囲ベース
+    // =========================================================================
+
+    /**
+     * シナリオ 3:
+     * Leave 申請時の通知送信先は、申請者の district/department と一致する
+     * UserManagementScope を持つ super_admin のみに限定する。
+     *
+     * ここでは Notification::fake() で database/mail 送信を止め、
+     * matchingApprover にだけ ApprovalRequestedNotification が送られることを確認する。
+     */
+    public function test_leave_approval_notification_is_sent_only_to_matching_scope_super_admins(): void
+    {
+        Notification::fake();
+
+        $district = District::factory()->create();
+        $department = Department::factory()->create();
+        $otherDistrict = District::factory()->create();
+
+        $requester = User::factory()->general()->create([
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $matchingApprover = User::factory()->superAdmin()->create();
+        UserManagementScope::factory()->create([
+            'user_id' => $matchingApprover->id,
+            'district_id' => $district->id,
+            'department_id' => $department->id,
+        ]);
+
+        $otherApprover = User::factory()->superAdmin()->create();
+        UserManagementScope::factory()->create([
+            'user_id' => $otherApprover->id,
+            'district_id' => $otherDistrict->id,
+            'department_id' => $department->id,
+        ]);
+
+        app(LeaveApplicationService::class)->apply(
+            $requester->id,
+            ['2026-06-13'],
+            'test',
+            $requester->id
+        );
+
+        Notification::assertSentTo($matchingApprover, ApprovalRequestedNotification::class);
+        Notification::assertNotSentTo($otherApprover, ApprovalRequestedNotification::class);
+    }
+
+    // =========================================================================
+    // 4. 承認操作: 現在選択中スコープベース
+    // =========================================================================
+
+    /**
+     * シナリオ 4:
+     * super_admin が関東・関西の両方を担当できても、現在選択中スコープが関西なら
+     * 関東の承認詳細は開けない。
+     *
+     * 期待結果:
+     * - selected_scope_id = 関東: 承認詳細を表示できる
+     * - selected_scope_id = 関西: Policy は false
+     * - HTTP では Handler の仕様により 403 ではなく welcome へリダイレクト
+     */
+    public function test_super_admin_can_act_only_on_currently_selected_scope(): void
+    {
+        $department = Department::factory()->create();
+        $kanto = District::factory()->create();
+        $kansai = District::factory()->create();
+
+        $superAdmin = User::factory()->superAdmin()->create();
+        $kantoScope = UserManagementScope::factory()->create([
+            'user_id' => $superAdmin->id,
+            'district_id' => $kanto->id,
+            'department_id' => $department->id,
+        ]);
+        $kansaiScope = UserManagementScope::factory()->create([
+            'user_id' => $superAdmin->id,
+            'district_id' => $kansai->id,
+            'department_id' => $department->id,
+        ]);
+
+        $kantoApproval = $this->makeLeaveApprovalForScope($kanto, $department, 'Kanto Request');
+
+        $this->withSession(['selected_scope_id' => $kantoScope->id])
+            ->actingAs($superAdmin)
+            ->get(route('approvals.show', $kantoApproval))
+            ->assertOk();
+
+        session(['selected_scope_id' => $kansaiScope->id]);
+        $this->assertFalse($superAdmin->can('view', $kantoApproval));
+
+        $this->withSession(['selected_scope_id' => $kansaiScope->id])
+            ->actingAs($superAdmin)
+            ->get(route('approvals.show', $kantoApproval))
+            ->assertRedirect(route('welcome'))
+            ->assertSessionHas('status', '403 This action is unauthorized.');
+    }
+
+    // =========================================================================
+    // 5〜6. 通知一覧・既読操作: 現在選択中スコープベース
+    // =========================================================================
+
+    /**
+     * シナリオ 5:
+     * super_admin が関東・関西両方の通知レコードを持っていても、
+     * 通知一覧には現在選択中スコープの承認通知だけを表示する。
+     *
+     * このテストでは selected_scope_id = 関東にして、
+     * Kanto Request は表示され、Kansai Request は表示されないことを確認する。
+     */
+    public function test_notifications_index_shows_only_currently_selected_scope_approval_requests(): void
+    {
+        $department = Department::factory()->create();
+        $kanto = District::factory()->create();
+        $kansai = District::factory()->create();
+
+        $superAdmin = User::factory()->superAdmin()->create();
+        $kantoScope = UserManagementScope::factory()->create([
+            'user_id' => $superAdmin->id,
+            'district_id' => $kanto->id,
+            'department_id' => $department->id,
+        ]);
+        UserManagementScope::factory()->create([
+            'user_id' => $superAdmin->id,
+            'district_id' => $kansai->id,
+            'department_id' => $department->id,
+        ]);
+
+        $kantoApproval = $this->makeLeaveApprovalForScope($kanto, $department, 'Kanto Request');
+        $kansaiApproval = $this->makeLeaveApprovalForScope($kansai, $department, 'Kansai Request');
+        $this->createDatabaseNotification($superAdmin, $kantoApproval);
+        $this->createDatabaseNotification($superAdmin, $kansaiApproval);
+
+        $this->withSession(['selected_scope_id' => $kantoScope->id])
+            ->actingAs($superAdmin)
+            ->get(route('notifications.index'))
+            ->assertOk()
+            ->assertSee('Kanto Request')
+            ->assertDontSee('Kansai Request');
+    }
+
+    /**
+     * シナリオ 6:
+     * 「すべて既読」はログインユーザーの全通知ではなく、
+     * 現在選択中スコープで表示対象になる未読通知だけを既読化する。
+     *
+     * 期待結果:
+     * - 関東スコープ選択中: 関東通知は read_at が入る
+     * - 関西通知は同じユーザー宛でも read_at は null のまま
+     */
+    public function test_read_all_marks_only_currently_selected_scope_notifications_as_read(): void
+    {
+        $department = Department::factory()->create();
+        $kanto = District::factory()->create();
+        $kansai = District::factory()->create();
+
+        $superAdmin = User::factory()->superAdmin()->create();
+        $kantoScope = UserManagementScope::factory()->create([
+            'user_id' => $superAdmin->id,
+            'district_id' => $kanto->id,
+            'department_id' => $department->id,
+        ]);
+        UserManagementScope::factory()->create([
+            'user_id' => $superAdmin->id,
+            'district_id' => $kansai->id,
+            'department_id' => $department->id,
+        ]);
+
+        $kantoNotification = $this->createDatabaseNotification(
+            $superAdmin,
+            $this->makeLeaveApprovalForScope($kanto, $department, 'Kanto Request')
+        );
+        $kansaiNotification = $this->createDatabaseNotification(
+            $superAdmin,
+            $this->makeLeaveApprovalForScope($kansai, $department, 'Kansai Request')
+        );
+
+        $this->withSession(['selected_scope_id' => $kantoScope->id])
+            ->actingAs($superAdmin)
+            ->post(route('notifications.readAll'))
+            ->assertRedirect();
+
+        $this->assertNotNull($kantoNotification->fresh()->read_at);
+        $this->assertNull($kansaiNotification->fresh()->read_at);
     }
 }


### PR DESCRIPTION
## 実装技術概要

### 目的

`super_admin` が複数の地区・部署スコープを持っている場合でも、承認通知・承認操作・既読処理を「現在選択中のスコープ」に限定するように変更しました。

これにより、例えば関東スコープで作業中に関西の承認案件が通知一覧や未読件数に混ざることを防ぎます。

## 主な変更点

### 新規追加

#### `app/Services/Notifications/ScopedNotificationService.php`

通知の表示可否・未読件数・一括既読対象・承認案件スコープ判定を集約する Service を追加しました。

必要性:

- `NotificationController`
- `AppServiceProvider`
- `AuthServiceProvider`
- `ApprovalRequestPolicy`

で同じ「現在スコープに一致する通知か」を判定する必要があるため、Controller や Policy にロジックを散らさないためです。

主な責務:

- 現在スコープで表示可能な通知だけを返す
- 現在スコープ内の未読通知数を返す
- 現在スコープ内の通知だけを一括既読にする
- `ApprovalRequest` の district / department が現在スコープと一致するか判定する

## 変更ファイル

### `app/Http/Controllers/NotificationController.php`

通知一覧と一括既読処理で `ScopedNotificationService` を使用するように変更しました。

必要性:

- 以前はログインユーザー宛の通知をすべて表示していた
- 今回は「ユーザー宛」かつ「現在選択中スコープに一致する承認通知」のみ表示する必要がある
- 「すべて既読」も全通知ではなく、現在スコープに表示される通知だけを対象にする必要がある

### `app/Policies/ApprovalRequestPolicy.php`

承認詳細の閲覧・承認/却下操作を、現在選択中スコープに一致する場合だけ許可するように変更しました。

必要性:

- 通知一覧で隠しても、URL直アクセスで別スコープの承認詳細を開けると不整合になる
- 認可ロジックは docs 方針通り Policy に置く必要がある

### `app/Providers/AuthServiceProvider.php`

`view-notification` Gate で `ScopedNotificationService` を使うように変更しました。

必要性:

- 通知詳細遷移や既読化操作でも現在スコープ外の通知を操作できないようにするため
- 通知一覧だけでなく、通知単体操作も同じ判定に揃えるため

### `app/Providers/AppServiceProvider.php`

ヘッダーの未読通知数を `ScopedNotificationService::unreadCount()` に変更しました。

必要性:

- ヘッダーのバッジに別スコープの未読通知数が混ざると、現在の作業スコープと表示が一致しないため

### `resources/views/notifications/index.blade.php`

「すべて既読にする」ボタンの表示条件を、スコープ済み未読件数に変更しました。

必要性:

- 現在スコープに未読通知がない場合は、別スコープに未読があってもボタンを出さないため

### `app/Models/ApprovalRequest.php`

承認案件の district / department を解決するメソッドを追加しました。

必要性:

- Leave や RoleChange など、承認対象モデルごとに district / department の持ち方が異なる
- 通知・Policy・送信先判定で同じ方法で承認案件スコープを解決するため

### `app/Models/User.php`

承認通知の送信対象を district / department の管理範囲で絞る scope を追加しました。

必要性:

- 通知送信時点では、対象案件を担当できる `super_admin` のみに通知する必要があるため
- `UserManagementScope` を使った送信先絞り込みを再利用可能にするため

### `app/Services/LeaveApply/LeaveApplicationService.php`

Leave 申請時の承認通知送信先を、対象ユーザーの district / department に一致する `super_admin` のみに変更しました。

必要性:

- 以前は全 `super_admin` に通知していた
- 地区部署に関係ない承認通知を送らないため

### `app/Services/RoleChange/RoleChangeApplicationService.php`

RoleChange 申請時の承認通知送信先を、申請された district / department に一致する `super_admin` のみに変更しました。

必要性:

- RoleChange も全 `super_admin` へ送っていたため
- 申請対象の地区部署を担当する承認者だけに通知するため

### `app/Services/CurrentScopeService.php`

現在スコープのキャッシュ条件に user / selected_scope_id を含めました。

必要性:

- テストや同一プロセス内で `selected_scope_id` が切り替わった場合に、古いスコープが残るのを防ぐため
- singleton として登録されている Service でも、ユーザーやセッション変更に追従できるようにするため

### `tests/Feature/ApprovalControllerTest.php`

現在スコープ制御のテストを追加・補強しました。

追加したシナリオ:

- 通知送信先は管理範囲一致の `super_admin` のみ
- 現在選択中スコープ外の承認詳細は開けない
- 通知一覧は現在スコープの承認通知のみ表示
- 「すべて既読」は現在スコープの通知だけ既読化
- テストファイル冒頭に、既存テストと同じ形式でシナリオ・セットアップ方針・重要仕様メモを追加

## 確認済みテスト

```bash
docker exec -w /var/www/html/Jin_10 jin_app php artisan test tests/Feature/ApprovalControllerTest.php tests/Feature/CurrentScopeServiceTest.php tests/Feature/RoleChangeTest.php
```

結果:

```text
26 passed, 82 assertions
```

個別確認:

```bash
docker exec -w /var/www/html/Jin_10 jin_app php artisan test tests/Feature/ApprovalControllerTest.php
```

結果:

```text
6 passed, 25 assertions
```
