### PR TITLE
Snapshotの「全削除→再生成」を「差分更新」に変更

### DIFF
--- a/app/Services/Calendar/LeaveSnapshotService.php
+++ b/app/Services/Calendar/LeaveSnapshotService.php
@@ -32,12 +32,17 @@ class LeaveSnapshotService
                 return;
             }
 
-            // まず既存のスナップショットを消す（冪等性）
-            $this->deleteSnapshotsForLeave($leave);
-
             // 期間生成（end_date が null の場合は単日）
             $start = Carbon::parse($leave->start_date);
             $end   = $leave->end_date ? Carbon::parse($leave->end_date) : Carbon::parse($leave->start_date);
+
+            // 不要になったスナップショットのみ削除（期間外・対象ユーザー変更）
+            // → 期間内の既存スナップショットは残し、assigned_user 等の手動編集を保持する
+            $this->deleteStaleSnapshotsForLeave($leave, $start, $end);
+
+            // kind 変更を既存スナップショットへ反映
+            $leave->generatedEvents()->update(['Leave_type' => (string) $leave->kind]);
+
             $period = CarbonPeriod::create($start, $end);
 
             foreach ($period as $date) {
@@ -52,6 +57,28 @@ class LeaveSnapshotService
     public function deleteSnapshotsForLeave(Leave $leave): void
     {
         $this->generatedShiftDecision->applyAction($leave, GeneratedShiftDecisionService::ACTION_DELETE);
+    }
+
+    /**
+     * 現在の Leave 内容と一致しなくなったスナップショットのみ削除
+     * （期間外の日付、または対象ユーザーが変わったもの）
+     */
+    private function deleteStaleSnapshotsForLeave(Leave $leave, Carbon $start, Carbon $end): void
+    {
+        $leave->generatedEvents()
+            ->where(function ($q) use ($leave, $start, $end) {
+                $q->whereDate('event_date', '<', $start->toDateString())
+                    ->orWhereDate('event_date', '>', $end->toDateString());
+
+                if ($leave->user_id === null) {
+                    $q->orWhereNotNull('original_user_id');
+                } else {
+                    $q->orWhere(fn($qq) => $qq
+                        ->where('original_user_id', '!=', $leave->user_id)
+                        ->orWhereNull('original_user_id'));
+                }
+            })
+            ->delete();
     }
 
     /**
@@ -79,9 +106,16 @@ class LeaveSnapshotService
             ->whereDate('effective_end', '>=', $ymd)
             ->where('dow', $dow)
             ->get()
+            // Subシフトはスナップショット対象外
+            ->reject(fn($line) => strcasecmp(trim((string)($line->school_name ?? '')), 'sub') === 0)
             ->values();
 
+        $dayEvents = fn() => Event::query()
+            ->whereDate('event_date', $ymd)
+            ->where('source_leave_id', $leave->id);
+
         if ($lines->isEmpty()) {
+            $dayEvents()->delete();
             return; // 割当なし → スナップショット対象なし
         }
 
@@ -92,24 +126,22 @@ class LeaveSnapshotService
                 ->exists();
 
             if ($existsInSubs) {
+                $dayEvents()->delete();
                 return;
             }
         }
 
-        $existingLineIds = Event::query()
-            ->whereDate('event_date', $ymd)
-            ->where('source_leave_id', $leave->id)
+        // スケジュール変更等で対象外になったラインのスナップショットを削除
+        $dayEvents()
+            ->whereNotIn('source_schedule_line_id', $lines->pluck('id')->all())
+            ->delete();
+
+        $existingLineIds = $dayEvents()
             ->whereIn('source_schedule_line_id', $lines->pluck('id')->all())
             ->pluck('source_schedule_line_id')
             ->flip();
 
         foreach ($lines as $line) {
-            // Subシフトはスナップショット対象外
-            $school = (string)($line->school_name ?? '');
-            if (strcasecmp(trim($school), 'sub') === 0) {
-                continue;
-            }
-
             if ($existingLineIds->has($line->id)) {
                 continue;
             }


### PR DESCRIPTION
## 問題

`Leave`（欠席）を保存するたびに、`LeaveObserver.php:22` が `rebuildSnapshotsForLeave` を呼び、`LeaveSnapshotService.php` が既存の生成シフト（Cover Shift）を全削除してから、`assigned_user_id = null` で作り直す方式になっていました。

そのため、`Pending → Approved` のようにステータスを変えるだけでも、管理者が割り当てた以下の情報がすべて消えていました。

* Assigned User
* ステータス
* メモ

---

## 修正内容

対象ファイル：`LeaveSnapshotService.php` のみ

「全削除 → 再生成」を「差分更新」に変更しました。

### 保持されるもの

期間内で条件が変わっていないシフトは、そのまま保持されます。

そのため、以下の情報が残ります。

* Assigned User
* シフトのステータス
* notes

`Pending ↔ Approved` の変更では何も消えません。

### 削除されるもの

削除されるのは、本当に不要になったものだけです。

* 期間の短縮などで期間外になった日のシフト
* 対象ユーザー（`user_id`）が変更された場合の旧ユーザー分
* スケジュール変更で該当ラインがなくなった日
* `subs` に登録された日

  * 従来挙動を踏襲

### 新規生成されるもの

不足している日付分だけ新規生成します。

`snapshotDay` にあった既存チェックが、従来は直前の全削除で無意味になっていたため、それを活かす形にしました。

### 欠席種別変更時の対応

`kind`（欠席種別）を変更した場合は、既存シフトの `Leave_type` を上書きして表示の整合を保ちます。

### Rejected / Cancelled への変更時

`Rejected` / `Cancelled` への変更時の挙動は従来どおりです。

* delete / detach を確認するフローは変更なし

個別更新・一括更新・承認フロー（`ApprovalService`）はすべて同じ Observer 経由なので、まとめて直ります。

---

## 他に考慮すべき点

### 期間短縮・ユーザー変更時

期間短縮・ユーザー変更では、割当済みシフトも消えます。

これは「シフト自体が不要になる」ため意図どおりですが、割当済みのシフトが消える場合に確認モーダルを出す UI は、将来検討してもよいと思います。

例：

* ステータス変更時の `generated_shift_action` と同様の確認モーダル

### Pending 時点でのシフト生成

`Pending` の時点でシフトが生成される仕様は維持しています。

`snapshotValues` に `pending` を含むためです。

むしろ、この仕様があるからこそ今回の問題が顕在化していました。

---

