### PR TITLE
feat: 添付ファイルストレージをローカルディスクからCloudflare R2に移行

### DIFF
--- a/app/Http/Controllers/LeaveApplyController.php
+++ b/app/Http/Controllers/LeaveApplyController.php
@@ -101,7 +101,10 @@ class LeaveApplyController extends Controller
         }
 
         $file = $request->file('attachment');
-        $path = $file->store('attachments/' . now()->format('Y/m'), 'local');
+        $path = $file->store('attachments/' . now()->format('Y/m'), 's3');
+        if ($path === false) {
+            throw new \RuntimeException('ファイルのアップロードに失敗しました。');
+        }
 
         return [
             'path'          => $path,

--- a/app/Http/Controllers/LeaveAttachmentController.php
+++ b/app/Http/Controllers/LeaveAttachmentController.php
@@ -25,18 +25,24 @@ class LeaveAttachmentController extends Controller
         // ② 認可
         $this->authorize('view', $leave);
 
-        // ③ ファイルパス取得（local ディスク）
-        $disk = Storage::disk('local');
-
-        if (! $disk->exists($attachment->path)) {
+        // ③ パスが有効か確認（R2アップロード失敗時に '0' 等が入るケースを除外）
+        $path = $attachment->path;
+        if (empty($path) || $path === '0') {
             abort(404);
         }
 
-        $fullPath = $disk->path($attachment->path);
+        // ④ R2 から署名付き一時URLを生成してリダイレクト（5分間有効）
+        $disk = Storage::disk('s3');
 
-        // inline 表示（PDF/画像ならブラウザでそのまま開く）
-        return response()->file($fullPath);
-        // ダウンロードさせたいなら ↓
-        // return response()->download($fullPath, $attachment->original_name ?? basename($fullPath));
+        try {
+            if (! $disk->exists($path)) {
+                abort(404);
+            }
+            $url = $disk->temporaryUrl($path, now()->addMinutes(5));
+        } catch (\League\Flysystem\UnableToRetrieveMetadata|\League\Flysystem\UnableToCheckFileExistence $e) {
+            abort(404);
+        }
+
+        return redirect($url);
     }
 }

--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -356,8 +356,19 @@ class LeaveController extends Controller
             abort(404);
         }
 
+        $path = $attachment->path;
+        if (empty($path) || $path === '0') {
+            abort(404);
+        }
+
         $downloadName = $attachment->original_name ?: 'attachment';
 
-        return Storage::disk('local')->download($attachment->path, $downloadName);
+        try {
+            $url = Storage::disk('s3')->temporaryUrl($path, now()->addMinutes(5));
+        } catch (\League\Flysystem\UnableToRetrieveMetadata|\League\Flysystem\UnableToCheckFileExistence $e) {
+            abort(404);
+        }
+
+        return redirect($url);
     }
 }

--- a/app/Http/Controllers/ReceivedPostController.php
+++ b/app/Http/Controllers/ReceivedPostController.php
@@ -193,19 +193,19 @@ class ReceivedPostController extends Controller
         // ② 認可
         $this->authorize('view', $post);
 
-        // ③ ファイルパス取得（local ディスク）
-        $disk = Storage::disk('local');
-
-        if (! $disk->exists($attachment->path)) {
+        // ③ パスが有効か確認
+        $path = $attachment->path;
+        if (empty($path) || $path === '0') {
             abort(404);
         }
 
-        // ④ ローカルパスに解決してブラウザに表示
-        $fullPath = $disk->path($attachment->path);
+        // ④ R2 から署名付き一時URLを生成してリダイレクト（5分間有効）
+        try {
+            $url = Storage::disk('s3')->temporaryUrl($path, now()->addMinutes(5));
+        } catch (\League\Flysystem\UnableToRetrieveMetadata|\League\Flysystem\UnableToCheckFileExistence $e) {
+            abort(404);
+        }
 
-        // inline 表示（PDF/画像ならブラウザでそのまま開く）
-        return response()->file($fullPath);
-        // ダウンロードさせたいなら ↓
-        // return response()->download($fullPath, $attachment->original_name ?? basename($fullPath));
+        return redirect($url);
     }
 }

--- a/app/Services/Leave/ReportLeaveService.php
+++ b/app/Services/Leave/ReportLeaveService.php
@@ -19,10 +19,13 @@ class ReportLeaveService
         if ($file) {
             DB::transaction(function () use ($file, $leave) {
                 if ($leave->attachment) {
-                    Storage::disk('local')->delete($leave->attachment->path);
+                    Storage::disk('s3')->delete($leave->attachment->path);
                     $leave->attachment->delete();
                 }
-                $path = $file->store('attachments/' . now()->format('Y/m'), 'local');
+                $path = $file->store('attachments/' . now()->format('Y/m'), 's3');
+                if ($path === false) {
+                    throw new \RuntimeException('ファイルのアップロードに失敗しました。');
+                }
                 $leave->attachment()->create([
                     'path'          => $path,
                     'original_name' => $file->getClientOriginalName(),

--- a/app/Services/Post/PostSendService.php
+++ b/app/Services/Post/PostSendService.php
@@ -27,7 +27,10 @@ class PostSendService
 
             foreach ($files as $file) {
                 $folder = 'attachments/' . now()->format('Y/m');
-                $path   = $file->store($folder, 'local');
+                $path = $file->store($folder, 's3');
+                if ($path === false) {
+                    throw new \RuntimeException('ファイルのアップロードに失敗しました。');
+                }
 
                 $post->attachments()->create([
                     'path'          => $path,

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.8",
+        "league/flysystem-aws-s3-v3": "^3.0",
         "spatie/laravel-permission": "^6"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,159 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44328d6f7595f0aa6cf7948ffd22f835",
+    "content-hash": "0f035e01518ae2b1d1bf0bda28d8ca53",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.384.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "71513f9c05ed1fde0fb95e8c7e7d3c88409d7de9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/71513f9c05ed1fde0fb95e8c7e7d3c88409d7de9",
+                "reference": "71513f9c05ed1fde0fb95e8c7e7d3c88409d7de9",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.384.9"
+            },
+            "time": "2026-06-12T18:10:49+00:00"
+        },
         {
             "name": "barryvdh/laravel-dompdf",
             "version": "v3.1.1",
@@ -2030,6 +2181,61 @@
             "time": "2026-05-14T10:28:08+00:00"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.371.5",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.34.0"
+            },
+            "time": "2026-05-04T08:24:00+00:00"
+        },
+        {
             "name": "league/flysystem-local",
             "version": "3.31.0",
             "source": {
@@ -2485,6 +2691,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
+            },
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -4369,6 +4641,76 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",


### PR DESCRIPTION
## 概要

Cloudflare R2 を導入し、添付ファイルの保存先をローカルディスクからS3互換ストレージへ変更。

Render のエフェメラルファイルシステムにより、再デプロイ時に添付ファイルが消失していた問題を解消。

## 背景・課題

Render のファイルシステムは永続化されないため、これまで `storage/app` に保存していた添付ファイルが、再デプロイのたびに消失していた。

対象となる添付ファイルは以下。
* Leave（休暇申請・欠席報告）の添付ファイル
* Post（受信投稿）の添付ファイル

## 採用ソリューション

Cloudflare R2 をS3互換ストレージとして採用。

主な理由は以下。

* S3互換のため Laravel 標準の `s3` ディスクを利用できる
* コード変更を最小限に抑えられる
* ファイルを永続保存できる
* エグレス課金が発生しない

## Cloudflare側の事前準備

以下を設定。

* R2バケット作成
* APIトークン発行
  * Object Read & Write
  * 対象バケットを指定
* Account ID / Access Key / Secret Key を取得

## 追加パッケージ

```txt
league/flysystem-aws-s3-v3
```

Laravel の `s3` ディスクドライバーでS3互換ストレージへ接続するために追加。

`composer.json` / `composer.lock` に反映。

## 環境変数

`FILESYSTEM_DISK` を `s3` に切り替え、R2接続用の環境変数を追加。

主な設定項目は以下。

```env

FILESYSTEM_DISK=s3

AWS_ACCESS_KEY_ID=

AWS_SECRET_ACCESS_KEY=

AWS_DEFAULT_REGION=auto

AWS_BUCKET=

AWS_ENDPOINT=

AWS_USE_PATH_STYLE_ENDPOINT=true

```

ローカル環境と Render Environment の両方に設定が必要。

※ Access Key / Secret Key などの秘密情報はGitHubに記載しない。

## アップロード処理の変更

Leave / Post の添付ファイル保存先を `local` から `s3` に変更。

これにより、保存されたファイルが Cloudflare R2 上に永続化され、Render の再デプロイ後も消失しないように対応。

## ダウンロード・表示処理の変更

ローカルファイルパスを直接参照する方式から、署名付き一時URL（`temporaryUrl`）へリダイレクトする方式に変更。

これにより、非公開バケット内のファイルへ安全にアクセスできるようにし、アプリケーションサーバー経由のストリーミングを避けて負荷を軽減。

## アップロード失敗時の安全対策

ストレージへの書き込み失敗時に `false` が返る場合があるため、アップロード結果を検証する処理を追加。

書き込みに失敗した場合は例外を発生させ、DB更新も含めてトランザクションをロールバックするように変更。

これにより、ファイル保存に失敗した状態でDBに不正な添付情報が残ることを防止。

## 読み取り時の防御

不正なパス、または既に存在しないファイルへのアクセス時にアプリがクラッシュしないよう、404へフォールバックする処理を追加。

## セキュリティ上の配慮

添付ファイルは非公開バケットに保存。

ファイル配信は数分で失効する署名付き一時URL経由に限定し、公開URLで直接アクセスできない構成に変更。

## 修正内容まとめ

| 項目     | 内容                                  |
| ------ | ----------------------------------- |
| 保存先    | `local` から `s3` / Cloudflare R2 に変更 |
| 対象     | Leave添付ファイル、Post添付ファイル              |
| 表示方式   | ローカル参照から `temporaryUrl` へ変更         |
| 失敗時対応  | アップロード失敗時に例外を発生させてロールバック            |
| 読み取り防御 | 不正パス・存在しないファイルは404へフォールバック          |
| セキュリティ | 非公開バケット + 署名付き一時URLで配信              |