### PR TITLE
fix/feat: absenceReportAllのCSSスコープ修正とデザイン刷新

### DIFF
--- a/resources/views/calendar/absenceReport.blade.php
+++ b/resources/views/calendar/absenceReport.blade.php
@@ -2,217 +2,244 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="d-flex justify-content-between align-items-center mb-3">
-  <div>
-    <h2 class="mb-0">Absence Report</h2>
-    <div class="text-muted small mt-1">
-      User: <span class="fw-semibold">{{ $user->name ?? trim(($user->family_name ?? '').' '.($user->first_name ?? '')) }}</span>
-    </div>
-  </div>
-  @role('admin|super_admin')
-  <span class="badge text-bg-primary">Admin View</span>
-  @else
-  <span class="badge text-bg-secondary">My Absences</span>
-  @endrole
-</div>
+<div class="ar-page">
 
-<div class="card">
-  <div class="card-body p-1">
+  {{-- Header --}}
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h2 class="mb-0 fw-semibold">Absence Report</h2>
+      <div class="text-muted small mt-1">
+        User: <span class="fw-semibold">{{ $user->name ?? trim(($user->family_name ?? '').' '.($user->first_name ?? '')) }}</span>
+      </div>
+    </div>
+    @role('admin|super_admin')
+    <span class="ar-badge ar-badge--admin">Admin View</span>
+    @else
+    <span class="ar-badge ar-badge--self">My Absences</span>
+    @endrole
+  </div>
+
+  {{-- 列ヘッダー（デスクトップのみ） --}}
+  <div class="ar-header d-none d-lg-flex">
+    <div class="ar-col ar-col--date">Date</div>
+    <div class="ar-col ar-col--kind">Kind</div>
+    <div class="ar-col ar-col--status">Status</div>
+    <div class="ar-col ar-col--reason">Reason</div>
+    <div class="ar-col ar-col--handle">Handle Type</div>
+    <div class="ar-col ar-col--attachment">Attachment</div>
+    <div class="ar-col ar-col--action"></div>
+  </div>
+
+  {{-- List --}}
+  <div class="ar-list">
 
     @forelse($rows as $row)
     @php($leave = $row['leave'])
-    <div class="leave-row border rounded-2 p-1 mb-2 {{ $row['needsReport'] ? 'bg-required' : '' }}">
-      <div class="row g-1 align-items-end">
 
-        {{-- Date --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-1 mb-1">
-          <label class="form-label small text-muted mb-1">Date</label>
-          <div class="fw-semibold">{{ $row['dateMain'] }}</div>
-          @if($row['dateSub'])
-          <div class="small text-muted">〜 {{ $row['dateSub'] }}</div>
-          @endif
-        </div>
+    <div class="ar-card {{ $row['needsReport'] ? 'ar-card--required' : '' }}">
 
-        {{-- Kind --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-2">
-          <label class="form-label small text-muted mb-1">Kind</label>
-          <div>
-            <span class="badge rounded-pill
-            @switch($row['kindLabel'])
-              @case('Unpaid Leave') text-bg-primary text-white @break
-              @case('ALP')          text-bg-info    text-white @break
-              @default              text-bg-info    text-white
-            @endswitch
-          ">{{ $row['kindLabel'] }}</span>
-          </div>
-        </div>
-
-        {{-- Reason --}}
-        <div class="col-12 col-sm-12 col-md-6 col-lg-2">
-          <label class="form-label small text-muted mb-1">Reason</label>
-          @if($row['needsReport'])
-          <textarea
-            name="reason"
-            form="{{ $row['formId'] }}"
-            class="form-control form-control-sm"
-            rows="1"
-            placeholder="Enter reason (required)"
-            required></textarea>
-          @else
-          <textarea
-            class="form-control form-control-sm bg-body-tertiary"
-            rows="1"
-            readonly>{{ $leave->reason }}</textarea>
-          @endif
-        </div>
-
-        {{-- Attachment --}}
-        <div class="col-12 col-sm-12 col-md-6 col-lg-2">
-          <label class="form-label small text-muted mb-1">Attachment</label>
-          @if($row['needsReport'])
-          <input
-            type="file"
-            name="attachment"
-            form="{{ $row['formId'] }}"
-            class="form-control form-control-sm">
-          @else
-          @if($leave->attachment)
-          <a
-            href="{{ route('absence.download', $leave) }}"
-            class="btn btn-sm btn-outline-primary w-100 px-1 py-1 text-truncate"
-            title="{{ $leave->attachment->original_name ?? 'View Attachment' }}">
-            <span class="d-block text-truncate" style="max-width: 100%;">
-              {{ $leave->attachment->original_name ?? 'View Attachment' }}
-            </span>
-          </a>
-          @else
-          <input
-            type="text"
-            class="form-control form-control-sm bg-body-tertiary"
-            value="No attachment"
-            readonly>
-          @endif
-          @endif
-        </div>
-
-        {{-- Handle Type --}}
-        <div class="col-12 col-sm-12 col-md-12 col-lg-3">
-          <label class="form-label small text-muted mb-1">Handle Type</label>
-          @if($row['needsReport'])
-          <select
-            name="handle_type"
-            form="{{ $row['formId'] }}"
-            class="form-select form-select-sm"
-            required>
-            <option value="">— Select —</option>
-            @foreach($handleTypeOptions as $val => $label)
-            <option value="{{ $val }}">{{ $label }}</option>
-            @endforeach
-          </select>
-          @else
-          <input
-            type="text"
-            class="form-control form-control-sm bg-body-tertiary"
-            value="{{ $row['handleLabel'] }}"
-            readonly>
-          @endif
-        </div>
-
-        {{-- Status --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-1">
-          <label class="form-label small text-muted mb-1">Status</label>
-          <div>
-            @if($row['statusText'] === 'Submitted')
-            <span class="badge rounded-pill text-bg-success">Submitted</span>
-            @elseif($row['statusText'] === 'Required')
-            <span class="badge rounded-pill text-bg-warning text-dark">Required</span>
-            @else
-            <span class="text-muted">—</span>
-            @endif
-          </div>
-        </div>
-
-        {{-- Action --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-1 text-end">
-          <label class="form-label small text-muted mb-1 d-none d-md-block">&nbsp;</label>
-          @if($row['needsReport'])
-          <form
-            id="{{ $row['formId'] }}"
-            method="POST"
-            action="{{ route('report.update', $leave) }}"
-            class="d-inline-block"
-            enctype="multipart/form-data">
-            @csrf @method('PUT')
-            <button type="submit" class="btn btn-sm btn-primary w-100">Submit</button>
-          </form>
-          @else
-          <button type="button" class="btn btn-sm btn-outline-secondary w-100" disabled>✔️</button>
-          @endif
-        </div>
-
+      {{-- Date --}}
+      <div class="ar-col ar-col--date">
+        <span class="ar-mobile-label">Date</span>
+        <span class="fw-semibold">{{ $row['dateMain'] }}</span>
+        @if($row['dateSub'])
+        <span class="text-muted" style="font-size:0.72rem;">〜{{ $row['dateSub'] }}</span>
+        @endif
       </div>
+
+      {{-- Kind --}}
+      <div class="ar-col ar-col--kind">
+        <span class="ar-mobile-label">Kind</span>
+        <span class="ar-kind-badge ar-kind-badge--{{ Str::slug($row['kindLabel']) }}">{{ $row['kindLabel'] }}</span>
+      </div>
+
+      {{-- Status --}}
+      <div class="ar-col ar-col--status">
+        <span class="ar-mobile-label">Status</span>
+        @if($row['statusText'] === 'Submitted')
+        <span class="ar-status ar-status--done"><i class="bi bi-check-circle-fill me-1"></i>Submitted</span>
+        @elseif($row['statusText'] === 'Required')
+        <span class="ar-status ar-status--pending"><i class="bi bi-exclamation-circle-fill me-1"></i>Required</span>
+        @else
+        <span class="text-muted">—</span>
+        @endif
+      </div>
+
+      {{-- Reason --}}
+      <div class="ar-col ar-col--reason">
+        <span class="ar-mobile-label">Reason</span>
+        @if($row['needsReport'])
+        <textarea name="reason" form="{{ $row['formId'] }}"
+          class="form-control form-control-sm" rows="1"
+          placeholder="Enter reason (required)" required></textarea>
+        @else
+        <textarea class="form-control form-control-sm" rows="1" readonly>{{ $leave->reason }}</textarea>
+        @endif
+      </div>
+
+      {{-- Handle Type --}}
+      <div class="ar-col ar-col--handle">
+        <span class="ar-mobile-label">Handle Type</span>
+        @if($row['needsReport'])
+        <select name="handle_type" form="{{ $row['formId'] }}"
+          class="form-select form-select-sm" required>
+          <option value="">— Select —</option>
+          @foreach($handleTypeOptions as $val => $label)
+          <option value="{{ $val }}">{{ $label }}</option>
+          @endforeach
+        </select>
+        @else
+        <input type="text" class="form-control form-control-sm" value="{{ $row['handleLabel'] }}" readonly>
+        @endif
+      </div>
+
+      {{-- Attachment --}}
+      <div class="ar-col ar-col--attachment">
+        <span class="ar-mobile-label">Attachment</span>
+        @if($row['needsReport'])
+        <input type="file" name="attachment" form="{{ $row['formId'] }}" class="form-control form-control-sm">
+        @elseif($leave->attachment)
+        <a href="{{ route('absence.download', $leave) }}"
+           class="ar-attachment-link"
+           title="{{ $leave->attachment->original_name ?? 'View Attachment' }}">
+          <i class="bi bi-paperclip me-1"></i>
+          <span class="text-truncate">{{ $leave->attachment->original_name ?? 'View Attachment' }}</span>
+        </a>
+        @else
+        <span class="text-muted small">—</span>
+        @endif
+      </div>
+
+      {{-- Action --}}
+      <div class="ar-col ar-col--action">
+        @if($row['needsReport'])
+        <form id="{{ $row['formId'] }}" method="POST"
+          action="{{ route('report.update', $leave) }}"
+          enctype="multipart/form-data">
+          @csrf @method('PUT')
+          <button type="submit" class="ar-submit-btn">
+            <i class="bi bi-send me-1"></i>Submit
+          </button>
+        </form>
+        @else
+        <div class="ar-done-mark"><i class="bi bi-check-lg"></i></div>
+        @endif
+      </div>
+
     </div>
     @empty
-    <div class="text-center text-muted py-4">No records.</div>
+    <div class="ar-empty">
+      <i class="bi bi-inbox fs-2 d-block mb-2"></i>No records.
+    </div>
     @endforelse
 
   </div>
+
 </div>
 @endsection
 
 @push('styles')
 <style>
-  /* 必要行のハイライト（カード版） */
-  .bg-required {
-    background: linear-gradient(90deg, rgba(252, 211, 77, .12), transparent 55%);
-    border-left: 4px solid #f59e0b !important;
+  /* ===== すべて .ar-page 以下にスコープ ===== */
+
+  .ar-page .ar-badge {
+    font-size: 0.75rem; font-weight: 500;
+    padding: 0.3rem 0.75rem; border-radius: 9999px;
+  }
+  .ar-page .ar-badge--admin { background: #dbeafe; color: #1d4ed8; }
+  .ar-page .ar-badge--self  { background: #f1f5f9; color: #475569; }
+
+  /* 列ヘッダー */
+  .ar-page .ar-header {
+    display: flex; align-items: center; gap: 0.5rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.7rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; color: #94a3b8;
   }
 
-  /* 読取専用の背景 */
-  .form-control[readonly],
-  .bg-body-tertiary {
-    background-color: var(--bs-tertiary-bg) !important;
+  /* リスト */
+  .ar-page .ar-list { display: flex; flex-direction: column; gap: 0.3rem; }
+
+  /* カード = 1行 */
+  .ar-page .ar-card {
+    display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    transition: box-shadow 0.15s;
+  }
+  .ar-page .ar-card:hover { box-shadow: 0 1px 6px rgba(0,0,0,.07); }
+  .ar-page .ar-card--required {
+    border-left: 3px solid #f59e0b;
+    background: linear-gradient(90deg, rgba(251,191,36,.06), transparent 40%);
   }
 
-  /* ボタン・バッジのトーン統一 */
-  .badge.rounded-pill {
-    font-size: 0.8rem;
-    font-weight: 400 !important;
-    padding: .48rem .65rem;
-    border-radius: 1rem !important;
-    line-height: 1.2;
+  /* 列幅定義（デスクトップ） */
+  .ar-page .ar-col { min-width: 0; }
+  .ar-page .ar-col--date       { flex: 0 0 90px; }
+  .ar-page .ar-col--kind       { flex: 0 0 100px; }
+  .ar-page .ar-col--status     { flex: 0 0 100px; }
+  .ar-page .ar-col--reason     { flex: 2 1 160px; }
+  .ar-page .ar-col--handle     { flex: 2 1 140px; }
+  .ar-page .ar-col--attachment { flex: 1 1 120px; }
+  .ar-page .ar-col--action     { flex: 0 0 80px; text-align: right; }
+
+  /* モバイル用ラベル（lg 以上では非表示） */
+  .ar-page .ar-mobile-label {
+    display: none;
+    font-size: 0.68rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; color: #94a3b8; margin-bottom: 0.15rem;
+  }
+  @media (max-width: 991.98px) {
+    .ar-page .ar-card        { flex-direction: column; align-items: stretch; padding: 0.6rem 0.75rem; gap: 0.4rem; }
+    .ar-page .ar-col         { flex: none !important; width: 100%; }
+    .ar-page .ar-mobile-label { display: block; }
   }
 
-  .btn-primary {
-    background-color: #2563eb;
-    border-color: #2563eb;
+  /* Kind バッジ */
+  .ar-page .ar-kind-badge {
+    display: inline-block; font-size: 0.72rem; font-weight: 500;
+    padding: 0.2rem 0.55rem; border-radius: 9999px;
+    background: #e0f2fe; color: #0369a1;
+  }
+  .ar-page .ar-kind-badge--unpaid-leave { background: #dbeafe; color: #1d4ed8; }
+
+  /* Status */
+  .ar-page .ar-status {
+    display: inline-flex; align-items: center;
+    font-size: 0.72rem; font-weight: 500;
+    padding: 0.2rem 0.55rem; border-radius: 9999px;
+  }
+  .ar-page .ar-status--done    { background: #dcfce7; color: #16a34a; }
+  .ar-page .ar-status--pending { background: #fef9c3; color: #a16207; }
+
+  /* 添付ファイルリンク */
+  .ar-page .ar-attachment-link {
+    display: inline-flex; align-items: center; max-width: 100%;
+    font-size: 0.75rem; color: #2563eb; text-decoration: none;
+    border: 1px solid #bfdbfe; border-radius: 0.35rem;
+    padding: 0.2rem 0.5rem; background: #eff6ff; overflow: hidden;
+  }
+  .ar-page .ar-attachment-link:hover { background: #dbeafe; }
+
+  /* Submit ボタン */
+  .ar-page .ar-submit-btn {
+    display: inline-flex; align-items: center; white-space: nowrap;
+    font-size: 0.78rem; font-weight: 500;
+    padding: 0.28rem 0.75rem; border-radius: 0.4rem; border: none;
+    background: #2563eb; color: #fff; cursor: pointer; transition: background 0.15s;
+  }
+  .ar-page .ar-submit-btn:hover { background: #1d4ed8; }
+
+  /* 完了マーク */
+  .ar-page .ar-done-mark {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 1.6rem; height: 1.6rem; border-radius: 50%;
+    background: #f1f5f9; color: #94a3b8; font-size: 0.85rem;
   }
 
-  .btn-primary:hover {
-    background-color: #1e40af;
-    border-color: #1e40af;
-  }
-
-  .btn-outline-secondary:disabled {
-    opacity: 1;
-    color: #9ca3af;
-  }
-
-  .badge.text-bg-success {
-    background-color: #22c55e !important;
-  }
-
-  .badge.text-bg-warning {
-    background-color: #facc15 !important;
-    color: #1e293b !important;
-  }
-
-  .badge.text-bg-primary {
-    background-color: #3b82f6 !important;
-  }
-
-  .badge.text-bg-info {
-    background-color: #38bdf8 !important;
-  }
+  /* 空状態 */
+  .ar-page .ar-empty { text-align: center; color: #94a3b8; padding: 3rem 1rem; }
 </style>
 @endpush

--- a/resources/views/calendar/absenceReportAll.blade.php
+++ b/resources/views/calendar/absenceReportAll.blade.php
@@ -3,188 +3,262 @@
 @section('title', 'All Absence Reports')
 
 @section('content')
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <div>
-        <h2 class="mb-0">All Absence Reports</h2>
-    </div>
-    <span class="badge text-bg-primary">Admin View</span>
-</div>
+<div class="ara-page">
 
-@if ($errors->any())
-<div class="alert alert-danger py-2 mb-2">
+  {{-- Header --}}
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0 fw-semibold">All Absence Reports</h2>
+    <span class="ara-badge ara-badge--admin">Admin View</span>
+  </div>
+
+  @if ($errors->any())
+  <div class="alert alert-danger py-2 mb-3">
     <ul class="mb-0">@foreach ($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>
-</div>
-@endif
+  </div>
+  @endif
 
-{{-- フィルタ --}}
-<form method="GET" class="card card-body mb-3 p-2">
+  {{-- フィルタ --}}
+  <form method="GET" class="ara-filter mb-3">
     <div class="row g-2 align-items-end">
-        <div class="col-6 col-md-2">
-            <label class="form-label small mb-1">Status</label>
-            <select name="status" class="form-select form-select-sm">
-                @php $st = $filters['status'] ?? 'all'; @endphp
-                <option value="all" @selected($st==='all' )>All</option>
-                <option value="required" @selected($st==='required' )>Required</option>
-                <option value="submitted" @selected($st==='submitted' )>Submitted</option>
-            </select>
-        </div>
-
-        <div class="col-6 col-md-2">
-            <label class="form-label small mb-1">Kind</label>
-            <select name="kind" class="form-select form-select-sm">
-                @php $kd = $filters['kind'] ?? 'absence'; @endphp
-                <option value="absence" @selected($kd==='absence' )>Unpaid Leave</option>
-                <option value="absence_to_paid" @selected($kd==='absence_to_paid' )>ALP</option>
-                <option value="other" @selected($kd==='other' )>Others</option>
-                <option value="all" @selected($kd==='all' )>All</option>
-            </select>
-        </div>
-
-        <div class="col-6 col-md-2">
-            <label class="form-label small mb-1">From</label>
-            <input type="date" name="from" value="{{ $filters['from'] ?? '' }}" class="form-control form-control-sm">
-        </div>
-        <div class="col-6 col-md-2">
-            <label class="form-label small mb-1">To</label>
-            <input type="date" name="to" value="{{ $filters['to'] ?? '' }}" class="form-control form-control-sm">
-        </div>
-
-        <div class="col-12 col-md-3">
-            <label class="form-label small mb-1">User</label>
-            <select name="user_id" class="form-select form-select-sm">
-                <option value="">— All Users —</option>
-                @php $uid = $filters['userId'] ?? null; @endphp
-                @foreach($userOptions as $u)
-                @php
-                $uname = trim(($u->family_name ?? '').' '.($u->first_name ?? '')) ?: ('User #'.$u->id);
-                $ucode = $u->employee_code ? " [{$u->employee_code}]" : '';
-                @endphp
-                <option value="{{ $u->id }}" @selected($uid==$u->id)>{{ $uname }}{{ $ucode }}</option>
-                @endforeach
-            </select>
-        </div>
-
-        <div class="col-12 col-md-1 d-grid">
-            <button type="submit" class="btn btn-sm btn-primary">Filter</button>
-        </div>
+      <div class="col-6 col-md-2">
+        <label class="ara-filter-label">Status</label>
+        <select name="status" class="form-select form-select-sm">
+          @php $st = $filters['status'] ?? 'all'; @endphp
+          <option value="all"       @selected($st==='all'      )>All</option>
+          <option value="required"  @selected($st==='required' )>Required</option>
+          <option value="submitted" @selected($st==='submitted')>Submitted</option>
+        </select>
+      </div>
+      <div class="col-6 col-md-2">
+        <label class="ara-filter-label">Kind</label>
+        <select name="kind" class="form-select form-select-sm">
+          @php $kd = $filters['kind'] ?? 'absence'; @endphp
+          <option value="absence"         @selected($kd==='absence'        )>Unpaid Leave</option>
+          <option value="absence_to_paid" @selected($kd==='absence_to_paid')>ALP</option>
+          <option value="other"           @selected($kd==='other'          )>Others</option>
+          <option value="all"             @selected($kd==='all'            )>All</option>
+        </select>
+      </div>
+      <div class="col-6 col-md-2">
+        <label class="ara-filter-label">From</label>
+        <input type="date" name="from" value="{{ $filters['from'] ?? '' }}" class="form-control form-control-sm">
+      </div>
+      <div class="col-6 col-md-2">
+        <label class="ara-filter-label">To</label>
+        <input type="date" name="to" value="{{ $filters['to'] ?? '' }}" class="form-control form-control-sm">
+      </div>
+      <div class="col-12 col-md-3">
+        <label class="ara-filter-label">User</label>
+        <select name="user_id" class="form-select form-select-sm">
+          <option value="">— All Users —</option>
+          @php $uid = $filters['userId'] ?? null; @endphp
+          @foreach($userOptions as $u)
+          @php
+            $uname = trim(($u->family_name ?? '').' '.($u->first_name ?? '')) ?: ('User #'.$u->id);
+            $ucode = $u->employee_code ? " [{$u->employee_code}]" : '';
+          @endphp
+          <option value="{{ $u->id }}" @selected($uid==$u->id)>{{ $uname }}{{ $ucode }}</option>
+          @endforeach
+        </select>
+      </div>
+      <div class="col-12 col-md-1 d-grid">
+        <button type="submit" class="ara-filter-btn">
+          <i class="bi bi-funnel me-1"></i>Filter
+        </button>
+      </div>
     </div>
-</form>
+  </form>
 
-{{-- 一覧（カード行） --}}
-@if($leaves->count())
-@foreach($leaves as $row)
-@php($leave = $row['leave'])
-<div class="leave-row border rounded-2 p-2 mb-1 {{ $row['needsReport'] ? 'bg-required' : '' }}">
-    <div class="row g-1 align-items-end">
-        {{-- User --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-2 mb-1">
-            <div class="small text-muted mb-1">User</div>
-            <div class="fw-semibold">{{ $row['userName'] }}
-                @if(!empty($row['employeeCode']))
-                <span class="text-muted">[{{ $row['employeeCode'] }}]</span>
-                @endif
-            </div>
-        </div>
+  {{-- 列ヘッダー（デスクトップのみ） --}}
+  <div class="ara-header d-none d-lg-flex">
+    <div class="ara-col ara-col--user">User</div>
+    <div class="ara-col ara-col--date">Date</div>
+    <div class="ara-col ara-col--kind">Kind</div>
+    <div class="ara-col ara-col--status">Status</div>
+    <div class="ara-col ara-col--reason">Reason</div>
+    <div class="ara-col ara-col--handle">Handle Type</div>
+    <div class="ara-col ara-col--action"></div>
+  </div>
 
-        {{-- Date --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-2 mb-1">
-            <div class="small text-muted mb-1">Date</div>
-            <div class="fw-semibold">{{ $row['dateMain'] }}</div>
-            @if($row['dateSub'])
-            <div class="small text-muted">〜 {{ $row['dateSub'] }}</div>
-            @endif
-        </div>
+  {{-- 一覧 --}}
+  @if($leaves->count())
+  <div class="ara-list">
+    @foreach($leaves as $row)
+    @php($leave = $row['leave'])
 
-        {{-- Kind --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-2">
-            <div class="small text-muted mb-1">Kind</div>
-            <span class="badge rounded-pill
-            @switch($row['kindLabel'])
-              @case('Unpaid Leave') text-bg-primary text-white @break
-              @case('ALP')          text-bg-info    text-white @break
-              @default              text-bg-info    text-white
-            @endswitch
-          ">{{ $row['kindLabel'] }}</span>
-        </div>
+    <div class="ara-card {{ $row['needsReport'] ? 'ara-card--required' : '' }}">
 
-        {{-- Status --}}
-        <div class="col-6 col-sm-6 col-md-6 col-lg-1">
-            <div class="small text-muted mb-1">Status</div>
-            @if($row['statusText'] === 'Submitted')
-            <span class="badge rounded-pill text-bg-success">Submitted</span>
-            @elseif($row['statusText'] === 'Required')
-            <span class="badge rounded-pill text-bg-warning text-dark">Required</span>
-            @else
-            <span class="text-muted">—</span>
-            @endif
-        </div>
+      {{-- User --}}
+      <div class="ara-col ara-col--user">
+        <span class="ara-mobile-label">User</span>
+        <span class="fw-semibold">{{ $row['userName'] }}</span>
+        @if(!empty($row['employeeCode']))
+        <span class="ara-code">[{{ $row['employeeCode'] }}]</span>
+        @endif
+      </div>
 
-        {{-- Reason (read-only in ALL view) --}}
-        <div class="col-12 col-sm-12 col-md-6 col-lg-2">
-            <div class="small text-muted mb-1">Reason</div>
-            <textarea class="form-control form-control-sm bg-body-tertiary" rows="1" readonly>{{ $leave->reason }}</textarea>
-        </div>
+      {{-- Date --}}
+      <div class="ara-col ara-col--date">
+        <span class="ara-mobile-label">Date</span>
+        <span class="fw-semibold">{{ $row['dateMain'] }}</span>
+        @if($row['dateSub'])
+        <span class="text-muted" style="font-size:0.72rem;">〜{{ $row['dateSub'] }}</span>
+        @endif
+      </div>
 
-        {{-- Handle Type --}}
-        <div class="col-12 col-sm-12 col-md-6 col-lg-2">
-            <div class="small text-muted mb-1">Handle Type</div>
-            <input type="text" class="form-control form-control-sm bg-body-tertiary"
-                value="{{ $row['handleLabel'] }}" readonly>
-        </div>
+      {{-- Kind --}}
+      <div class="ara-col ara-col--kind">
+        <span class="ara-mobile-label">Kind</span>
+        <span class="ara-kind-badge ara-kind-badge--{{ Str::slug($row['kindLabel']) }}">{{ $row['kindLabel'] }}</span>
+      </div>
 
-        {{-- Open user page --}}
-        <div class="col-6 col-sm-6 col-md-3 col-lg-1 ms-auto d-grid">
-            <a href="{{ route('absence.edit', $leave->user->employee_code) }}" class="btn btn-sm btn-outline-secondary">
-                Details
-            </a>
-        </div>
+      {{-- Status --}}
+      <div class="ara-col ara-col--status">
+        <span class="ara-mobile-label">Status</span>
+        @if($row['statusText'] === 'Submitted')
+        <span class="ara-status ara-status--done"><i class="bi bi-check-circle-fill me-1"></i>Submitted</span>
+        @elseif($row['statusText'] === 'Required')
+        <span class="ara-status ara-status--pending"><i class="bi bi-exclamation-circle-fill me-1"></i>Required</span>
+        @else
+        <span class="text-muted">—</span>
+        @endif
+      </div>
+
+      {{-- Reason --}}
+      <div class="ara-col ara-col--reason">
+        <span class="ara-mobile-label">Reason</span>
+        <textarea class="form-control form-control-sm" rows="1" readonly>{{ $leave->reason }}</textarea>
+      </div>
+
+      {{-- Handle Type --}}
+      <div class="ara-col ara-col--handle">
+        <span class="ara-mobile-label">Handle Type</span>
+        <input type="text" class="form-control form-control-sm" value="{{ $row['handleLabel'] }}" readonly>
+      </div>
+
+      {{-- Details --}}
+      <div class="ara-col ara-col--action">
+        <a href="{{ route('absence.edit', $leave->user->employee_code) }}" class="ara-details-btn">
+          <i class="bi bi-arrow-right me-1"></i>Details
+        </a>
+      </div>
+
     </div>
-</div>
-@endforeach
+    @endforeach
+  </div>
 
-<div class="mt-3">
-    {{ $leaves->links() }}
+  <div class="mt-3">{{ $leaves->links() }}</div>
+
+  @else
+  <div class="ara-empty">
+    <i class="bi bi-inbox fs-2 d-block mb-2"></i>No records.
+  </div>
+  @endif
+
 </div>
-@else
-<div class="text-center text-muted py-5">No records.</div>
-@endif
 @endsection
 
 @push('styles')
 <style>
-    .bg-required {
-        background: linear-gradient(90deg, rgba(252, 211, 77, .12), transparent 55%);
-        border-left: 4px solid #f59e0b !important;
-    }
+  /* ===== すべて .ara-page 以下にスコープ ===== */
 
-    .form-control[readonly],
-    .bg-body-tertiary {
-        background-color: var(--bs-tertiary-bg) !important;
-    }
+  .ara-page .ara-badge {
+    font-size: 0.75rem; font-weight: 500;
+    padding: 0.3rem 0.75rem; border-radius: 9999px;
+  }
+  .ara-page .ara-badge--admin { background: #dbeafe; color: #1d4ed8; }
 
-    .badge.rounded-pill {
-        font-size: .8rem;
-        font-weight: 400 !important;
-        padding: .48rem .65rem;
-        border-radius: 1rem !important;
-        line-height: 1.2;
-    }
+  /* フィルタ */
+  .ara-page .ara-filter {
+    background: #f8fafc; border: 1px solid #e2e8f0;
+    border-radius: 0.6rem; padding: 0.75rem 1rem;
+  }
+  .ara-page .ara-filter-label {
+    display: block; font-size: 0.7rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: #94a3b8; margin-bottom: 0.2rem;
+  }
+  .ara-page .ara-filter-btn {
+    display: inline-flex; align-items: center; justify-content: center; width: 100%;
+    font-size: 0.78rem; font-weight: 500; padding: 0.34rem 0.75rem;
+    border-radius: 0.4rem; border: none; background: #2563eb; color: #fff;
+    cursor: pointer; transition: background 0.15s;
+  }
+  .ara-page .ara-filter-btn:hover { background: #1d4ed8; }
 
-    .badge.text-bg-success {
-        background-color: #22c55e !important;
-    }
+  /* 列ヘッダー */
+  .ara-page .ara-header {
+    display: flex; align-items: center; gap: 0.5rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.7rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; color: #94a3b8;
+  }
 
-    .badge.text-bg-warning {
-        background-color: #facc15 !important;
-        color: #1e293b !important;
-    }
+  /* リスト */
+  .ara-page .ara-list { display: flex; flex-direction: column; gap: 0.3rem; }
 
-    .badge.text-bg-primary {
-        background-color: #3b82f6 !important;
-    }
+  /* カード = 1行 */
+  .ara-page .ara-card {
+    display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+    background: #fff; border: 1px solid #e2e8f0;
+    border-radius: 0.5rem; padding: 0.35rem 0.75rem;
+    transition: box-shadow 0.15s;
+  }
+  .ara-page .ara-card:hover { box-shadow: 0 1px 6px rgba(0,0,0,.07); }
+  .ara-page .ara-card--required {
+    border-left: 3px solid #f59e0b;
+    background: linear-gradient(90deg, rgba(251,191,36,.06), transparent 40%);
+  }
 
-    .badge.text-bg-info {
-        background-color: #38bdf8 !important;
-    }
+  /* 列幅定義 */
+  .ara-page .ara-col { min-width: 0; }
+  .ara-page .ara-col--user   { flex: 0 0 110px; }
+  .ara-page .ara-col--date   { flex: 0 0 90px; }
+  .ara-page .ara-col--kind   { flex: 0 0 100px; }
+  .ara-page .ara-col--status { flex: 0 0 100px; }
+  .ara-page .ara-col--reason { flex: 3 1 160px; }
+  .ara-page .ara-col--handle { flex: 2 1 140px; }
+  .ara-page .ara-col--action { flex: 0 0 80px; text-align: right; }
+
+  /* モバイル用ラベル */
+  .ara-page .ara-mobile-label {
+    display: none; font-size: 0.68rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: #94a3b8; margin-bottom: 0.15rem;
+  }
+  @media (max-width: 991.98px) {
+    .ara-page .ara-card         { flex-direction: column; align-items: stretch; padding: 0.6rem 0.75rem; gap: 0.4rem; }
+    .ara-page .ara-col          { flex: none !important; width: 100%; }
+    .ara-page .ara-mobile-label { display: block; }
+  }
+
+  /* 付属スタイル */
+  .ara-page .ara-code { font-size: 0.72rem; color: #94a3b8; margin-left: 0.2rem; }
+
+  .ara-page .ara-kind-badge {
+    display: inline-block; font-size: 0.72rem; font-weight: 500;
+    padding: 0.2rem 0.55rem; border-radius: 9999px;
+    background: #e0f2fe; color: #0369a1;
+  }
+  .ara-page .ara-kind-badge--unpaid-leave { background: #dbeafe; color: #1d4ed8; }
+
+  .ara-page .ara-status {
+    display: inline-flex; align-items: center;
+    font-size: 0.72rem; font-weight: 500;
+    padding: 0.2rem 0.55rem; border-radius: 9999px;
+  }
+  .ara-page .ara-status--done    { background: #dcfce7; color: #16a34a; }
+  .ara-page .ara-status--pending { background: #fef9c3; color: #a16207; }
+
+  .ara-page .ara-details-btn {
+    display: inline-flex; align-items: center; white-space: nowrap;
+    font-size: 0.75rem; font-weight: 500;
+    padding: 0.25rem 0.65rem; border-radius: 0.4rem;
+    border: 1px solid #e2e8f0; background: #f8fafc; color: #475569;
+    text-decoration: none; transition: background 0.15s, border-color 0.15s;
+  }
+  .ara-page .ara-details-btn:hover { background: #f1f5f9; border-color: #cbd5e1; color: #1e293b; }
+
+  .ara-page .ara-empty { text-align: center; color: #94a3b8; padding: 3rem 1rem; }
 </style>
 @endpush


### PR DESCRIPTION
## 概要



Absence Report（個人用）/ All Absence Reports（管理者用一覧）の2画面について、CSSのスコープ漏れを修正し、あわせて画面デザインを刷新。



## 背景・問題点



従来、両画面では Bootstrap の汎用クラスに対して、`@push('styles')` 内で直接スタイルを上書きしていた。



```css

/* 修正前 */

.btn-primary {

    background-color: #2563eb;

}



.badge.text-bg-success {

    background-color: #22c55e !important;

}

```



これらのセレクタはページ全体に適用されるため、他画面の同名クラスのボタンやバッジの見た目まで意図せず変更される可能性があった。



特に `absenceReportAll.blade.php` は管理者が他画面と並行して利用することがあるため、CSSの影響範囲が広い状態になっていた。



## 修正内容



### 1. CSSスコープの修正



各画面のルート要素に専用クラスを付与し、スタイルの適用範囲をその配下に限定。



* Absence Report：`.ar-page` 配下にスコープ

* All Absence Reports：`.ara-page` 配下にスコープ



```css

/* 修正後 */

.ar-page .ar-submit-btn {

    background: #2563eb;

}



.ara-page .ara-status--done {

    background: #dcfce7;

    color: #16a34a;

}

```



Bootstrap の汎用クラスを直接上書きせず、画面固有のクラス名に対してのみスタイルを適用するよう変更。



### 2. デザイン刷新



以下の画面構造・見た目を変更。



* Bootstrap グリッド中心のレイアウトから、独自のカード/列レイアウトへ変更

* デスクトップ表示では列ヘッダーを表示

* モバイル表示では各列にラベルを表示し、縦積みレイアウトに切り替え

* ステータス・種別バッジを Bootstrap Icons 付きの独自バッジに変更

* 添付ファイルリンク、Submitボタン、Detailsボタンを独自スタイルに変更

* 必須報告行のハイライトを独自クラスに変更



## 主なクラス設計

| 画面                  | ルートクラス      | 主なプレフィックス |
| ------------------- | ----------- | --------- |
| Absence Report      | `.ar-page`  | `ar-`     |
| All Absence Reports | `.ara-page` | `ara-`    |


## 修正ファイル


| ファイル                                                  | 変更内容                                         |
| ----------------------------------------------------- | -------------------------------------------- |
| `resources/views/calendar/absenceReport.blade.php`    | `.ar-page` 配下にCSSをスコープ化し、カードレイアウトへ刷新         |
| `resources/views/calendar/absenceReportAll.blade.php` | `.ara-page` 配下にCSSをスコープ化し、フィルタ・一覧カードレイアウトへ刷新 |



両ファイルとも、マークアップとCSS設計の方針は共通化し、プレフィックスのみ `ar-` / `ara-` で区別。