### PR TITLE
fix: カレンダー月選択フォームが無視される問題を修正

### DIFF
--- a/public/js/forecast.js
+++ b/public/js/forecast.js
@@ -3,7 +3,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const savedView = ['dayGridMonth', 'listWeek'].includes(storedView)
         ? storedView
         : 'dayGridMonth';
-    const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;
+    const urlMonth = new URLSearchParams(location.search).get('month');
+    const savedDate = urlMonth ? window.initialDate : (localStorage.getItem('forecastCalendarDate') || window.initialDate);
     const calendarEl = document.getElementById('calendar');
     // ▼▼ Total Subs 明細モーダル ▼▼
     function openSubModal(ev) {

--- a/public/js/fullcalendar.js
+++ b/public/js/fullcalendar.js
@@ -3,7 +3,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const savedView = ['dayGridMonth', 'listWeek'].includes(storedView)
         ? storedView
         : 'dayGridMonth';
-    const savedDate = localStorage.getItem('userCalendarDate') || window.initialDate;
+    const urlMonth = new URLSearchParams(location.search).get('month');
+    const savedDate = urlMonth ? window.initialDate : (localStorage.getItem('userCalendarDate') || window.initialDate);
 
     // ▼▼ これによりLessonの終了時間を計算 ▼▼
     // HH:MM 形式の文字列に分数を加算して HH:MM 形式で返す

--- a/public/js/leave.js
+++ b/public/js/leave.js
@@ -3,7 +3,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const savedView = ['dayGridMonth', 'listMonth'].includes(storedView)
         ? storedView
         : 'dayGridMonth';
-    const savedDate = localStorage.getItem('leaveCalendarDate') || window.initialDate;
+    const urlMonth = new URLSearchParams(location.search).get('month');
+    const savedDate = urlMonth ? window.initialDate : (localStorage.getItem('leaveCalendarDate') || window.initialDate);
     const calendarEl = document.getElementById('calendar');
     console.log('[] loaded - leave.js:3');
 


### PR DESCRIPTION
## 概要



カレンダー画面（Forecast / FullCalendar / Leave）で、月選択フォームから `?month=YYYY-MM` 付きで遷移しても、選択した月が反映されない不具合を修正。



## 原因



各カレンダー初期化処理で、表示日付の決定時に `localStorage` に保存された前回表示日付を常に優先していたため、URLの `month` パラメータに基づいてサーバー側から渡される `window.initialDate` が上書きされていた。



```js

// 修正前

const savedDate = localStorage.getItem('forecastCalendarDate') || window.initialDate;

```



その結果、ユーザーが月選択フォームで別の月を選択してページ遷移しても、ブラウザに古い表示月が保存されている場合、フォームの選択月が無視されていた。



## 修正内容



URLに `month` パラメータが存在する場合は、フォーム選択を優先して `window.initialDate` を使用するよう修正。



`month` パラメータが存在しない場合のみ、従来通り `localStorage` の保存値にフォールバックする。



```js

// 修正後

const urlMonth = new URLSearchParams(location.search).get('month');

const savedDate = urlMonth

    ? window.initialDate

    : (localStorage.getItem('forecastCalendarDate') || window.initialDate);

```



## 修正ファイル



| ファイル                        | localStorageキー         | 用途            |

| `public/js/forecast.js`     | `forecastCalendarDate` | Forecastカレンダー |

| `public/js/fullcalendar.js` | `userCalendarDate`     | メインのシフトカレンダー  |

| `public/js/leave.js`        | `leaveCalendarDate`    | 休暇カレンダー       |



3ファイルとも同一ロジックのため、同じ方針で横展開して修正。