### PR TITLE
Daily Shift ボタンを欠席モーダルと月次予報画面に追加

### DIFF
--- a/public/js/leave.js
+++ b/public/js/leave.js
@@ -89,6 +89,16 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             // ★ end here
 
+            // ★Daily Board ボタン初期化
+            const dayBoardBtn = document.getElementById('dayBoardLink');
+            if (dayBoardBtn) {
+                dayBoardBtn.href = '#';
+                dayBoardBtn.style.display = 'none';
+                dayBoardBtn.classList.add('disabled');
+                dayBoardBtn.setAttribute('aria-disabled', 'true');
+            }
+            // ★ end here
+
             const title = e.title || 'Leave';
             const fmt = (d) => d ? d.toLocaleDateString('ja-JP') : '';
 
@@ -143,6 +153,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 relatedBtn.style.removeProperty('display');
                 relatedBtn.classList.remove('disabled');
                 relatedBtn.setAttribute('aria-disabled', 'false');
+            }
+            // ★ end here
+
+            // ★Daily Board へのリンク設定（関連シフト日付がある場合のみ）
+            if (dayBoardBtn && sDate2) {
+                dayBoardBtn.href = `/forecast/day-assigner?date=${encodeURIComponent(sDate2)}`;
+                dayBoardBtn.style.removeProperty('display');
+                dayBoardBtn.classList.remove('disabled');
+                dayBoardBtn.setAttribute('aria-disabled', 'false');
             }
             // ★ end here
 

--- a/resources/views/calendar/forecast.blade.php
+++ b/resources/views/calendar/forecast.blade.php
@@ -3,7 +3,11 @@
 @section('content')
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h2 class="mb-0">Forecast Calendar</h2>
-    <span class="badge text-bg-info">Admin View</span>
+    <div class="d-flex align-items-center gap-2">
+        <a href="{{ route('calendar.daily_assigner', ['date' => now()->format('Y-m-d')]) }}"
+           class="btn btn-sm btn-outline-secondary">Day Board</a>
+        <span class="badge text-bg-info">Admin View</span>
+    </div>
 </div>
 
 {{-- ▼▼ 月選択フォーム（GET） ▼▼ --}}

--- a/resources/views/calendar/leave.blade.php
+++ b/resources/views/calendar/leave.blade.php
@@ -50,6 +50,12 @@
                       class="btn btn-sm btn-outline-secondary"
                       style="display:none; color:#6c757d;"
                       rel="noopener">Shift</a> {{--target="_blank" (タブの管理大変の為、削除)--}}
+                    <!-- ★追加：Daily Board へのリンク（関連シフトがある場合のみ表示） -->
+                    <a id="dayBoardLink"
+                      href="#"
+                      class="btn btn-sm btn-outline-secondary"
+                      style="display:none; color:#6c757d;"
+                      rel="noopener">Day Board</a>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
             </div>


### PR DESCRIPTION
## 変更内容

* `forecast.blade.php` のページ右上ヘッダーに `Day Board` ボタンを追加
* 今日の日付を使用して `/forecast/day-assigner?date=YYYY-MM-DD` へ遷移するように設定
* `leave.blade.php` のモーダルヘッダーに `Day Board` ボタンを追加
* `leave.js` でモーダル表示時に `Day Board` リンクを初期化
* Leave の開始日が取得できる場合のみ、該当日の `/forecast/day-assigner?date=YYYY-MM-DD` リンクを表示するように変更
